### PR TITLE
fix: 修复 cascader bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/cascader/cascader.tsx
+++ b/packages/base/src/cascader/cascader.tsx
@@ -531,6 +531,7 @@ const Cascader = <DataItem, Value extends KeygenResult[]>(
         id={path[0]}
         parentId=''
         path={[] as unknown as Value}
+        mode={mode}
       />,
     ];
     const childs = path.map((p, i) => {
@@ -574,7 +575,7 @@ const Cascader = <DataItem, Value extends KeygenResult[]>(
     const listStyle =
       data && data.length === 0
         ? { height: 'auto', minHeight: 232, width: '100%' }
-        : { height, minHeight: 232 };
+        : { height, minHeight: height || 232, };
     return (
       <div className={classNames(styles.listContent)} style={listStyle}>
         {cascaderList}

--- a/packages/base/src/cascader/list.tsx
+++ b/packages/base/src/cascader/list.tsx
@@ -22,6 +22,7 @@ const CascaderList = <DataItem, Value extends KeygenResult[]>(
     childrenKey,
     shouldFinal,
     path,
+    mode,
   } = props;
 
   const styles = jssStyle?.cascader?.() as CascaderClasses;
@@ -63,6 +64,7 @@ const CascaderList = <DataItem, Value extends KeygenResult[]>(
             onPathChange={onPathChange}
             onChange={onChange}
             multiple={multiple}
+            mode={mode}
             expandTrigger={expandTrigger}
             childrenKey={childrenKey}
             shouldFinal={shouldFinal}

--- a/packages/base/src/cascader/list.type.ts
+++ b/packages/base/src/cascader/list.type.ts
@@ -5,7 +5,7 @@ import { JssStyleType, CascaderProps } from './cascader.type';
 export interface CascaderListProps<DataItem, Value extends KeygenResult[]>
   extends Pick<
     CascaderProps<DataItem, Value>,
-    'loader' | 'multiple' | 'expandTrigger' | 'renderItem' | 'keygen'
+    'loader' | 'multiple' | 'expandTrigger' | 'renderItem' | 'keygen' | 'mode'
   > {
   jssStyle?: JssStyleType;
   id: KeygenResult;

--- a/packages/base/src/cascader/node.tsx
+++ b/packages/base/src/cascader/node.tsx
@@ -27,6 +27,7 @@ const CascaderNode = <DataItem, Value extends KeygenResult[]>(
     shouldFinal,
     onChange,
     onPathChange,
+    mode,
   } = props;
 
   const [loading, setLoading] = useState(false);
@@ -40,7 +41,7 @@ const CascaderNode = <DataItem, Value extends KeygenResult[]>(
   const rootClass = classNames(
     styles.option,
     active && styles.activeOption,
-    isDisabled && styles.optionDisabled,
+    isDisabled && mode !== 4 && styles.optionDisabled,
   );
 
   const handlePathChange = () => {
@@ -51,7 +52,7 @@ const CascaderNode = <DataItem, Value extends KeygenResult[]>(
     if (onPathChange) onPathChange(id, data, path, true);
     if (!multiple) {
       // 单选设置了 final 属性后 如果不是末节点不触发onChange
-      const shouldJump = shouldFinal && hasChildren
+      const shouldJump = shouldFinal && hasChildren;
       if (onChange && path && !shouldJump) onChange([...path, id] as Value, datum.getDataById(id));
     }
     if (
@@ -81,8 +82,9 @@ const CascaderNode = <DataItem, Value extends KeygenResult[]>(
 
   const getEvents = () => {
     const events: any = {};
-    if (!isDisabled && (expandTrigger !== 'hover-only' || !hasChildren)) {
-      events.onClick = handleClick;
+
+    if (expandTrigger !== 'hover-only' || !hasChildren) {
+      if (!isDisabled || props.mode === 4) events.onClick = handleClick;
     }
 
     if (expandTrigger === 'hover' || expandTrigger === 'hover-only') {

--- a/packages/hooks/src/components/use-cascader/use-cascader.ts
+++ b/packages/hooks/src/components/use-cascader/use-cascader.ts
@@ -18,6 +18,7 @@ const useCascader = <DataItem, Value extends KeygenResult[]>(
     value: valueProp,
     onChange: onChangeProp,
     filterSameChange,
+    childrenKey,
   } = props;
 
   const { value, onChange } = useInputAble({
@@ -36,6 +37,7 @@ const useCascader = <DataItem, Value extends KeygenResult[]>(
     mode,
     disabled,
     isControlled: control,
+    childrenKey,
   });
 
   return {

--- a/packages/shineout-style/src/cascader/cascader.ts
+++ b/packages/shineout-style/src/cascader/cascader.ts
@@ -382,6 +382,7 @@ const cascaderStyle: JsStyles<CascaderClassType> = {
     paddingTop: 3,
     paddingBottom: 3,
     display: 'inline-block',
+    overflow: 'auto'
   },
   tag: {
     '&$tag + &$tag': {

--- a/packages/shineout/src/cascader/__doc__/changelog.cn.md
+++ b/packages/shineout/src/cascader/__doc__/changelog.cn.md
@@ -1,3 +1,12 @@
+## 3.0.4
+2024-04-24
+
+### 🐞 BugFix
+
+- 修复 `Cascader` 设置 `height` 后内容溢出无法内滚  ([#386](https://github.com/sheinsight/shineout-next/pull/386))
+- 修复 `Cascader` 设置 `childrenKey` 后选中结果展示错误 ([#386](https://github.com/sheinsight/shineout-next/pull/386))
+- 修复 `Cascader` 设置 `mode = 4` 时禁用节点无法点击展开 ([#386](https://github.com/sheinsight/shineout-next/pull/386))
+
 ## 3.0.3
 2024-04-22
 


### PR DESCRIPTION
- Cascader 设置 height 后会内容会溢出无法内滚，并且 minHeight 写死 导致 height 不生效
- Cascader 设置childrenKey 以后 renderItem 展示错误
- Cascader mode = 4 的时候 禁用节点需要点击可展开