### PR TITLE
fix: repair button is loading when return false in promise of onOk an…

### DIFF
--- a/packages/base/src/popover/confirm.tsx
+++ b/packages/base/src/popover/confirm.tsx
@@ -19,6 +19,8 @@ const Confirm = (props: PopoverConfirmProps) => {
       (callback as Promise<any>).then(() => {
         close();
         setOk(false);
+      }).catch(() => {
+        setOk(false);
       });
     } else {
       close();
@@ -33,6 +35,8 @@ const Confirm = (props: PopoverConfirmProps) => {
       setCancel(true);
       (callback as Promise<any>).then(() => {
         close();
+        setCancel(false);
+      }).catch(() => {
         setCancel(false);
       });
     } else {


### PR DESCRIPTION
fix: 修复popover.confirm的onOk和onCancel方法返回失败时loading不取消问题