### PR TITLE
fix: 修复 Checkbox.Group size 属性失效的问题

### DIFF
--- a/packages/base/src/checkbox/checkbox-group.tsx
+++ b/packages/base/src/checkbox/checkbox-group.tsx
@@ -8,7 +8,7 @@ import useWithFormConfig from '../common/use-with-form-config';
 
 const Group = <DataItem, Value extends any[]>(props0: CheckboxGroupProps<DataItem, Value>) => {
   const props = useWithFormConfig(props0);
-  const { children, className, block, keygen, jssStyle, style, disabled } = props;
+  const { children, className, block, keygen, jssStyle, size, style, disabled } = props;
   const checkboxStyle = jssStyle?.checkbox?.();
 
   const inputAbleProps = useInputAble({
@@ -62,6 +62,7 @@ const Group = <DataItem, Value extends any[]>(props0: CheckboxGroupProps<DataIte
     checked: isChecked,
     onChange: handleItemChange,
     disabled,
+    size,
   };
   const groupClass = classNames(
     className,
@@ -80,6 +81,7 @@ const Group = <DataItem, Value extends any[]>(props0: CheckboxGroupProps<DataIte
         {props.data.map((d, i) => (
           <Checkbox
             jssStyle={jssStyle}
+            size={size}
             checked={datum.check(d)}
             disabled={datum.disabledCheck(d)}
             key={util.getKey(keygen, d, i)}


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | * |
| Version   | * |
| OS       | * |

`Checkbox.Group` 在设置 `size` 属性后无法生效

### Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

- 修复 `Checkbox.Group` 设置 `size` 属性不生效的问题
