### PR TITLE
fix: 修复 Table 组件 height 类型错误的问题，支持 string 类型

### DIFF
--- a/packages/base/src/table/table.type.ts
+++ b/packages/base/src/table/table.type.ts
@@ -163,7 +163,7 @@ export interface TableProps<DataItem, Value>
    * @en height of table, same with style.height
    * @cn 表格高度，与 style.height 作用相同
    */
-  height?: number;
+  height?: number | string;
   /**
    * @en The callback function after scrolling.\nx: Horizontal rolling ratio(0 <= x <= 1)\ny: Vertical scroll ratio(0 <= y <= 1)
    * @cn 滚动条滚动后回调函数；\nx: 横向滚动比(0 <= x <= 1)\ny: 纵向滚动比(0 <= y <= 1)

--- a/packages/shineout/src/table/__doc__/changelog.cn.md
+++ b/packages/shineout/src/table/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.3.0-beta.14
+未发布
+2024-07-22
+
+### 🐞 BugFix
+- 修复 `Table` 组件 `height` 类型错误，支持 string 类型 ([#580](https://github.com/sheinsight/shineout-next/pull/580))
+
 ## 3.3.0-beta.13
 2024-07-16
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | * |
| Version   | * |
| OS       | * |

`Table` 组件 `height` 属性输入字符串类型数据时 ts 报错

### Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

- 修复 `Table` 组件 `height` 类型错误的问题，支持 string 类型
