### PR TITLE
fix: 修复`Tabs`组件下的a标签在边缘区域无法点击的问题

### DIFF
--- a/packages/base/src/tabs/tab.tsx
+++ b/packages/base/src/tabs/tab.tsx
@@ -9,7 +9,7 @@ import { useConfig } from '../config';
 import { useTabsContext, util } from '@sheinx/hooks';
 
 const Tab = (props: TabProps, ref: any) => {
-  const { jssStyle, tab, disabled, id, color } = props;
+  const { jssStyle, tab: propTab, disabled, id, color } = props;
   const {
     active,
     shape = 'card',
@@ -36,14 +36,13 @@ const Tab = (props: TabProps, ref: any) => {
   const handleClick = () => {
     if (disabled) return;
 
-    if (util.isLink(tab)) {
-      if (tab.props.onClick && typeof tab.props.onClick === 'function') {
-        tab.props.onClick()
-      }
-    }
-
     onChange?.(id);
   };
+
+  const tab = util.isLink(propTab) ? (
+    // 直接返回a标签的内容，不要a标签
+    propTab.props.children
+  ) : propTab
 
   const renderCardTab = () => {
     return tab;
@@ -75,35 +74,49 @@ const Tab = (props: TabProps, ref: any) => {
     style.color = color;
   }
 
-  if (shape === 'button')
+  const containerProps = {
+    className: tabClass,
+    ...getStateProps(),
+    style: style,
+    onClick: handleClick,
+    ref: ref,
+    dir: config.direction,
+  }
+
+  if (shape === 'button') {
     return (
       <Button
-        className={tabClass}
         jssStyle={{ button: buttonStyle }}
-        {...getStateProps()}
-        style={style}
         disabled={disabled}
         type={isActive ? 'primary' : 'secondary'}
-        onClick={handleClick}
-        dir={config.direction}
+
+        {...containerProps}
       >
         {tab}
       </Button>
     );
+  }
 
-  return (
-    <div
-      dir={config.direction}
-      className={tabClass}
-      {...getStateProps()}
-      style={style}
-      onClick={handleClick}
-      ref={ref}
-    >
+  const $children = (
+    <>
       {shape === 'card' && renderCardTab()}
       {shape === 'line' && renderLineTab()}
       {shape === 'dash' && renderDashTab()}
       {shape === 'fill' && renderFillTab()}
+    </>
+  );
+
+  if (util.isLink(propTab)) {
+    return React.cloneElement(propTab, {
+      children: $children,
+
+      ...containerProps,
+    });
+  }
+
+  return (
+    <div {...containerProps}>
+      {$children}
     </div>
   );
 };

--- a/packages/shineout/src/tabs/__example__/t-01-tabs-link.tsx
+++ b/packages/shineout/src/tabs/__example__/t-01-tabs-link.tsx
@@ -16,7 +16,7 @@ export default () => {
       <Tabs shape='line' defaultActive={0}>
         {tabs.map((tab, index) => {
           return (
-            <Tabs.Panel key={index} tab={<a onClick={() => {console.log('a element clicked')}}>{tab.title}</a>}>
+            <Tabs.Panel key={index} tab={<a href="http://www.baidu.com/" target="_blank" onClick={() => {console.log('a element clicked')}} rel="noreferrer">{tab.title}</a>}>
               <div style={{ padding: 16, height: '100%', fontSize: 14 }}>{tab.content}</div>
             </Tabs.Panel>
           );


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Changelog
- `Tabs`组件下的tab属性传的是a标签元素时，点击区域过小的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了选项卡组件，使其可以链接到外部网站。
	- 选项卡标题现在支持点击并在新标签页中打开外部链接。

- **优化**
	- 重构了选项卡组件的属性处理和渲染逻辑，提高代码可读性和效率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->