### PR TITLE
feat: Transfer 新增 equalPanelWidth 属性

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.4.0-beta.1",
+  "version": "3.4.0-beta.2",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/checkbox/simple-checkbox.tsx
+++ b/packages/base/src/checkbox/simple-checkbox.tsx
@@ -58,7 +58,7 @@ const Checkbox = (props: SimpleCheckboxProps) => {
         </i>
       </span>
       {children !== undefined && children !== null && (
-        <span className={checkboxStyle?.desc}>{children}</span>
+        <span data-soui-role='desc' className={checkboxStyle?.desc}>{children}</span>
       )}
       {typeof renderFooter === 'function' ? renderFooter(checked) : null}
     </div>

--- a/packages/base/src/transfer/transfer.tsx
+++ b/packages/base/src/transfer/transfer.tsx
@@ -40,6 +40,7 @@ const Transfer = <DataItem, Value extends KeygenResult[]>(
     listHeight = 186,
     operationIcon = true,
     searchPlaceholder,
+    equalPanelWidth,
     beforeChange,
     renderFilter,
     onSearch,
@@ -89,6 +90,7 @@ const Transfer = <DataItem, Value extends KeygenResult[]>(
     [styles.simple]: simple,
     [styles.small]: size === 'small',
     [styles.large]: size === 'large',
+    [styles.equalPanelWidth]: equalPanelWidth,
   });
 
   const renderOperations = () => {

--- a/packages/base/src/transfer/transfer.type.ts
+++ b/packages/base/src/transfer/transfer.type.ts
@@ -39,6 +39,7 @@ export interface TransferClasses {
   itemWrapper: string;
   checkbox: string;
   empty: string;
+  equalPanelWidth: string;
 }
 
 export type JssStyleType = {
@@ -176,4 +177,9 @@ export interface TransferProps<DataItem, Value extends KeygenResult[]>
    * @override ((props: { onSelected: ((string | number)[]) => void; direction: "left" | "right"; selectedKeys: (string | number)[]; value: Value; filterText: string; }) => ReactNode)
    */
   children?: (props: CustomRenderProps<Value>) => React.ReactNode;
+  /**
+   * @en Panel equal distribution container width
+   * @cn 面板均等分配容器宽度
+   */
+  equalPanelWidth?: boolean;
 }

--- a/packages/shineout-style/src/transfer/transfer.ts
+++ b/packages/shineout-style/src/transfer/transfer.ts
@@ -11,6 +11,11 @@ const TransferStyle: JsStyles<TransferClass> = {
     color: Token.transferFontColor,
     fontSize: Token.transferFontSize,
   },
+  equalPanelWidth: {
+    '& $view': {
+      flex: 1,
+    },
+  },
   small: {
     '& $operations': { '& svg': { width: 12 } },
     '& $header': {
@@ -187,7 +192,14 @@ const TransferStyle: JsStyles<TransferClass> = {
       marginRight: 0,
     },
   },
-  checkbox: {},
+  checkbox: {
+    '&>[data-soui-role="desc"]': {
+      flex: 1,
+      overflow: 'hidden',
+      whiteSpace: 'nowrap',
+      textOverflow: 'ellipsis',
+    },
+  },
   empty: {
     height: '100%',
     display: 'flex',

--- a/packages/shineout/src/card-group/__test__/__snapshots__/cardGroup.spec.tsx.snap
+++ b/packages/shineout/src/card-group/__test__/__snapshots__/cardGroup.spec.tsx.snap
@@ -401,6 +401,7 @@ exports[`CardGroup[Base] should render correctly about checkbox 1`] = `
       </span>
       <span
         class="soui-checkbox-desc"
+        data-soui-role="desc"
       >
         全选
       </span>

--- a/packages/shineout/src/checkbox/__test__/__snapshots__/checkbox.spec.tsx.snap
+++ b/packages/shineout/src/checkbox/__test__/__snapshots__/checkbox.spec.tsx.snap
@@ -20,6 +20,7 @@ exports[`Checkbox[Base] should render correctly  1`] = `
   </span>
   <span
     class="soui-checkbox-desc"
+    data-soui-role="desc"
   >
     Checkbox
   </span>
@@ -50,6 +51,7 @@ exports[`Checkbox[Checked, disabled] should render correctly about checked 1`] =
       </span>
       <span
         class="soui-checkbox-desc"
+        data-soui-role="desc"
       >
         not checked
       </span>
@@ -86,6 +88,7 @@ exports[`Checkbox[Checked, disabled] should render correctly about checked 1`] =
       </span>
       <span
         class="soui-checkbox-desc"
+        data-soui-role="desc"
       >
         checked
       </span>
@@ -119,6 +122,7 @@ exports[`Checkbox[Checked, disabled] should render correctly about checked 1`] =
       </span>
       <span
         class="soui-checkbox-desc"
+        data-soui-role="desc"
       >
         indeterminate
       </span>
@@ -147,6 +151,7 @@ exports[`Checkbox[Checked, disabled] should render correctly about checked 1`] =
       </span>
       <span
         class="soui-checkbox-desc"
+        data-soui-role="desc"
       >
         not checked
       </span>
@@ -184,6 +189,7 @@ exports[`Checkbox[Checked, disabled] should render correctly about checked 1`] =
       </span>
       <span
         class="soui-checkbox-desc"
+        data-soui-role="desc"
       >
         checked
       </span>
@@ -218,6 +224,7 @@ exports[`Checkbox[Checked, disabled] should render correctly about checked 1`] =
       </span>
       <span
         class="soui-checkbox-desc"
+        data-soui-role="desc"
       >
         indeterminate
       </span>
@@ -247,6 +254,7 @@ exports[`Checkbox[Checked, disabled] should render correctly about checked is in
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       CheckAll
     </span>
@@ -274,6 +282,7 @@ exports[`Checkbox[Checked, disabled] should render correctly about checked is in
       </span>
       <span
         class="soui-checkbox-desc"
+        data-soui-role="desc"
       >
         Option1
       </span>
@@ -297,6 +306,7 @@ exports[`Checkbox[Checked, disabled] should render correctly about checked is in
       </span>
       <span
         class="soui-checkbox-desc"
+        data-soui-role="desc"
       >
         Option2
       </span>
@@ -320,6 +330,7 @@ exports[`Checkbox[Checked, disabled] should render correctly about checked is in
       </span>
       <span
         class="soui-checkbox-desc"
+        data-soui-role="desc"
       >
         Option3
       </span>
@@ -349,6 +360,7 @@ exports[`Checkbox[Click] should render correctly about click 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       Click Me
        0 Times!
@@ -377,6 +389,7 @@ exports[`Checkbox[HtmlValue] should render correctly about htmlValue 1`] = `
   </span>
   <span
     class="soui-checkbox-desc"
+    data-soui-role="desc"
   >
     value is "ok"
   </span>

--- a/packages/shineout/src/checkbox/__test__/__snapshots__/checkboxGroup.spec.tsx.snap
+++ b/packages/shineout/src/checkbox/__test__/__snapshots__/checkboxGroup.spec.tsx.snap
@@ -23,6 +23,7 @@ exports[`CheckboxGroup[Base] should render correctly by CheckboxBlock 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       red
     </span>
@@ -46,6 +47,7 @@ exports[`CheckboxGroup[Base] should render correctly by CheckboxBlock 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       orange
     </span>
@@ -69,6 +71,7 @@ exports[`CheckboxGroup[Base] should render correctly by CheckboxBlock 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       yellow
     </span>
@@ -92,6 +95,7 @@ exports[`CheckboxGroup[Base] should render correctly by CheckboxBlock 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       green
     </span>
@@ -128,6 +132,7 @@ exports[`CheckboxGroup[Base] should render correctly by CheckboxBlock 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       cyan
     </span>
@@ -164,6 +169,7 @@ exports[`CheckboxGroup[Base] should render correctly by CheckboxBlock 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       blue
     </span>
@@ -187,6 +193,7 @@ exports[`CheckboxGroup[Base] should render correctly by CheckboxBlock 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       violet
     </span>
@@ -217,6 +224,7 @@ exports[`CheckboxGroup[Base] should render correctly by CheckboxGroup 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       <span
         style="border-bottom: 1px solid red;"
@@ -244,6 +252,7 @@ exports[`CheckboxGroup[Base] should render correctly by CheckboxGroup 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       <span
         style="border-bottom: 1px solid orange;"
@@ -271,6 +280,7 @@ exports[`CheckboxGroup[Base] should render correctly by CheckboxGroup 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       <span
         style="border-bottom: 1px solid yellow;"
@@ -298,6 +308,7 @@ exports[`CheckboxGroup[Base] should render correctly by CheckboxGroup 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       <span
         style="border-bottom: 1px solid green;"
@@ -338,6 +349,7 @@ exports[`CheckboxGroup[Base] should render correctly by CheckboxGroup 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       <span
         style="border-bottom: 1px solid cyan;"
@@ -378,6 +390,7 @@ exports[`CheckboxGroup[Base] should render correctly by CheckboxGroup 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       <span
         style="border-bottom: 1px solid blue;"
@@ -405,6 +418,7 @@ exports[`CheckboxGroup[Base] should render correctly by CheckboxGroup 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       <span
         style="border-bottom: 1px solid violet;"
@@ -439,6 +453,7 @@ exports[`CheckboxGroup[Base] should render correctly by CheckboxRawgroup 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       red
     </span>
@@ -462,6 +477,7 @@ exports[`CheckboxGroup[Base] should render correctly by CheckboxRawgroup 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       cyan
     </span>
@@ -498,6 +514,7 @@ exports[`CheckboxGroup[Base] should render correctly by CheckboxRawgroup 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       blue
     </span>
@@ -521,6 +538,7 @@ exports[`CheckboxGroup[Base] should render correctly by CheckboxRawgroup 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       green
     </span>
@@ -557,6 +575,7 @@ exports[`CheckboxGroup[Base] should render correctly by CheckboxRawgroup 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       yellow
     </span>
@@ -580,6 +599,7 @@ exports[`CheckboxGroup[Base] should render correctly by CheckboxRawgroup 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       orange
     </span>
@@ -603,6 +623,7 @@ exports[`CheckboxGroup[Base] should render correctly by CheckboxRawgroup 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       violet
     </span>
@@ -634,6 +655,7 @@ exports[`CheckboxGroup[Disabled] should render correctly by disabled-A 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       red
     </span>
@@ -658,6 +680,7 @@ exports[`CheckboxGroup[Disabled] should render correctly by disabled-A 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       orange
     </span>
@@ -682,6 +705,7 @@ exports[`CheckboxGroup[Disabled] should render correctly by disabled-A 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       yellow
     </span>
@@ -706,6 +730,7 @@ exports[`CheckboxGroup[Disabled] should render correctly by disabled-A 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       green
     </span>
@@ -743,6 +768,7 @@ exports[`CheckboxGroup[Disabled] should render correctly by disabled-A 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       cyan
     </span>
@@ -780,6 +806,7 @@ exports[`CheckboxGroup[Disabled] should render correctly by disabled-A 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       blue
     </span>
@@ -804,6 +831,7 @@ exports[`CheckboxGroup[Disabled] should render correctly by disabled-A 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       violet
     </span>
@@ -834,6 +862,7 @@ exports[`CheckboxGroup[Disabled] should render correctly by disabled-B 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       red
     </span>
@@ -857,6 +886,7 @@ exports[`CheckboxGroup[Disabled] should render correctly by disabled-B 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       orange
     </span>
@@ -881,6 +911,7 @@ exports[`CheckboxGroup[Disabled] should render correctly by disabled-B 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       yellow
     </span>
@@ -904,6 +935,7 @@ exports[`CheckboxGroup[Disabled] should render correctly by disabled-B 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       green
     </span>
@@ -940,6 +972,7 @@ exports[`CheckboxGroup[Disabled] should render correctly by disabled-B 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       cyan
     </span>
@@ -976,6 +1009,7 @@ exports[`CheckboxGroup[Disabled] should render correctly by disabled-B 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       blue
     </span>
@@ -999,6 +1033,7 @@ exports[`CheckboxGroup[Disabled] should render correctly by disabled-B 1`] = `
     </span>
     <span
       class="soui-checkbox-desc"
+      data-soui-role="desc"
     >
       violet
     </span>

--- a/packages/shineout/src/collapse/__test__/__snapshots__/collapse.spec.tsx.snap
+++ b/packages/shineout/src/collapse/__test__/__snapshots__/collapse.spec.tsx.snap
@@ -622,6 +622,7 @@ exports[`Collapse[Base] should render correctly about extra 1`] = `
             </span>
             <span
               class="soui-checkbox-desc"
+              data-soui-role="desc"
             >
               checkbox
             </span>

--- a/packages/shineout/src/drawer/__test__/__snapshots__/drawer.spec.tsx.snap
+++ b/packages/shineout/src/drawer/__test__/__snapshots__/drawer.spec.tsx.snap
@@ -573,6 +573,7 @@ exports[`Drawer[Base] should render correctly about full screen 1`] = `
                     </span>
                     <span
                       class="soui-checkbox-desc"
+                      data-soui-role="desc"
                     >
                       chinese
                     </span>
@@ -596,6 +597,7 @@ exports[`Drawer[Base] should render correctly about full screen 1`] = `
                     </span>
                     <span
                       class="soui-checkbox-desc"
+                      data-soui-role="desc"
                     >
                       maths
                     </span>
@@ -619,6 +621,7 @@ exports[`Drawer[Base] should render correctly about full screen 1`] = `
                     </span>
                     <span
                       class="soui-checkbox-desc"
+                      data-soui-role="desc"
                     >
                       english
                     </span>
@@ -642,6 +645,7 @@ exports[`Drawer[Base] should render correctly about full screen 1`] = `
                     </span>
                     <span
                       class="soui-checkbox-desc"
+                      data-soui-role="desc"
                     >
                       physics
                     </span>

--- a/packages/shineout/src/transfer/__doc__/changelog.cn.md
+++ b/packages/shineout/src/transfer/__doc__/changelog.cn.md
@@ -1,6 +1,17 @@
 ## 3.1.19
 2024-05-29
 
+### 🆕 Feature
+
+- 新增 `equalPanelWidth` 属性，支持根据容器宽度均等分配面板宽度 ([#613](https://github.com/sheinsight/shineout-next/pull/613))
+
+### 💎 Enhancement
+
+- 优化勾选项的容器宽度，默认占满整行，超出后自动省略文案内容 ([#613](https://github.com/sheinsight/shineout-next/pull/613))
+
+## 3.1.19
+2024-05-29
+
 ### 🐞 BugFix
 
 - 修复 `Transfer` 自定义渲染参数 `selectKeys` 为空问题 ([#484](https://github.com/sheinsight/shineout-next/pull/484))

--- a/packages/shineout/src/transfer/__test__/__snapshots__/transfer.spec.tsx.snap
+++ b/packages/shineout/src/transfer/__test__/__snapshots__/transfer.spec.tsx.snap
@@ -29,6 +29,7 @@ exports[`Transfer[Base] should render correctly  1`] = `
         </span>
         <span
           class="soui-checkbox-desc"
+          data-soui-role="desc"
         >
           <span
             class="soui-transfer-count"
@@ -90,6 +91,7 @@ exports[`Transfer[Base] should render correctly  1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-1
                       </span>
@@ -122,6 +124,7 @@ exports[`Transfer[Base] should render correctly  1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-2
                       </span>
@@ -154,6 +157,7 @@ exports[`Transfer[Base] should render correctly  1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-3
                       </span>
@@ -186,6 +190,7 @@ exports[`Transfer[Base] should render correctly  1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-4
                       </span>
@@ -218,6 +223,7 @@ exports[`Transfer[Base] should render correctly  1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-5
                       </span>
@@ -250,6 +256,7 @@ exports[`Transfer[Base] should render correctly  1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-6
                       </span>
@@ -282,6 +289,7 @@ exports[`Transfer[Base] should render correctly  1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-7
                       </span>
@@ -314,6 +322,7 @@ exports[`Transfer[Base] should render correctly  1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-8
                       </span>
@@ -346,6 +355,7 @@ exports[`Transfer[Base] should render correctly  1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-9
                       </span>
@@ -378,6 +388,7 @@ exports[`Transfer[Base] should render correctly  1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-10
                       </span>
@@ -465,6 +476,7 @@ exports[`Transfer[Base] should render correctly  1`] = `
         </span>
         <span
           class="soui-checkbox-desc"
+          data-soui-role="desc"
         >
           <span
             class="soui-transfer-count"
@@ -727,6 +739,7 @@ exports[`Transfer[Base] should render correctly about bigdata 1`] = `
         </span>
         <span
           class="soui-checkbox-desc"
+          data-soui-role="desc"
         >
           <span
             class="soui-transfer-count"
@@ -788,6 +801,7 @@ exports[`Transfer[Base] should render correctly about bigdata 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-1
                       </span>
@@ -820,6 +834,7 @@ exports[`Transfer[Base] should render correctly about bigdata 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-2
                       </span>
@@ -852,6 +867,7 @@ exports[`Transfer[Base] should render correctly about bigdata 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-3
                       </span>
@@ -884,6 +900,7 @@ exports[`Transfer[Base] should render correctly about bigdata 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-4
                       </span>
@@ -916,6 +933,7 @@ exports[`Transfer[Base] should render correctly about bigdata 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-5
                       </span>
@@ -948,6 +966,7 @@ exports[`Transfer[Base] should render correctly about bigdata 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-6
                       </span>
@@ -980,6 +999,7 @@ exports[`Transfer[Base] should render correctly about bigdata 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-7
                       </span>
@@ -1012,6 +1032,7 @@ exports[`Transfer[Base] should render correctly about bigdata 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-8
                       </span>
@@ -1044,6 +1065,7 @@ exports[`Transfer[Base] should render correctly about bigdata 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-9
                       </span>
@@ -1076,6 +1098,7 @@ exports[`Transfer[Base] should render correctly about bigdata 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-10
                       </span>
@@ -1108,6 +1131,7 @@ exports[`Transfer[Base] should render correctly about bigdata 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-11
                       </span>
@@ -1140,6 +1164,7 @@ exports[`Transfer[Base] should render correctly about bigdata 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-12
                       </span>
@@ -1172,6 +1197,7 @@ exports[`Transfer[Base] should render correctly about bigdata 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-13
                       </span>
@@ -1204,6 +1230,7 @@ exports[`Transfer[Base] should render correctly about bigdata 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-14
                       </span>
@@ -1236,6 +1263,7 @@ exports[`Transfer[Base] should render correctly about bigdata 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-15
                       </span>
@@ -1268,6 +1296,7 @@ exports[`Transfer[Base] should render correctly about bigdata 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-16
                       </span>
@@ -1300,6 +1329,7 @@ exports[`Transfer[Base] should render correctly about bigdata 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-17
                       </span>
@@ -1332,6 +1362,7 @@ exports[`Transfer[Base] should render correctly about bigdata 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-18
                       </span>
@@ -1364,6 +1395,7 @@ exports[`Transfer[Base] should render correctly about bigdata 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-19
                       </span>
@@ -1396,6 +1428,7 @@ exports[`Transfer[Base] should render correctly about bigdata 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-20
                       </span>
@@ -1483,6 +1516,7 @@ exports[`Transfer[Base] should render correctly about bigdata 1`] = `
         </span>
         <span
           class="soui-checkbox-desc"
+          data-soui-role="desc"
         >
           <span
             class="soui-transfer-count"
@@ -1746,6 +1780,7 @@ exports[`Transfer[Base] should render correctly about control 1`] = `
           </span>
           <span
             class="soui-checkbox-desc"
+            data-soui-role="desc"
           >
             <span
               class="soui-transfer-count"
@@ -1807,6 +1842,7 @@ exports[`Transfer[Base] should render correctly about control 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-1
                         </span>
@@ -1839,6 +1875,7 @@ exports[`Transfer[Base] should render correctly about control 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-2
                         </span>
@@ -1871,6 +1908,7 @@ exports[`Transfer[Base] should render correctly about control 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-3
                         </span>
@@ -1903,6 +1941,7 @@ exports[`Transfer[Base] should render correctly about control 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-4
                         </span>
@@ -1935,6 +1974,7 @@ exports[`Transfer[Base] should render correctly about control 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-5
                         </span>
@@ -1967,6 +2007,7 @@ exports[`Transfer[Base] should render correctly about control 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-6
                         </span>
@@ -1999,6 +2040,7 @@ exports[`Transfer[Base] should render correctly about control 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-7
                         </span>
@@ -2031,6 +2073,7 @@ exports[`Transfer[Base] should render correctly about control 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-8
                         </span>
@@ -2063,6 +2106,7 @@ exports[`Transfer[Base] should render correctly about control 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-9
                         </span>
@@ -2095,6 +2139,7 @@ exports[`Transfer[Base] should render correctly about control 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-10
                         </span>
@@ -2182,6 +2227,7 @@ exports[`Transfer[Base] should render correctly about control 1`] = `
           </span>
           <span
             class="soui-checkbox-desc"
+            data-soui-role="desc"
           >
             <span
               class="soui-transfer-count"
@@ -2451,6 +2497,7 @@ exports[`Transfer[Base] should render correctly about custom render 1`] = `
             </span>
             <span
               class="soui-checkbox-desc"
+              data-soui-role="desc"
             >
               <span
                 class="soui-transfer-count"
@@ -2514,6 +2561,7 @@ exports[`Transfer[Base] should render correctly about custom render 1`] = `
                           </span>
                           <span
                             class="soui-checkbox-desc"
+                            data-soui-role="desc"
                           >
                             name-1
                           </span>
@@ -2546,6 +2594,7 @@ exports[`Transfer[Base] should render correctly about custom render 1`] = `
                           </span>
                           <span
                             class="soui-checkbox-desc"
+                            data-soui-role="desc"
                           >
                             name-2
                           </span>
@@ -2578,6 +2627,7 @@ exports[`Transfer[Base] should render correctly about custom render 1`] = `
                           </span>
                           <span
                             class="soui-checkbox-desc"
+                            data-soui-role="desc"
                           >
                             name-3
                           </span>
@@ -2610,6 +2660,7 @@ exports[`Transfer[Base] should render correctly about custom render 1`] = `
                           </span>
                           <span
                             class="soui-checkbox-desc"
+                            data-soui-role="desc"
                           >
                             name-4
                           </span>
@@ -2642,6 +2693,7 @@ exports[`Transfer[Base] should render correctly about custom render 1`] = `
                           </span>
                           <span
                             class="soui-checkbox-desc"
+                            data-soui-role="desc"
                           >
                             name-5
                           </span>
@@ -2674,6 +2726,7 @@ exports[`Transfer[Base] should render correctly about custom render 1`] = `
                           </span>
                           <span
                             class="soui-checkbox-desc"
+                            data-soui-role="desc"
                           >
                             name-6
                           </span>
@@ -2706,6 +2759,7 @@ exports[`Transfer[Base] should render correctly about custom render 1`] = `
                           </span>
                           <span
                             class="soui-checkbox-desc"
+                            data-soui-role="desc"
                           >
                             name-7
                           </span>
@@ -2738,6 +2792,7 @@ exports[`Transfer[Base] should render correctly about custom render 1`] = `
                           </span>
                           <span
                             class="soui-checkbox-desc"
+                            data-soui-role="desc"
                           >
                             name-8
                           </span>
@@ -2770,6 +2825,7 @@ exports[`Transfer[Base] should render correctly about custom render 1`] = `
                           </span>
                           <span
                             class="soui-checkbox-desc"
+                            data-soui-role="desc"
                           >
                             name-9
                           </span>
@@ -2802,6 +2858,7 @@ exports[`Transfer[Base] should render correctly about custom render 1`] = `
                           </span>
                           <span
                             class="soui-checkbox-desc"
+                            data-soui-role="desc"
                           >
                             name-10
                           </span>
@@ -2892,6 +2949,7 @@ exports[`Transfer[Base] should render correctly about custom render 1`] = `
             </span>
             <span
               class="soui-checkbox-desc"
+              data-soui-role="desc"
             >
               <span
                 class="soui-transfer-count"
@@ -3175,6 +3233,7 @@ exports[`Transfer[Base] should render correctly about customFilter 1`] = `
         </span>
         <span
           class="soui-checkbox-desc"
+          data-soui-role="desc"
         >
           <span
             class="soui-transfer-count"
@@ -3258,6 +3317,7 @@ exports[`Transfer[Base] should render correctly about customFilter 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-1
                       </span>
@@ -3290,6 +3350,7 @@ exports[`Transfer[Base] should render correctly about customFilter 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-2
                       </span>
@@ -3322,6 +3383,7 @@ exports[`Transfer[Base] should render correctly about customFilter 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-3
                       </span>
@@ -3354,6 +3416,7 @@ exports[`Transfer[Base] should render correctly about customFilter 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-4
                       </span>
@@ -3386,6 +3449,7 @@ exports[`Transfer[Base] should render correctly about customFilter 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-5
                       </span>
@@ -3418,6 +3482,7 @@ exports[`Transfer[Base] should render correctly about customFilter 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-6
                       </span>
@@ -3450,6 +3515,7 @@ exports[`Transfer[Base] should render correctly about customFilter 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-7
                       </span>
@@ -3482,6 +3548,7 @@ exports[`Transfer[Base] should render correctly about customFilter 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-8
                       </span>
@@ -3514,6 +3581,7 @@ exports[`Transfer[Base] should render correctly about customFilter 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-9
                       </span>
@@ -3546,6 +3614,7 @@ exports[`Transfer[Base] should render correctly about customFilter 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-10
                       </span>
@@ -3633,6 +3702,7 @@ exports[`Transfer[Base] should render correctly about customFilter 1`] = `
         </span>
         <span
           class="soui-checkbox-desc"
+          data-soui-role="desc"
         >
           <span
             class="soui-transfer-count"
@@ -3917,6 +3987,7 @@ exports[`Transfer[Base] should render correctly about filter 1`] = `
         </span>
         <span
           class="soui-checkbox-desc"
+          data-soui-role="desc"
         >
           <span
             class="soui-transfer-count"
@@ -4006,6 +4077,7 @@ exports[`Transfer[Base] should render correctly about filter 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-1
                       </span>
@@ -4038,6 +4110,7 @@ exports[`Transfer[Base] should render correctly about filter 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-2
                       </span>
@@ -4070,6 +4143,7 @@ exports[`Transfer[Base] should render correctly about filter 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-3
                       </span>
@@ -4102,6 +4176,7 @@ exports[`Transfer[Base] should render correctly about filter 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-4
                       </span>
@@ -4134,6 +4209,7 @@ exports[`Transfer[Base] should render correctly about filter 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-5
                       </span>
@@ -4166,6 +4242,7 @@ exports[`Transfer[Base] should render correctly about filter 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-6
                       </span>
@@ -4198,6 +4275,7 @@ exports[`Transfer[Base] should render correctly about filter 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-7
                       </span>
@@ -4230,6 +4308,7 @@ exports[`Transfer[Base] should render correctly about filter 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-8
                       </span>
@@ -4262,6 +4341,7 @@ exports[`Transfer[Base] should render correctly about filter 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-9
                       </span>
@@ -4294,6 +4374,7 @@ exports[`Transfer[Base] should render correctly about filter 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-10
                       </span>
@@ -4381,6 +4462,7 @@ exports[`Transfer[Base] should render correctly about filter 1`] = `
         </span>
         <span
           class="soui-checkbox-desc"
+          data-soui-role="desc"
         >
           <span
             class="soui-transfer-count"
@@ -4672,6 +4754,7 @@ exports[`Transfer[Base] should render correctly about loading 1`] = `
         </span>
         <span
           class="soui-checkbox-desc"
+          data-soui-role="desc"
         >
           <span
             class="soui-transfer-count"
@@ -4733,6 +4816,7 @@ exports[`Transfer[Base] should render correctly about loading 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-1
                       </span>
@@ -4765,6 +4849,7 @@ exports[`Transfer[Base] should render correctly about loading 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-2
                       </span>
@@ -4797,6 +4882,7 @@ exports[`Transfer[Base] should render correctly about loading 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-3
                       </span>
@@ -4829,6 +4915,7 @@ exports[`Transfer[Base] should render correctly about loading 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-4
                       </span>
@@ -4861,6 +4948,7 @@ exports[`Transfer[Base] should render correctly about loading 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-5
                       </span>
@@ -4893,6 +4981,7 @@ exports[`Transfer[Base] should render correctly about loading 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-6
                       </span>
@@ -4925,6 +5014,7 @@ exports[`Transfer[Base] should render correctly about loading 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-7
                       </span>
@@ -4957,6 +5047,7 @@ exports[`Transfer[Base] should render correctly about loading 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-8
                       </span>
@@ -4989,6 +5080,7 @@ exports[`Transfer[Base] should render correctly about loading 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-9
                       </span>
@@ -5021,6 +5113,7 @@ exports[`Transfer[Base] should render correctly about loading 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-10
                       </span>
@@ -5117,6 +5210,7 @@ exports[`Transfer[Base] should render correctly about loading 1`] = `
         </span>
         <span
           class="soui-checkbox-desc"
+          data-soui-role="desc"
         >
           <span
             class="soui-transfer-count"
@@ -5388,6 +5482,7 @@ exports[`Transfer[Base] should render correctly about loading control 1`] = `
         </span>
         <span
           class="soui-checkbox-desc"
+          data-soui-role="desc"
         >
           <span
             class="soui-transfer-count"
@@ -5449,6 +5544,7 @@ exports[`Transfer[Base] should render correctly about loading control 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-1
                       </span>
@@ -5481,6 +5577,7 @@ exports[`Transfer[Base] should render correctly about loading control 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-2
                       </span>
@@ -5513,6 +5610,7 @@ exports[`Transfer[Base] should render correctly about loading control 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-3
                       </span>
@@ -5545,6 +5643,7 @@ exports[`Transfer[Base] should render correctly about loading control 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-4
                       </span>
@@ -5577,6 +5676,7 @@ exports[`Transfer[Base] should render correctly about loading control 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-5
                       </span>
@@ -5609,6 +5709,7 @@ exports[`Transfer[Base] should render correctly about loading control 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-6
                       </span>
@@ -5641,6 +5742,7 @@ exports[`Transfer[Base] should render correctly about loading control 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-7
                       </span>
@@ -5673,6 +5775,7 @@ exports[`Transfer[Base] should render correctly about loading control 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-8
                       </span>
@@ -5705,6 +5808,7 @@ exports[`Transfer[Base] should render correctly about loading control 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-9
                       </span>
@@ -5737,6 +5841,7 @@ exports[`Transfer[Base] should render correctly about loading control 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-10
                       </span>
@@ -5832,6 +5937,7 @@ exports[`Transfer[Base] should render correctly about loading control 1`] = `
         </span>
         <span
           class="soui-checkbox-desc"
+          data-soui-role="desc"
         >
           <span
             class="soui-transfer-count"
@@ -6095,6 +6201,7 @@ exports[`Transfer[Base] should render correctly about seleced 1`] = `
           </span>
           <span
             class="soui-checkbox-desc"
+            data-soui-role="desc"
           >
             <span
               class="soui-transfer-count"
@@ -6156,6 +6263,7 @@ exports[`Transfer[Base] should render correctly about seleced 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-1
                         </span>
@@ -6188,6 +6296,7 @@ exports[`Transfer[Base] should render correctly about seleced 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-2
                         </span>
@@ -6220,6 +6329,7 @@ exports[`Transfer[Base] should render correctly about seleced 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-3
                         </span>
@@ -6252,6 +6362,7 @@ exports[`Transfer[Base] should render correctly about seleced 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-4
                         </span>
@@ -6284,6 +6395,7 @@ exports[`Transfer[Base] should render correctly about seleced 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-5
                         </span>
@@ -6316,6 +6428,7 @@ exports[`Transfer[Base] should render correctly about seleced 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-6
                         </span>
@@ -6348,6 +6461,7 @@ exports[`Transfer[Base] should render correctly about seleced 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-7
                         </span>
@@ -6380,6 +6494,7 @@ exports[`Transfer[Base] should render correctly about seleced 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-8
                         </span>
@@ -6412,6 +6527,7 @@ exports[`Transfer[Base] should render correctly about seleced 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-9
                         </span>
@@ -6444,6 +6560,7 @@ exports[`Transfer[Base] should render correctly about seleced 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-10
                         </span>
@@ -6531,6 +6648,7 @@ exports[`Transfer[Base] should render correctly about seleced 1`] = `
           </span>
           <span
             class="soui-checkbox-desc"
+            data-soui-role="desc"
           >
             <span
               class="soui-transfer-count"
@@ -6794,6 +6912,7 @@ exports[`Transfer[Base] should render correctly about simple 1`] = `
         </span>
         <span
           class="soui-checkbox-desc"
+          data-soui-role="desc"
         >
           <span
             class="soui-transfer-count"
@@ -6853,6 +6972,7 @@ exports[`Transfer[Base] should render correctly about simple 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-1
                       </span>
@@ -6885,6 +7005,7 @@ exports[`Transfer[Base] should render correctly about simple 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-2
                       </span>
@@ -6917,6 +7038,7 @@ exports[`Transfer[Base] should render correctly about simple 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-3
                       </span>
@@ -6949,6 +7071,7 @@ exports[`Transfer[Base] should render correctly about simple 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-4
                       </span>
@@ -6981,6 +7104,7 @@ exports[`Transfer[Base] should render correctly about simple 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-5
                       </span>
@@ -7013,6 +7137,7 @@ exports[`Transfer[Base] should render correctly about simple 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-6
                       </span>
@@ -7045,6 +7170,7 @@ exports[`Transfer[Base] should render correctly about simple 1`] = `
                       </span>
                       <span
                         class="soui-checkbox-desc"
+                        data-soui-role="desc"
                       >
                         name-7
                       </span>
@@ -7318,6 +7444,7 @@ exports[`Transfer[Base] should render correctly about size 1`] = `
           </span>
           <span
             class="soui-checkbox-desc"
+            data-soui-role="desc"
           >
             <span
               class="soui-transfer-count"
@@ -7379,6 +7506,7 @@ exports[`Transfer[Base] should render correctly about size 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-1
                         </span>
@@ -7411,6 +7539,7 @@ exports[`Transfer[Base] should render correctly about size 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-2
                         </span>
@@ -7443,6 +7572,7 @@ exports[`Transfer[Base] should render correctly about size 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-3
                         </span>
@@ -7475,6 +7605,7 @@ exports[`Transfer[Base] should render correctly about size 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-4
                         </span>
@@ -7507,6 +7638,7 @@ exports[`Transfer[Base] should render correctly about size 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-5
                         </span>
@@ -7539,6 +7671,7 @@ exports[`Transfer[Base] should render correctly about size 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-6
                         </span>
@@ -7571,6 +7704,7 @@ exports[`Transfer[Base] should render correctly about size 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-7
                         </span>
@@ -7603,6 +7737,7 @@ exports[`Transfer[Base] should render correctly about size 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-8
                         </span>
@@ -7635,6 +7770,7 @@ exports[`Transfer[Base] should render correctly about size 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-9
                         </span>
@@ -7667,6 +7803,7 @@ exports[`Transfer[Base] should render correctly about size 1`] = `
                         </span>
                         <span
                           class="soui-checkbox-desc"
+                          data-soui-role="desc"
                         >
                           name-10
                         </span>
@@ -7754,6 +7891,7 @@ exports[`Transfer[Base] should render correctly about size 1`] = `
           </span>
           <span
             class="soui-checkbox-desc"
+            data-soui-role="desc"
           >
             <span
               class="soui-transfer-count"


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others


### Changelog

- 新增 `equalPanelWidth` 属性，支持根据容器宽度均等分配面板宽度
- 优化勾选项的容器宽度，默认占满整行，超出后自动省略文案内容