### PR TITLE
fix-table-column-shadow/main

### DIFF
--- a/docs/markdown/shineout/changelog-v3.md
+++ b/docs/markdown/shineout/changelog-v3.md
@@ -57,6 +57,8 @@
   - 废弃 `fixed` 属性，使用 `virtual` 代替
 - Tag
   - 废弃 `type` 属性，使用 `color` 代替
+- Popover
+  - 废弃 `Popover.Content` 组件，使用boolean属性 `useTextStyle` 代替
 
 
 ### 功能改进

--- a/packages/shineout-style/src/table/table.ts
+++ b/packages/shineout-style/src/table/table.ts
@@ -237,7 +237,7 @@ const tableStyle: JsStyles<TableClassType> = {
         content: '""',
         position: 'absolute',
         top: 0,
-        bottom: 0,
+        bottom: -1,
         width: '5px',
       },
       '&[dir=ltr]::after': {
@@ -257,6 +257,7 @@ const tableStyle: JsStyles<TableClassType> = {
       },
     },
   },
+
   floatRight: {
     '& $cellFixedLast$cellFixedRight': {
       '&::before': {


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Changelog
- 修复`Table`固定列的阴影有1px的露底问题