### PR TITLE
fix: Table column的width类型修改

### DIFF
--- a/packages/base/src/table/colgroup.tsx
+++ b/packages/base/src/table/colgroup.tsx
@@ -1,6 +1,6 @@
 interface ColgroupProps {
-  colgroup?: (number | string | undefined)[];
-  columns?: { key: string | number; width?: number | string }[];
+  colgroup?: (number | undefined)[];
+  columns?: { key: string | number; width?: number }[];
   shouldLastColAuto: boolean;
 }
 const Colgroup = (props: ColgroupProps) => {

--- a/packages/base/src/table/tbody.type.ts
+++ b/packages/base/src/table/tbody.type.ts
@@ -26,7 +26,7 @@ export interface TbodyProps
   > {
   columns: TableFormatColumn<any>[];
   data: any[];
-  colgroup: (number | string | undefined)[];
+  colgroup: (number | undefined)[];
   isScrollX: boolean;
   currentIndex?: number;
   expandHideCol: UseColumnsResult['expandHideCol'];

--- a/packages/base/src/table/tfoot.tsx
+++ b/packages/base/src/table/tfoot.tsx
@@ -22,7 +22,7 @@ export default (props: TfootProps) => {
           transform: `translate3d(${props.fixLeftNum}px, 0, 0)`,
         } as React.CSSProperties;
       }
-      const left = colgroup.slice(0, index).reduce((a, b) => Number(a || 0) + Number(b || 0), 0);
+      const left = colgroup.slice(0, index).reduce((a, b) => (a || 0) + (b || 0), 0);
       return {
         left: left,
         position: 'sticky',
@@ -34,7 +34,7 @@ export default (props: TfootProps) => {
           transform: `translate3d(-${props.fixRightNum}px, 0, 0)`,
         } as React.CSSProperties;
       }
-      const right = colgroup.slice(index + colSpan).reduce((a, b) => Number(a || 0) + Number(b || 0), 0);
+      const right = colgroup.slice(index + colSpan).reduce((a, b) => (a || 0) + (b || 0), 0);
       return {
         right: right,
         position: 'sticky',

--- a/packages/base/src/table/tfoot.type.ts
+++ b/packages/base/src/table/tfoot.type.ts
@@ -7,5 +7,5 @@ export interface TfootProps
   fixLeftNum?: number;
   fixRightNum?: number;
   columns: TableFormatColumn<any>[];
-  colgroup: (number | string | undefined)[];
+  colgroup: (number | undefined)[];
 }

--- a/packages/base/src/table/thead.tsx
+++ b/packages/base/src/table/thead.tsx
@@ -120,7 +120,7 @@ export default (props: TheadProps) => {
           transform: `translate3d(${props.fixLeftNum}px, 0, 0)`,
         } as React.CSSProperties;
       }
-      const left = colgroup.slice(0, index).reduce((a, b) => Number(a || 0) + Number(b || 0), 0);
+      const left = colgroup.slice(0, index).reduce((a, b) => (a || 0) + (b || 0), 0);
       return {
         left: left,
         position: 'sticky',
@@ -132,7 +132,7 @@ export default (props: TheadProps) => {
           transform: `translate3d(${0 - props.fixRightNum}px, 0, 0)`,
         } as React.CSSProperties;
       }
-      const right = colgroup.slice(index + colSpan).reduce((a, b) => Number(a || 0) + Number(b || 0), 0);
+      const right = colgroup.slice(index + colSpan).reduce((a, b) => (a || 0) + (b || 0), 0);
       return {
         right: right,
         position: 'sticky',

--- a/packages/base/src/table/thead.type.ts
+++ b/packages/base/src/table/thead.type.ts
@@ -22,7 +22,7 @@ export interface TheadProps
   columns: TableFormatColumn<any>[];
   isScrollY?: boolean;
   bordered?: boolean;
-  colgroup: (number | string | undefined)[];
+  colgroup: (number | undefined)[];
   datum: ListDatum;
   fixLeftNum?: number;
   fixRightNum?: number;

--- a/packages/base/src/table/tr.tsx
+++ b/packages/base/src/table/tr.tsx
@@ -40,7 +40,7 @@ interface TrProps
   rowIndex: number;
   columns: TableFormatColumn<any>[];
   isScrollX: boolean;
-  colgroup: (number | string | undefined)[];
+  colgroup: (number | undefined)[];
   rawData: any;
   expanded: boolean;
   expandCol: TbodyProps['expandHideCol'] | undefined;
@@ -71,7 +71,7 @@ const Tr = (props: TrProps) => {
           transform: `translate3d(${props.fixLeftNum}px, 0, 0)`,
         } as React.CSSProperties;
       }
-      const left = props.colgroup.slice(0, index).reduce((a, b) => Number(a || 0) + Number(b || 0), 0);
+      const left = props.colgroup.slice(0, index).reduce((a, b) => (a || 0) + (b || 0), 0);
       return {
         position: 'sticky',
         left,
@@ -83,7 +83,7 @@ const Tr = (props: TrProps) => {
           transform: `translate3d(${0 - props.fixRightNum}px, 0, 0)`,
         } as React.CSSProperties;
       }
-      const right = props.colgroup.slice(index + colSpan).reduce((a, b) => Number(a || 0) + Number(b || 0), 0);
+      const right = props.colgroup.slice(index + colSpan).reduce((a, b) => (a || 0) + (b || 0), 0);
 
       return {
         position: 'sticky',

--- a/packages/hooks/src/components/use-table/use-table.type.ts
+++ b/packages/hooks/src/components/use-table/use-table.type.ts
@@ -264,7 +264,7 @@ export interface TableColumnItem<DataItem> {
    * @en width
    * @cn 列宽
    */
-  width?: number | string;
+  width?: number;
 
   /**
    * @cn 列对应的类名


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了表格组件的列组属性，现仅接受数字或未定义值，增强了类型安全性。
  
- **修复**
	- 简化了表尾组件的数值处理逻辑，确保功能保持不变。

- **文档**
	- 修改了多个接口的属性类型定义，以提高一致性和可预测性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->