### PR TITLE
fix: 修复 table 虚拟滚动 内部 元素 scrollIntoView 会导致页面偏移的问题

### DIFF
--- a/packages/base/src/virtual-scroll/scroll.tsx
+++ b/packages/base/src/virtual-scroll/scroll.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { usePersistFn, useResize, util } from '@sheinx/hooks';
+import { useForkRef, usePersistFn, useResize, util } from '@sheinx/hooks';
 import { useConfig } from '../config';
 
 interface scrollProps {
@@ -27,6 +27,9 @@ interface scrollProps {
 
 const Scroll = (props: scrollProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const wrapperRef = useForkRef(scrollRef, props.wrapperRef);
   const { current: context } = useRef({
     timer: null as any,
     isMouseDown: false,
@@ -99,13 +102,21 @@ const Scroll = (props: scrollProps) => {
       });
   });
 
+  const handleInnerScroll = usePersistFn((e: React.UIEvent) => {
+    const scrollTop = (e.currentTarget as HTMLDivElement).scrollTop;
+    if (scrollRef.current) {
+      e.currentTarget.scrollTop = 0;
+      scrollRef.current.scrollTop += scrollTop;
+    }
+  });
+
   return (
     <div className={props.className} style={props.style} onMouseMove={props.onMouseMove}>
       <div
         {...util.getDataAttribute({ role: 'scroll' })}
         style={scrollerStyle}
         onScroll={handleScroll}
-        ref={props.wrapperRef}
+        ref={wrapperRef}
         onMouseDown={() => {
           context.isMouseDown = true;
         }}
@@ -117,6 +128,7 @@ const Scroll = (props: scrollProps) => {
           {...util.getDataAttribute({ role: 'scroll-container' })}
           style={containerStyle}
           ref={containerRef}
+          onScroll={handleInnerScroll}
         >
           <div style={{ flexGrow: 1, ...props.childrenStyle }}>{props.children}</div>
         </div>


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1.  描述 修复 table 虚拟滚动 内部 元素 scrollIntoView 会导致页面偏移的问题
2.  原因：容器有overflow: hidden 与 scrollIntoView 冲突
-->

### Changelog

修复 Table 虚拟滚动内部元素 scrollIntoView 会导致页面偏移的问题

### Other information