### PR TITLE
fix: 修复 `Modal` 组件下存在多个`Form`组件时，`Modal.Submit`提交无效的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.3.6-beta.2",
+  "version": "3.3.6-beta.4",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/form/form-footer-context.tsx
+++ b/packages/base/src/form/form-footer-context.tsx
@@ -15,10 +15,13 @@ export const FormFooterContext = createContext<FormFooterContextValue | null>(nu
 
 export const FormFooterProvider = (props: { children: React.ReactNode }) => {
   const [formStats, setFormS] = useState<FormFooterContextValue['formStats']>(undefined);
-  const { current: context } = useRef({ submit: () => {} });
+  const { current: context } = useRef({ submit: () => {}, hasSubmit: false });
 
   const setFormInfo = usePersistFn((info: { submit: () => void }) => {
-    context.submit = info.submit;
+    if(!context.hasSubmit){
+      context.submit = info.submit;
+      context.hasSubmit = true;
+    }
   });
   const setFormStats = usePersistFn((disabled?: 'disabled' | 'pending') => {
     if (disabled !== formStats) {

--- a/packages/base/src/form/form.tsx
+++ b/packages/base/src/form/form.tsx
@@ -63,7 +63,9 @@ const Form = <V extends ObjectType>(props: FormProps<V>) => {
     if (status !== modalFormContext?.formStats) {
       modalFormContext?.setFormStats(status);
     }
-    modalFormContext?.setFormInfo(formRefObj);
+    if(props.onSubmit){
+      modalFormContext?.setFormInfo(formRefObj);
+    }
   };
   useEffect(() => {
     handleFormModalInfo();

--- a/packages/shineout/src/modal/__doc__/changelog.cn.md
+++ b/packages/shineout/src/modal/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.3.3-beta.4
+2024-08-29
+
+### 🐞 BugFix
+
+- 修复 `Modal` 组件下存在多个`Form`组件时，`Modal.Submit`提交无效的问题 ([#625](https://github.com/sheinsight/shineout-next/pull/625))
+
 ## 3.3.2
 2024-07-29
 

--- a/packages/shineout/src/modal/__example__/test-05-multiple-form-submit.tsx
+++ b/packages/shineout/src/modal/__example__/test-05-multiple-form-submit.tsx
@@ -1,0 +1,74 @@
+/**
+ * cn - 多个表单onSubmit
+ * en - Multiple form
+ */
+import React, { useState } from 'react';
+import { Modal, Button, Form, Input, Message } from 'shineout';
+
+const App: React.FC = () => {
+  const [visible, setVisible] = useState(false);
+  const [form2, setForm2] = useState({ email2: '123' });
+
+  const show = () => {
+    setVisible(true);
+  };
+
+  const handleClose = () => {
+    setVisible(false);
+  };
+
+  const footer = () => (
+    <div>
+      <Button onClick={handleClose} mode='outline'>
+        Cancel
+      </Button>
+      <Modal.Submit type='primary'>Submit</Modal.Submit>
+    </div>
+  );
+
+  const handleSubmit1 = (data: any) => {
+    // setVisible(false);
+    Message.success('submit1:' + JSON.stringify(data));
+  };
+
+  return (
+    <div>
+      <Button mode='outline' onClick={show}>
+        Modal Form
+      </Button>
+
+      <Modal visible={visible} width={456} title='Form' onClose={handleClose} footer={footer()}>
+        <div>
+          <Form
+            labelWidth={100}
+            labelAlign='right'
+            style={{ maxWidth: 400 }}
+            onSubmit={handleSubmit1}
+          >
+            <Form.Item required label='Email'>
+              <Input name='email' />
+            </Form.Item>
+
+            <Form.Item required label='Password'>
+              <Input name='password' type='password' />
+            </Form.Item>
+          </Form>
+
+          <Form
+            value={form2}
+            onChange={setForm2}
+            onSubmit={(v) => {
+              Message.success('submit2:' + JSON.stringify(v));
+            }}
+          >
+            <Form.Item required label='Email2'>
+              <Input name='email2' />
+            </Form.Item>
+          </Form>
+        </div>
+      </Modal>
+    </div>
+  );
+};
+
+export default App;


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Changelog
- 修复 `Modal` 组件下存在多个`Form`组件时，`Modal.Submit`提交无效的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 引入了一个新的组件，用于在模态对话框中处理多个表单提交，提升了用户交互体验。
	- 增加了表单提交的状态管理机制，确保提交逻辑在组件生命周期中只被设置一次。

- **Bug 修复**
	- 优化了表单组件的逻辑，仅在提供 `onSubmit` 属性时调用提交方法，防止不必要的更新。 

- **版本更新**
	- 项目版本从 "3.3.6-beta.3" 更新至 "3.3.6-beta.4"。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->