### PR TITLE
fix: `Table`合并行数据中有较大合并行数据时滚动出现空白的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.3.6-beta.4",
+  "version": "3.3.6-beta.5",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-table/use-table-virtual.tsx
+++ b/packages/hooks/src/components/use-table/use-table-virtual.tsx
@@ -85,6 +85,7 @@ const useTableVirtual = (props: UseTableVirtualProps) => {
     controlScrollRate: null as number | null,
     heightCallback: null as null | (() => void),
     preIndex: null as number | null,
+    externalRows: 0,
   });
 
   const getTranslate = usePersistFn((left?: number, top?: number) => {
@@ -138,6 +139,7 @@ const useTableVirtual = (props: UseTableVirtualProps) => {
     let top = 0;
     const maxIndex = Math.max(props.data.length - rowsInView, 0);
     for (let i = 0; i <= maxIndex; i++) {
+      context.externalRows = 0
       sum += context.cachedHeight[i] || props.rowHeight;
       let rowSpanHeight = 0
       if(rowSpanInfos){
@@ -149,6 +151,7 @@ const useTableVirtual = (props: UseTableVirtualProps) => {
         }
         for(let j=0; j<siblingsIndexs.length; j++){
           const index = siblingsIndexs[j]
+          context.externalRows += 1
           rowSpanHeight += context.cachedHeight[index] || props.rowHeight;
         }
       }
@@ -283,9 +286,10 @@ const useTableVirtual = (props: UseTableVirtualProps) => {
     }
   }, [scrollHeight]);
 
+  const finalRowsInView = context.externalRows + rowsInView;
   const renderData = props.disabled
     ? props.data
-    : [...props.data].slice(startIndex, startIndex + rowsInView);
+    : [...props.data].slice(startIndex, startIndex + finalRowsInView);
   return {
     scrollHeight,
     startIndex,

--- a/packages/shineout/src/table/__example__/test-006-fix-scroll-y2.tsx
+++ b/packages/shineout/src/table/__example__/test-006-fix-scroll-y2.tsx
@@ -189,6 +189,7 @@ return (
         columns={columns}
         width={columns.reduce((a, b) => a + (b.width as number), 50)}
         virtual
+        rowsInView={10}
       />
     </div>
   </div>


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Changelog
- `Table`合并行数据中有较大合并行数据时滚动出现空白的问题