### PR TITLE
fix: 修复`Table` 虚拟滚动时，默认的rowsInView渲染结果不够撑满一屏导致的滚动空白问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.3.6-beta.5",
+  "version": "3.3.6-beta.6",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout/src/table/__doc__/changelog.cn.md
+++ b/packages/shineout/src/table/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.3.6-beta.6
+2024-08-30
+
+### 🐞 BugFix
+- 修复`Table` 虚拟滚动时，默认的rowsInView渲染结果不够撑满一屏导致的滚动空白问题
+- 修复`Table` 虚拟滚动的内部元素被执行scrollIntoView导致的页面偏移的问题([#624](https://github.com/sheinsight/shineout-next/pull/624))
+
 ## 3.3.3
 2024-08-15
 

--- a/packages/shineout/src/table/__doc__/changelog.cn.md
+++ b/packages/shineout/src/table/__doc__/changelog.cn.md
@@ -2,8 +2,8 @@
 2024-08-30
 
 ### 🐞 BugFix
-- 修复`Table` 虚拟滚动时，默认的rowsInView渲染结果不够撑满一屏导致的滚动空白问题
-- 修复`Table` 虚拟滚动的内部元素被执行scrollIntoView导致的页面偏移的问题([#624](https://github.com/sheinsight/shineout-next/pull/624))
+- 修复`Table` 虚拟滚动时，默认的rowsInView渲染结果不够撑满一屏导致的滚动空白问题 ([#628](https://github.com/sheinsight/shineout-next/pull/628))
+- 修复`Table` 虚拟滚动的内部元素被执行scrollIntoView导致的页面偏移的问题 ([#624](https://github.com/sheinsight/shineout-next/pull/624))
 
 ## 3.3.3
 2024-08-15

--- a/packages/shineout/src/table/__example__/test-006-fix-scroll-y.tsx
+++ b/packages/shineout/src/table/__example__/test-006-fix-scroll-y.tsx
@@ -1,180 +1,96 @@
 /**
- * cn - 合并行的虚拟滚动
- *    -- 修复表格滚动
- * en - fix-table-scroll
- *    -- fix table scroll
+ * cn - 虚拟滚动内测
+ *    -- 虚拟列表提供了一个 scrollToIndex 方法滚动到指定行
+ * en - scrollToIndex
+ *    -- The virtual list table provides a scrollToIndex method to scroll to the specified row
  */
-import React, { useEffect, useState } from 'react';
-import { Button, Form, Input, Table, TYPE } from 'shineout';
+import React, { useState, useEffect } from 'react';
+import { Input, Table, Form, TYPE, Button } from 'shineout';
+import { user } from '@sheinx/mock';
 
 interface TableRowData {
   id: number;
   time: string;
   start: string;
+  height: number;
+  salary: number;
+  office: string;
+  country: string;
+  office5: string;
+  position: string;
+  lastName: string;
+  firstName: string;
 }
 
 type TableColumnItem = TYPE.Table.ColumnItem<TableRowData>;
 
-const data: TableRowData[] = [
-  { id: 8850, start: '2010-03-22', time: '000', },
-  { id: 9656, start: '2010-03-22', time: '111', },
-  { id: 9652, start: '2010-03-22', time: '111', },
-  { id: 1263, start: '2010-03-23', time: '111', },
-  { id: 1487, start: '2010-03-23', time: '222', },
-  { id: 5844, start: '2010-03-24', time: '222', },
-  { id: 8620, start: '2010-03-24', time: '333', },
-  { id: 7323, start: '2010-03-25', time: '333', },
-  { id: 9831, start: '2010-03-25', time: '444', },
-  { id: 1230, start: '2010-03-25', time: '444', },
-  { id: 4014, start: '2010-03-26', time: '444', },
-
-  { id: 8850, start: '2010-03-22', time: '000', },
-  { id: 9656, start: '2010-03-22', time: '111', },
-  { id: 9652, start: '2010-03-22', time: '111', },
-  { id: 1263, start: '2010-03-23', time: '111', },
-  { id: 1487, start: '2010-03-23', time: '222', },
-  { id: 5844, start: '2010-03-24', time: '222', },
-  { id: 8620, start: '2010-03-24', time: '333', },
-  { id: 7323, start: '2010-03-25', time: '333', },
-  { id: 9831, start: '2010-03-25', time: '444', },
-  { id: 1230, start: '2010-03-25', time: '444', },
-  { id: 4014, start: '2010-03-26', time: '444', },
-
-  { id: 8850, start: '2010-03-22', time: '000', },
-  { id: 9656, start: '2010-03-22', time: '111', },
-  { id: 9652, start: '2010-03-22', time: '111', },
-  { id: 1263, start: '2010-03-23', time: '111', },
-  { id: 1487, start: '2010-03-23', time: '222', },
-  { id: 5844, start: '2010-03-24', time: '222', },
-  { id: 8620, start: '2010-03-24', time: '333', },
-  { id: 7323, start: '2010-03-25', time: '333', },
-  { id: 9831, start: '2010-03-25', time: '444', },
-  { id: 1230, start: '2010-03-25', time: '444', },
-  { id: 4014, start: '2010-03-26', time: '444', },
-
-  { id: 8850, start: '2010-03-22', time: '000', },
-  { id: 9656, start: '2010-03-22', time: '111', },
-  { id: 9652, start: '2010-03-22', time: '111', },
-  { id: 1263, start: '2010-03-23', time: '111', },
-  { id: 1487, start: '2010-03-23', time: '222', },
-  { id: 5844, start: '2010-03-24', time: '222', },
-  { id: 8620, start: '2010-03-24', time: '333', },
-  { id: 7323, start: '2010-03-25', time: '333', },
-  { id: 9831, start: '2010-03-25', time: '444', },
-  { id: 1230, start: '2010-03-25', time: '444', },
-  { id: 4014, start: '2010-03-26', time: '444', },
-
-  { id: 8850, start: '2010-03-22', time: '000', },
-  { id: 9656, start: '2010-03-22', time: '111', },
-  { id: 9652, start: '2010-03-22', time: '111', },
-  { id: 1263, start: '2010-03-23', time: '111', },
-  { id: 1487, start: '2010-03-23', time: '222', },
-  { id: 5844, start: '2010-03-24', time: '222', },
-  { id: 8620, start: '2010-03-24', time: '333', },
-  { id: 7323, start: '2010-03-25', time: '333', },
-  { id: 9831, start: '2010-03-25', time: '444', },
-  { id: 1230, start: '2010-03-25', time: '444', },
-  { id: 4014, start: '2010-03-26', time: '444', },
-
-  { id: 8850, start: '2010-03-22', time: '000', },
-  { id: 9656, start: '2010-03-22', time: '111', },
-  { id: 9652, start: '2010-03-22', time: '111', },
-  { id: 1263, start: '2010-03-23', time: '111', },
-  { id: 1487, start: '2010-03-23', time: '222', },
-  { id: 5844, start: '2010-03-24', time: '222', },
-  { id: 8620, start: '2010-03-24', time: '333', },
-  { id: 7323, start: '2010-03-25', time: '333', },
-  { id: 9831, start: '2010-03-25', time: '444', },
-  { id: 1230, start: '2010-03-25', time: '444', },
-  { id: 4014, start: '2010-03-26', time: '444', },
-
-  { id: 8850, start: '2010-03-22', time: '000', },
-  { id: 9656, start: '2010-03-22', time: '111', },
-  { id: 9652, start: '2010-03-22', time: '111', },
-  { id: 1263, start: '2010-03-23', time: '111', },
-  { id: 1487, start: '2010-03-23', time: '222', },
-  { id: 5844, start: '2010-03-24', time: '222', },
-  { id: 8620, start: '2010-03-24', time: '333', },
-  { id: 7323, start: '2010-03-25', time: '333', },
-  { id: 9831, start: '2010-03-25', time: '444', },
-  { id: 1230, start: '2010-03-25', time: '444', },
-  { id: 4014, start: '2010-03-26', time: '444', },
-];
+const data: TableRowData[] = user.fetchSync(10000);
 
 const columns: TableColumnItem[] = [
+  { title: 'id', render: 'id', width: 80 },
   {
-    title: 'id',
-    render: (row, index) => index,
-    width: 70,
+    title: 'Name',
+    fixed: 'left',
+    render: (d) => (
+      <div id={`name_${d.id}`} style={{ height: d.height }}>
+        {`${d.firstName} ${d.lastName}`}
+      </div>
+    ),
+    width: 160,
   },
-  {
-    title: 'Start Date',
-    width: 200,
-    render:(row, index) => <span style={{color: 'red'}}>{row.start}-{index}</span>,
-    rowSpan: (a, b) => a.start === b.start,
-  },
-  { title: 'Time', render: 'time', rowSpan: (a, b) => a.time === b.time, },
+  { title: 'Country', render: 'country' },
+  { title: 'Position', render: 'position' },
+  { title: 'Office', render: 'office' },
+  { title: 'Start Date', render: 'start', width: 140 },
 ];
 
 const App: React.FC = () => {
-const [table, setTable] = useState<any>();
+  const [table, setTable] = useState<any>();
 
-const [state, setState] = useState({
-  index: 25,
-});
+  const [state, setState] = useState({
+    index: 25,
+  });
 
-const handleScroll = () => {
-  if (table)
-    table.scrollToIndex(state.index - 1, () => {
-      const el: HTMLElement = document.querySelector(`#name_${state.index}`)!;
-      if (el) {
-        el.style.color = 'red';
-      }
-    });
-};
+  const handleScroll = () => {
+    if (table)
+      table.scrollToIndex(state.index - 1, () => {
+        const el: HTMLElement = document.querySelector(`#name_${state.index}`)!;
+        if (el) {
+          el.style.color = 'red';
+        }
+      });
+  };
 
-const handleIndexChange = ({ index }: { index: number }) => {
-  setState({ index });
-};
+  const handleIndexChange = ({ index }: { index: number }) => {
+    setState({ index });
+  };
 
-useEffect(() => {
-  setTimeout(handleScroll);
-}, [state]);
+  useEffect(() => {
+    setTimeout(handleScroll);
+  }, [state]);
 
-return (
-  <div>
-    <Form style={{ marginBottom: 24 }} defaultValue={state} inline onSubmit={handleIndexChange}>
-      <Input.Number min={1} max={10000} width={100} name='index' />
-      <Button type='primary' htmlType='submit'>
-        Scroll
-      </Button>
-      <strong>表格数据总条数：{data.length}</strong>
-    </Form>
+  return (
+    <div>
+      <Form style={{ marginBottom: 24 }} defaultValue={state} inline onSubmit={handleIndexChange}>
+        <Input.Number min={1} max={10000} width={100} name='index' />
+        <Button type='primary' htmlType='submit'>
+          Scroll
+        </Button>
+      </Form>
 
-    {/* <Table
-      keygen='id'
-      bordered
-      data={data}
-      virtual
-      width={1400}
-      rowsInView={10}
-      columns={columns}
-      style={{ height: 500 }}
-      tableRef={(t) => setTable(t)}
-    /> */}
-    <div style={{height: 200}}>
-    <Table
-      tableRef={(t) => setTable(t)}
-      bordered
-      height="100%"
-      data={data}
-      keygen={(item, index:number) => `${item.id}-${index}`}
-      columns={columns}
-      virtual
-    />
-  </div>
-  </div>
-);
+      <Table
+        keygen='id'
+        bordered
+        data={data}
+        virtual
+        width={1400}
+        rowsInView={4}
+        columns={columns}
+        style={{ height: 500 }}
+        tableRef={(t) => setTable(t)}
+      />
+    </div>
+  );
 };
 
 export default App;


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others


### Changelog
- 修复`Table` 虚拟滚动时，默认的rowsInView渲染结果不够撑满一屏导致的滚动空白问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新至版本 3.3.6-beta.6，包含虚拟滚动表格的新功能。
	- 新增 `scrollToIndex` 方法，允许用户滚动到表格中的指定行。
	- 表格数据源改为动态获取，支持最多 10,000 条数据。

- **错误修复**
	- 修复了虚拟滚动功能中的两个关键问题，改善了表格的滚动体验和行渲染。

- **文档**
	- 更新了表格组件的变更日志，记录了版本 3.3.6-beta.6 的重要更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->