### PR TITLE
fix: 修复 `Checkbox.Group` 的children中的 `Checkbox` 的onChange不触发的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.3.6",
+  "version": "3.3.7-beta.1",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/checkbox/checkbox-group.tsx
+++ b/packages/base/src/checkbox/checkbox-group.tsx
@@ -1,6 +1,6 @@
 import { CheckboxGroupProps } from './checkbox-group.type';
 import { useInputAble, useListSelectMultiple, usePersistFn, util } from '@sheinx/hooks';
-import groupContext from './group-context';
+import GroupContext from './group-context';
 import Checkbox from './checkbox';
 import React from 'react';
 import classNames from 'classnames';
@@ -39,6 +39,10 @@ const Group = <DataItem, Value extends any[]>(props0: CheckboxGroupProps<DataIte
       } else {
         datum.remove(raw);
       }
+
+      if (children && React.isValidElement(children)) {
+        children.props.onChange?.(checked ? children.props.htmlValue : undefined, checked, children.props.htmlValue);
+      }
     },
   );
 
@@ -72,7 +76,9 @@ const Group = <DataItem, Value extends any[]>(props0: CheckboxGroupProps<DataIte
   if (props.data === undefined) {
     return (
       <div className={groupClass} style={style}>
-        <groupContext.Provider value={providerValue}>{children}</groupContext.Provider>
+        <GroupContext.Provider value={providerValue}>
+          {children}
+        </GroupContext.Provider>
       </div>
     );
   } else {

--- a/packages/shineout/src/checkbox/__doc__/changelog.cn.md
+++ b/packages/shineout/src/checkbox/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.3.7-beta.1
+2024-09-04
+### 🐞 BugFix
+
+- 修复 `Checkbox.Group` 的children中的 `Checkbox` 的onChange不触发的问题
+
+
 ## 3.3.0
 2024-07-23
 ### 🐞 BugFix

--- a/packages/shineout/src/checkbox/__doc__/changelog.cn.md
+++ b/packages/shineout/src/checkbox/__doc__/changelog.cn.md
@@ -2,7 +2,7 @@
 2024-09-04
 ### 🐞 BugFix
 
-- 修复 `Checkbox.Group` 的children中的 `Checkbox` 的onChange不触发的问题
+- 修复 `Checkbox.Group` 的children中的 `Checkbox` 的onChange不触发的问题 ([#637](https://github.com/sheinsight/shineout-next/pull/637))
 
 
 ## 3.3.0

--- a/packages/shineout/src/checkbox/__example__/test-001-group-onchange.tsx
+++ b/packages/shineout/src/checkbox/__example__/test-001-group-onchange.tsx
@@ -1,0 +1,29 @@
+/**
+ * cn - Group OnChange
+ *    -- 被Checkbox.Group包裹的Checkbox的onChange依然能触发
+ * en - Group OnChange
+ *    -- The onChange of the Checkbox wrapped by Checkbox.Group can still be triggered
+ */
+import React from 'react';
+import { Checkbox } from 'shineout';
+
+const App: React.FC = () => {
+  const [checked, setChecked] = React.useState();
+
+  console.log('useState checked: >>', checked);
+  const handleChange = (v) => {
+    setChecked(v)
+  }
+  return (
+    <Checkbox.Group keygen>
+      <Checkbox
+        value={checked}
+        onChange={handleChange}
+      >
+        {checked ? 'Checked' : 'Unchecked'}
+      </Checkbox>
+    </Checkbox.Group>
+  );
+};
+
+export default App;


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Changelog
- 修复 `Checkbox.Group` 的children中的 `Checkbox` 的onChange不触发的问题