### PR TITLE
feat: `DatePicker`的范围选择模式交互优化: 选择两个值后才关闭选择面板

### DIFF
--- a/packages/base/src/date-picker/date-picker.tsx
+++ b/packages/base/src/date-picker/date-picker.tsx
@@ -33,6 +33,7 @@ const DatePicker = <Value extends DatePickerValueType>(props0: DatePickerProps<V
     adjust = true,
   } = props;
   const [activeIndex, setActiveIndex] = React.useState(-1);
+  const [clickTimes, setClickTimes] = React.useState(0);
   const inputRef = useRef<{
     inputRef: HTMLInputElement | null;
   }>({
@@ -142,6 +143,7 @@ const DatePicker = <Value extends DatePickerValueType>(props0: DatePickerProps<V
 
   const handleClose = () => {
     closePop();
+    setClickTimes(0)
     inputRef.current.inputRef?.blur();
   };
 
@@ -292,6 +294,8 @@ const DatePicker = <Value extends DatePickerValueType>(props0: DatePickerProps<V
             disabledTime={props.disabledTime}
             quickSelect={props.quickSelect}
             showSelNow={props.showSelNow}
+            clickTimes={clickTimes}
+            setClickTimes={setClickTimes}
             setActiveIndex={setActiveIndex}
             hourStep={props.hourStep}
             minuteStep={props.minuteStep}

--- a/packages/base/src/date-picker/day.tsx
+++ b/packages/base/src/date-picker/day.tsx
@@ -17,8 +17,8 @@ const Day = (props: DayProps) => {
 
   const areaType = props.type === 'week' ? 'week' : 'day';
 
-  const onChange = usePersistFn((date) => {
-    props.onChange(date, props.type === 'datetime');
+  const onChange = usePersistFn((date, noClose?: boolean) => {
+    props.onChange(date, noClose || props.type === 'datetime');
     props.setTarget(undefined);
   });
 
@@ -75,7 +75,14 @@ const Day = (props: DayProps) => {
             styles?.pickerCellInRangeEnd,
         )}
         key={index}
-        onClick={() => func.handleDayClick(item)}
+        onClick={() => {
+          if(props.range){
+            func.handleDayClick(item, props.clickTimes < 1)
+            props.setClickTimes(props.clickTimes + 1)
+          }else{
+            func.handleDayClick(item)
+          }
+        }}
         onDoubleClick={() => {
           props.onDoubleClick?.(item, areaType);
         }}

--- a/packages/base/src/date-picker/day.type.ts
+++ b/packages/base/src/date-picker/day.type.ts
@@ -2,5 +2,8 @@ import type { CommonPickerProps, CommonTimeProps } from './picker.type';
 
 export interface DayProps extends CommonPickerProps, CommonTimeProps {
   open?: boolean;
+  clickTimes: number;
+  setClickTimes: (times: number) => void;
+  range?: boolean | number;
   onDoubleClick?: (date: Date, type: string) => void;
 }

--- a/packages/base/src/date-picker/picker.tsx
+++ b/packages/base/src/date-picker/picker.tsx
@@ -64,6 +64,9 @@ const Picker = (props: PickerProps) => {
       registerModeDisabled: props.registerModeDisabled,
       onMouseEnter: () => {},
       onMouseLeave: () => {},
+      range,
+      setClickTimes: props.setClickTimes,
+      clickTimes: props.clickTimes,
     };
     if (range) {
       commonProps['onMouseEnter'] = position === 'end' ? handleEnterEnd : handleEnterStart;

--- a/packages/base/src/date-picker/picker.type.ts
+++ b/packages/base/src/date-picker/picker.type.ts
@@ -45,6 +45,8 @@ export interface PickerProps {
     disabled: (d: Date) => boolean,
   ) => void;
   isDisabledDate: (date: Date, position: 'start' | 'end' | undefined) => boolean;
+  clickTimes: number;
+  setClickTimes: Dispatch<SetStateAction<number>>;
 }
 
 export interface CommonPickerProps

--- a/packages/hooks/src/components/use-datepicker/use-date.ts
+++ b/packages/hooks/src/components/use-datepicker/use-date.ts
@@ -117,11 +117,11 @@ const useDate = (props: UseDateProps) => {
     );
   };
 
-  const handleDayClick = (date: Date) => {
+  const handleDayClick = (date: Date, noClose?: boolean) => {
     if (isDisabled(date)) return;
 
     let newDate = getDateWithTime(date);
-    props.onChange?.(newDate);
+    props.onChange?.(newDate, noClose);
     setCurrent(newDate);
   };
 

--- a/packages/hooks/src/components/use-datepicker/use-date.type.ts
+++ b/packages/hooks/src/components/use-datepicker/use-date.type.ts
@@ -4,7 +4,7 @@ export interface UseDateProps {
   defaultCurrent?: Date;
   onCurrentChange?: (date: Date) => void;
   value?: Date;
-  onChange?: (date: Date) => void;
+  onChange?: (date: Date, onClose?: boolean) => void;
   min?: Date;
   max?: Date;
   type?: 'date' | 'week' | 'datetime';

--- a/packages/hooks/src/components/use-datepicker/use-date.type.ts
+++ b/packages/hooks/src/components/use-datepicker/use-date.type.ts
@@ -4,7 +4,7 @@ export interface UseDateProps {
   defaultCurrent?: Date;
   onCurrentChange?: (date: Date) => void;
   value?: Date;
-  onChange?: (date: Date, onClose?: boolean) => void;
+  onChange?: (date: Date, noClose?: boolean) => void;
   min?: Date;
   max?: Date;
   type?: 'date' | 'week' | 'datetime';


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Changelog
- `DatePicker`的范围选择模式交互优化: 选择两个值后才关闭选择面板