### PR TITLE
fix: 修复`Table`的scrollToIndex的回调方法

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.4.0-beta.6",
+  "version": "3.4.0-beta.7",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-table/use-table-virtual.tsx
+++ b/packages/hooks/src/components/use-table/use-table-virtual.tsx
@@ -236,7 +236,7 @@ const useTableVirtual = (props: UseTableVirtualProps) => {
     }
   };
 
-  const scrollToIndex = usePersistFn((index: number) => {
+  const scrollToIndex = usePersistFn((index: number, callback?: () => void) => {
     if (props.disabled) return;
     if (props.scrollRef.current) {
       context.shouldUpdateHeight = true;
@@ -246,6 +246,10 @@ const useTableVirtual = (props: UseTableVirtualProps) => {
         const beforeHeight2 = getContentHeight(i - 1);
         if (beforeHeight2 !== beforeHeight) {
           scrollToIndex(index);
+        }
+
+        if(callback && typeof callback === 'function'){
+          callback()
         }
       };
       props.scrollRef.current.scrollTop = beforeHeight;

--- a/packages/shineout/src/table/__doc__/changelog.cn.md
+++ b/packages/shineout/src/table/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.4.0-beta.7
+2024-09-09
+
+### 🐞 BugFix
+
+- 修复TableRef的`scrollToIndex`的回调方法不生效问题 ([#651](https://github.com/sheinsight/shineout-next/pull/651))
+
 ## 3.4.0-beta.6
 2024-09-06
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Changelog
- 修复TableRef的`scrollToIndex`的回调方法不生效问题