### PR TITLE
fix: 修复 `Datepicker` 的defaultPickerValue的第二位不生效的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.3.7-beta.4",
+  "version": "3.3.7-beta.5",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-datepicker/use-datepicker-format.ts
+++ b/packages/hooks/src/components/use-datepicker/use-datepicker-format.ts
@@ -88,6 +88,11 @@ const useDatePickerFormat = <Value extends DatePickerValueType>(
   const getCurrentArr = () => {
     const arr = convertValueToDateArr(value, format, options);
     const currentArr = convertValueToDateArr(props.defaultCurrent, 'YYYY-MM-DD', options);
+
+    const validArr = arr.filter((item) => item);
+    const validCurrentArr = currentArr.filter((item) => item);
+    if(!validArr.length && currentArr.length) return validCurrentArr;
+
     if (!arr[0]) arr[0] = arr[1] || currentArr[0] || new Date();
     if (range && !arr[1]) arr[1] = arr[0] || currentArr[1] || new Date();
     return arr as Date[];

--- a/packages/shineout/src/date-picker/__doc__/changelog.cn.md
+++ b/packages/shineout/src/date-picker/__doc__/changelog.cn.md
@@ -1,3 +1,11 @@
+## 3.3.7-beta.5
+2024-09-11
+
+### 🐞 BugFix
+
+- 修复 `Datepicker` 的defaultPickerValue的第二位不生效的问题 ([#660](https://github.com/sheinsight/shineout-next/pull/660))
+
+
 ## 3.3.6
 2024-08-28
 

--- a/packages/shineout/src/date-picker/__test__/datePicker.spec.tsx
+++ b/packages/shineout/src/date-picker/__test__/datePicker.spec.tsx
@@ -1610,7 +1610,7 @@ describe('DatePicker[DefaultPickerValue]', () => {
     const datePickerPickerWrapper = datePickerWrapper.querySelector(pickerWrapper)!;
     const pickerHeaders = datePickerPickerWrapper.querySelectorAll(pickerHeader);
     textContentTest(pickerHeaders[0], `${year}-${Number(month) - 1}`);
-    textContentTest(pickerHeaders[1], `${year}-${Number(month) - 1}`);
+    textContentTest(pickerHeaders[1], `${year}-${Number(month) - 2}`);
   });
 });
 describe('DatePicker[AllowSingle]', () => {


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Changelog
- 修复 `Datepicker` 的defaultPickerValue的第二位不生效的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新特性**
	- 更新了项目版本至 3.3.7-beta.5，包含了可能的bug修复和改进。

- **修复**
	- 修复了 `Datepicker` 组件中 `defaultPickerValue` 的第二位数字未正常工作的bug。

- **文档**
	- 更新了变更日志，记录了版本 3.3.7-beta.5 的相关修复信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->