### PR TITLE
feat: `Tree` 组件新增`setActive`，与`active`组成高亮的受控功能

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.4.0-beta.9",
+  "version": "3.4.0-beta.10",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.4.0-beta.10",
+  "version": "3.4.0-beta.11",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/tree/tree.tsx
+++ b/packages/base/src/tree/tree.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
 import { KeygenResult, useTree, util, ObjectKey } from '@sheinx/hooks';
 import { TreeClasses } from './tree.type';
@@ -36,10 +36,11 @@ const Tree = <DataItem, Value extends KeygenResult[]>(props: TreeProps<DataItem,
     dragSibling,
     unmatch,
     dragHoverExpand,
-    active,
+    active: propActive,
+    setActive: propSetActive,
     disabled,
     inlineNode,
-    highlight,
+    highlight: propHighlight,
     className,
     onClick,
     loader,
@@ -54,6 +55,16 @@ const Tree = <DataItem, Value extends KeygenResult[]>(props: TreeProps<DataItem,
     datum: propsDatum,
     ...rest
   } = props;
+
+  const [active, setActive] = useState(propActive);
+  const isActiveControlled = 'active' in props;
+  const highlight = propHighlight ?? isActiveControlled;
+
+  useEffect(() => {
+    if (isActiveControlled && propActive !== active) {
+      setActive(propActive);
+    }
+  }, [active, propActive]);
 
   const { current: context } = useRef({ mounted: false });
 
@@ -95,15 +106,16 @@ const Tree = <DataItem, Value extends KeygenResult[]>(props: TreeProps<DataItem,
   };
 
   const handleUpdateActive = (active?: KeygenResult) => {
+    setActive(active);
+    propSetActive?.(active);
+
     datum.updateMap.forEach((update, id) => {
       update('active', id === active);
     });
   };
 
   const handleNodeClick = (node: DataItem, id: KeygenResult) => {
-    if (active === undefined) {
-      handleUpdateActive(id);
-    }
+    handleUpdateActive(id);
 
     if (onClick) {
       onClick(node, id, datum.getPath(id));

--- a/packages/base/src/tree/tree.type.ts
+++ b/packages/base/src/tree/tree.type.ts
@@ -94,6 +94,11 @@ export interface TreeProps<DataItem, Value extends any[]>
    */
   active?: KeygenResult;
   /**
+   * @en Set active node key
+   * @cn 设置激活节点的key
+   */
+  setActive?: (key?: KeygenResult) => void;
+  /**
    * @en If need to double-click to expand
    * @cn 双击是否展开节点
    * @default false

--- a/packages/shineout/src/tree/__doc__/changelog.cn.md
+++ b/packages/shineout/src/tree/__doc__/changelog.cn.md
@@ -1,3 +1,11 @@
+## 3.4.0-beta.10
+2024-09-13
+
+### 🆕 Feature
+
+- `Tree` 组件新增`setActive`，与`active`组成高亮的受控功能  ([#665](https://github.com/sheinsight/shineout-next/pull/665))
+
+
 ## 3.1.22
 2024-05-31
 

--- a/packages/shineout/src/tree/__example__/11-highlight-control.tsx
+++ b/packages/shineout/src/tree/__example__/11-highlight-control.tsx
@@ -1,0 +1,47 @@
+/**
+ * cn -
+ *    -- 受控高亮：设置 `active` 和`setActive`
+ * en -
+ *    -- Highlight control: set `active` and `setActive`
+ */
+
+import { Button, Tree, TYPE } from 'shineout';
+import { createNestedArray } from './utils';
+import { useState } from 'react';
+
+type TreeProps = TYPE.Tree.Props<DataItem, string[]>;
+
+interface DataItem {
+  id: string;
+  children?: DataItem[];
+}
+
+export default () => {
+  const [active, setActive] = useState<string | number | undefined>();
+  const data: DataItem[] = createNestedArray([5, 1, 1]);
+
+  const renderItem: TreeProps['renderItem'] = (node) => {
+    return <span style={{ display: 'inline-block' }}>{`node ${node.id}`}</span>;
+  };
+
+  const handleClearHighlight = () => {
+    setActive(undefined);
+  }
+
+  return (
+    <div>
+      <Tree
+        active={active}
+        setActive={setActive}
+        data={data}
+        keygen='id'
+        line={false}
+        renderItem={renderItem}
+      />
+
+      <br />
+
+      <Button onClick={handleClearHighlight}>Clear highlight</Button>
+    </div>
+  );
+};

--- a/packages/shineout/src/tree/__test__/__snapshots__/tree.spec.tsx.snap
+++ b/packages/shineout/src/tree/__test__/__snapshots__/tree.spec.tsx.snap
@@ -1202,6 +1202,275 @@ exports[`Tree[Base] should render correctly about highlight 1`] = `
 </div>
 `;
 
+exports[`Tree[Base] should render correctly about highlight control 1`] = `
+<div>
+  <div
+    class="soui-tree-tree soui-tree-noline"
+  >
+    <div
+      class="soui-tree-root"
+      style="display: block;"
+    >
+      <div
+        class="soui-tree-node"
+        dir="ltr"
+      >
+        <div
+          class="soui-tree-content-wrapper soui-tree-childnode"
+          dir="ltr"
+        >
+          <span
+            class="soui-tree-icon-wrapper"
+            data-expanded="false"
+            data-icon="false"
+            dir="ltr"
+          >
+            <span
+              class="soui-tree-icon"
+              dir="ltr"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M18.2209 9.72141L12.6344 15.2952C12.2441 15.6847 11.6121 15.6846 11.2218 15.2952L5.6979 9.78337C5.30695 9.39327 5.30625 8.76011 5.69635 8.36915C5.88258 8.18251 6.13499 8.07697 6.39865 8.0755L17.5091 8.01351C18.0613 8.01043 18.5116 8.45564 18.5146 9.00792C18.5161 9.27546 18.4103 9.53244 18.2209 9.72141Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <div
+            class="soui-tree-content"
+            data-active="false"
+            data-expanded="false"
+            dir="ltr"
+          >
+            <div
+              class="soui-tree-text"
+              dir="ltr"
+            >
+              <span
+                style="display: inline-block;"
+              >
+                node 0
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="soui-tree-node"
+        dir="ltr"
+      >
+        <div
+          class="soui-tree-content-wrapper soui-tree-childnode"
+          dir="ltr"
+        >
+          <span
+            class="soui-tree-icon-wrapper"
+            data-expanded="false"
+            data-icon="false"
+            dir="ltr"
+          >
+            <span
+              class="soui-tree-icon"
+              dir="ltr"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M18.2209 9.72141L12.6344 15.2952C12.2441 15.6847 11.6121 15.6846 11.2218 15.2952L5.6979 9.78337C5.30695 9.39327 5.30625 8.76011 5.69635 8.36915C5.88258 8.18251 6.13499 8.07697 6.39865 8.0755L17.5091 8.01351C18.0613 8.01043 18.5116 8.45564 18.5146 9.00792C18.5161 9.27546 18.4103 9.53244 18.2209 9.72141Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <div
+            class="soui-tree-content"
+            data-active="false"
+            data-expanded="false"
+            dir="ltr"
+          >
+            <div
+              class="soui-tree-text"
+              dir="ltr"
+            >
+              <span
+                style="display: inline-block;"
+              >
+                node 1
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="soui-tree-node"
+        dir="ltr"
+      >
+        <div
+          class="soui-tree-content-wrapper soui-tree-childnode"
+          dir="ltr"
+        >
+          <span
+            class="soui-tree-icon-wrapper"
+            data-expanded="false"
+            data-icon="false"
+            dir="ltr"
+          >
+            <span
+              class="soui-tree-icon"
+              dir="ltr"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M18.2209 9.72141L12.6344 15.2952C12.2441 15.6847 11.6121 15.6846 11.2218 15.2952L5.6979 9.78337C5.30695 9.39327 5.30625 8.76011 5.69635 8.36915C5.88258 8.18251 6.13499 8.07697 6.39865 8.0755L17.5091 8.01351C18.0613 8.01043 18.5116 8.45564 18.5146 9.00792C18.5161 9.27546 18.4103 9.53244 18.2209 9.72141Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <div
+            class="soui-tree-content"
+            data-active="false"
+            data-expanded="false"
+            dir="ltr"
+          >
+            <div
+              class="soui-tree-text"
+              dir="ltr"
+            >
+              <span
+                style="display: inline-block;"
+              >
+                node 2
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="soui-tree-node"
+        dir="ltr"
+      >
+        <div
+          class="soui-tree-content-wrapper soui-tree-childnode"
+          dir="ltr"
+        >
+          <span
+            class="soui-tree-icon-wrapper"
+            data-expanded="false"
+            data-icon="false"
+            dir="ltr"
+          >
+            <span
+              class="soui-tree-icon"
+              dir="ltr"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M18.2209 9.72141L12.6344 15.2952C12.2441 15.6847 11.6121 15.6846 11.2218 15.2952L5.6979 9.78337C5.30695 9.39327 5.30625 8.76011 5.69635 8.36915C5.88258 8.18251 6.13499 8.07697 6.39865 8.0755L17.5091 8.01351C18.0613 8.01043 18.5116 8.45564 18.5146 9.00792C18.5161 9.27546 18.4103 9.53244 18.2209 9.72141Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <div
+            class="soui-tree-content"
+            data-active="false"
+            data-expanded="false"
+            dir="ltr"
+          >
+            <div
+              class="soui-tree-text"
+              dir="ltr"
+            >
+              <span
+                style="display: inline-block;"
+              >
+                node 3
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="soui-tree-node"
+        dir="ltr"
+      >
+        <div
+          class="soui-tree-content-wrapper soui-tree-childnode"
+          dir="ltr"
+        >
+          <span
+            class="soui-tree-icon-wrapper"
+            data-expanded="false"
+            data-icon="false"
+            dir="ltr"
+          >
+            <span
+              class="soui-tree-icon"
+              dir="ltr"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M18.2209 9.72141L12.6344 15.2952C12.2441 15.6847 11.6121 15.6846 11.2218 15.2952L5.6979 9.78337C5.30695 9.39327 5.30625 8.76011 5.69635 8.36915C5.88258 8.18251 6.13499 8.07697 6.39865 8.0755L17.5091 8.01351C18.0613 8.01043 18.5116 8.45564 18.5146 9.00792C18.5161 9.27546 18.4103 9.53244 18.2209 9.72141Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <div
+            class="soui-tree-content"
+            data-active="false"
+            data-expanded="false"
+            dir="ltr"
+          >
+            <div
+              class="soui-tree-text"
+              dir="ltr"
+            >
+              <span
+                style="display: inline-block;"
+              >
+                node 4
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <br />
+  <button
+    class="soui-button-secondary soui-button-button"
+    dir="ltr"
+    type="button"
+  >
+    <span>
+      Clear highlight
+    </span>
+  </button>
+</div>
+`;
+
 exports[`Tree[Base] should render correctly about line 1`] = `
 <div>
   <div

--- a/packages/shineout/src/tree/__test__/tree.spec.tsx
+++ b/packages/shineout/src/tree/__test__/tree.spec.tsx
@@ -7,7 +7,6 @@ import mountTest from '../../tests/mountTest';
 import { classLengthTest } from '../../tests/structureTest';
 import {
   attributesTest,
-  baseTest,
   classTest,
   createClassName,
   delay,
@@ -26,6 +25,7 @@ import TreeLoader from '../__example__/07-loader';
 import TreeDrag from '../__example__/08-drag';
 import TreeDragStyle from '../__example__/09-drag-style';
 import TreeHighlight from '../__example__/10-highlight';
+import TreeHighlightControl from '../__example__/11-highlight-control';
 
 const SO_PREFIX = 'tree';
 const originClasses = [
@@ -155,6 +155,8 @@ describe('Tree[Base]', () => {
   snapshotTest(<TreeDrag />, 'about drag');
   snapshotTest(<TreeDragStyle />, 'about drag style');
   snapshotTest(<TreeHighlight />, 'about highlight');
+  snapshotTest(<TreeHighlightControl />, 'about highlight control');
+
   test('should render default', () => {
     const { container } = render(<TreeTest />);
     const treeWrapper = container.querySelector(treeClassName)!;
@@ -698,7 +700,7 @@ describe('Tree[Drag]', () => {
       />,
     );
     const treeWrapper = container.querySelector(treeClassName)!;
-    
+
     const treeRootNodeAll = treeWrapper.querySelectorAll(nodeClassName)!;
     const firstNode = treeRootNodeAll[0];
     const dataTransfer = new MockDataTransfer();


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others


### Changelog
- `Tree` 组件新增`setActive`，与`active`组成高亮的受控功能