### PR TITLE
fix: 优化 Datepicker 的结果展示区域，改为不换行展示

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/date-picker/result.tsx
+++ b/packages/base/src/date-picker/result.tsx
@@ -24,6 +24,7 @@ export const Input = (props: {
   onFocus?: (e: React.FocusEvent) => void;
   onBlur?: (e: React.FocusEvent) => void;
   onClick?: (e?: React.MouseEvent) => void;
+  readOnly?: boolean;
 }) => {
   const [value, setValue] = useState(props.value);
 
@@ -48,6 +49,7 @@ export const Input = (props: {
       placeholder={props.placeholder}
       autoComplete={'off'}
       value={value}
+      readOnly={props.readOnly}
       maxLength={props.maxLength}
       disabled={props.disabled}
       onBlur={props.onBlur}
@@ -177,14 +179,14 @@ const Result = (props: ResultProps) => {
     return (
       <div className={className}>
         <span className={styles?.resultTextPadding}>
-          {info.inputable ? (
             <Input
               key={info.index}
               onRef={(el) => {
                 onRef.current.inputRef = el;
                 context.inputRefs[info.index] = el;
               }}
-              disabled={dis}
+              disabled={dis && info.inputable}
+              readOnly={!info.inputable}
               open={!!open}
               inputRef={inputRef}
               value={info.target || info.value || ''}
@@ -210,9 +212,6 @@ const Result = (props: ResultProps) => {
               }}
               onClick={onClickProps}
             />
-          ) : (
-            info.target || info.value || <span className={styles?.placeholder}>{info.place}</span>
-          )}
         </span>
         <div className={styles?.resultTextBg}></div>
       </div>

--- a/packages/shineout/src/card/__test__/__snapshots__/card.spec.tsx.snap
+++ b/packages/shineout/src/card/__test__/__snapshots__/card.spec.tsx.snap
@@ -353,11 +353,12 @@ exports[`Card[Base] should render correctly about collapse 1`] = `
                   <span
                     class="soui-datePicker-result-text-padding"
                   >
-                    <span
-                      class="soui-datePicker-placeholder"
-                    >
-                      Please select date
-                    </span>
+                    <input
+                      autocomplete="off"
+                      placeholder="Please select date"
+                      readonly=""
+                      value=""
+                    />
                   </span>
                   <div
                     class="soui-datePicker-result-text-bg"

--- a/packages/shineout/src/date-picker/__doc__/changelog.cn.md
+++ b/packages/shineout/src/date-picker/__doc__/changelog.cn.md
@@ -1,9 +1,17 @@
+## 3.4.1
+2024-09-20
+
+### 🐞 BugFix
+
+- 优化 `Datepicker` 的结果展示区域，改为不换行展示 ([#680](https://github.com/sheinsight/shineout-next/pull/680))
+
 ## 3.4.0
 2024-09-19
 
 ### 🆕 Feature
 - `Datepicker` 新增needConfirm属性: 是否开启手动确认按钮，开启后只有点击确认按钮才会提交选择的值。 ([#650](https://github.com/sheinsight/shineout-next/pull/650))
 - `Datepicker` 新增clearToUndefined，点击清除后返回undefined ([#644](https://github.com/sheinsight/shineout-next/pull/644))
+
 
 
 ## 3.3.7

--- a/packages/shineout/src/date-picker/__test__/datePicker.spec.tsx
+++ b/packages/shineout/src/date-picker/__test__/datePicker.spec.tsx
@@ -219,7 +219,7 @@ describe('Alert[Base]', () => {
     const datePickerResultWrapper = datePickerWrapper.querySelector(resultWrapper)!;
     attributesTest(datePickerResultWrapper, 'tabindex', '1');
     const datePickerResult = datePickerResultWrapper.querySelector(resultTextInput)!;
-    attributesTest(datePickerResult, 'placeholder', 'Please select date');
+    inputPlaceholderTest(datePickerResult, 'Please select date');
     const datePickerIcon = datePickerResultWrapper.querySelector(icon)!;
     classLengthTest(datePickerIcon, 'svg', 1);
 
@@ -321,8 +321,8 @@ describe('Alert[Base]', () => {
     const end = 'end';
     const { container } = render(<DatePicker range placeholder={[start, end]} />);
     const resultTexts = container.querySelectorAll(`${resultText} input`);
-    attributesTest(resultTexts[0], 'placeholder', start);
-    attributesTest(resultTexts[1], 'placeholder', end);
+    inputPlaceholderTest(resultTexts[0], start);
+    inputPlaceholderTest(resultTexts[1], end);
   });
   const sizeClassNamesMap: { [key: string]: string } = {
     small: wrapperSmall,
@@ -456,7 +456,7 @@ describe('DatePicker[Event]', () => {
     const datePickerWrapper = container.querySelector(wrapper)!;
     const datePickerResultWrapper = datePickerWrapper.querySelector(resultWrapper)!;
     const datePickerResult = datePickerResultWrapper.querySelector(resultTextInput)!;
-    attributesTest(datePickerResult, 'placeholder', 'Please select date');
+    inputPlaceholderTest(datePickerResult, 'Please select date');
     fireEvent.focus(datePickerResultWrapper);
     fireEvent.click(datePickerResultWrapper);
     await waitFor(async () => {
@@ -483,7 +483,7 @@ describe('DatePicker[Event]', () => {
     const datePickerWrapper = container.querySelector(wrapper)!;
     const datePickerResultWrapper = datePickerWrapper.querySelector(resultWrapper)!;
     const datePickerResult = datePickerResultWrapper.querySelector(resultTextInput)!;
-    attributesTest(datePickerResult, 'placeholder', 'Select date');
+    inputPlaceholderTest(datePickerResult, 'Select date');
     fireEvent.focus(datePickerResultWrapper);
     fireEvent.click(datePickerResultWrapper);
     await waitFor(async () => {
@@ -586,13 +586,13 @@ describe('DatePicker[Event]', () => {
       await delay(300);
     });
     const results = datePickerResultWrapper.querySelectorAll(`${resultText} input`);
-    attributesTest(results[0], 'value', `${year}-${month}-${cell.textContent} 00:00:00`);
+    inputValueTest(results[0], `${year}-${month}-${cell.textContent} 00:00:00`);
     fireEvent.doubleClick(cell);
     await waitFor(async () => {
       await delay(300);
     });
-    attributesTest(results[0], 'value', `${year}-${month}-${cell.textContent} 00:00:00`);
-    attributesTest(results[1], 'value', `${year}-${month}-${cell.textContent} 00:00:00`);
+    inputValueTest(results[0], `${year}-${month}-${cell.textContent} 00:00:00`);
+    inputValueTest(results[1], `${year}-${month}-${cell.textContent} 00:00:00`);
     const endCell = pickers[1]
       .querySelector(pickerBody)
       ?.querySelector('table')
@@ -603,8 +603,8 @@ describe('DatePicker[Event]', () => {
     await waitFor(async () => {
       await delay(300);
     });
-    attributesTest(results[0], 'value', `${year}-${month}-${endCell.textContent} 00:00:00`);
-    attributesTest(results[1], 'value', `${year}-${month}-${endCell.textContent} 00:00:00`);
+    inputValueTest(results[0], `${year}-${month}-${endCell.textContent} 00:00:00`);
+    inputValueTest(results[1], `${year}-${month}-${endCell.textContent} 00:00:00`);
   });
 });
 describe('DatePicker[Type]', () => {
@@ -866,22 +866,22 @@ describe('DatePicker[Type]', () => {
 describe('DatePicker[Value/DefaultValue/DefaultTime]', () => {
   test('should render when set defaultValue', () => {
     const { container } = render(<DatePicker defaultValue={Now} />);
-    attributesTest(container.querySelector(resultTextInput)!, 'value', `${year}-${month}-${day}`);
+    inputValueTest(container.querySelector(resultTextInput)!, `${year}-${month}-${day}`);
   });
   test('should render when set defaultValue is array', () => {
     const { container } = render(<DatePicker range defaultValue={[Now, Now]} />);
 
-    attributesTest(container.querySelectorAll(resultTextInput)[0], 'value', `${year}-${month}-${day}`);
-    attributesTest(container.querySelectorAll(resultTextInput)[1], 'value', `${year}-${month}-${day}`);
+    inputValueTest(container.querySelectorAll(resultTextInput)[0], `${year}-${month}-${day}`);
+    inputValueTest(container.querySelectorAll(resultTextInput)[1], `${year}-${month}-${day}`);
   });
   test('should render when set value', () => {
     const { container } = render(<DatePicker value={Now} />);
-    attributesTest(container.querySelector(resultTextInput)!, 'value', `${year}-${month}-${day}`);
+    inputValueTest(container.querySelector(resultTextInput)!, `${year}-${month}-${day}`);
   });
   test('should render when set value is array', () => {
     const { container } = render(<DatePicker range value={[Now, Now]} />);
-    attributesTest(container.querySelectorAll(resultTextInput)[0], 'value', `${year}-${month}-${day}`);
-    attributesTest(container.querySelectorAll(resultTextInput)[1], 'value', `${year}-${month}-${day}`);
+    inputValueTest(container.querySelectorAll(resultTextInput)[0], `${year}-${month}-${day}`);
+    inputValueTest(container.querySelectorAll(resultTextInput)[1], `${year}-${month}-${day}`);
   });
   test('should render when set value and defaultValue', () => {
     const nowDate = new Date();
@@ -898,7 +898,7 @@ describe('DatePicker[Value/DefaultValue/DefaultTime]', () => {
         <DatePicker defaultValue={Now} value={nowDate.getTime()} />,
     );
 
-    attributesTest(container.querySelector(resultTextInput)!, 'value', expectedDateString);
+    inputValueTest(container.querySelector(resultTextInput)!, expectedDateString);
   });
   test('should render when set defaultTime', async () => {
     const defaultTime = '10:01:02';
@@ -916,7 +916,7 @@ describe('DatePicker[Value/DefaultValue/DefaultTime]', () => {
       ?.querySelectorAll('tr')[3]
       .querySelectorAll('td')[0] as Element;
     fireEvent.click(cell);
-    attributesTest(container.querySelector(resultTextInput)!, 'value', `${year}-${month}-${cell.textContent} ${defaultTime}`);
+    inputValueTest(container.querySelector(resultTextInput)!, `${year}-${month}-${cell.textContent} ${defaultTime}`);
   });
 });
 describe('DatePicker[Format]', () => {
@@ -1021,8 +1021,8 @@ describe('DatePicker[Range]', () => {
     textContentTest(datePickerResult?.querySelector(resultSeparator) as Element, '~');
     const DatePickTexts = datePickerResult?.querySelectorAll(resultTextInput) as NodeListOf<Element>;
     expect(DatePickTexts?.length).toBe(2);
-    attributesTest(DatePickTexts[0], 'placeholder', 'Start quarter');
-    attributesTest(DatePickTexts[1], 'placeholder', 'End quarter');
+    inputPlaceholderTest(DatePickTexts[0], 'Start quarter');
+    inputPlaceholderTest(DatePickTexts[1], 'End quarter');
     const pickers = datePickerWrapper.querySelectorAll(picker);
     expect(pickers.length).toBe(2);
     fireEvent.click(pickers[0].querySelectorAll('td')[2]);
@@ -1030,8 +1030,8 @@ describe('DatePicker[Range]', () => {
     await waitFor(async () => {
       await delay(300);
     });
-    attributesTest(DatePickTexts[0], 'value', `${year}-Q3`);
-    attributesTest(DatePickTexts[1], 'value', `${year}-Q4`);
+    inputValueTest(DatePickTexts[0], `${year}-Q3`);
+    inputValueTest(DatePickTexts[1], `${year}-Q4`);
   });
   test('should render when set range and type is year', async () => {
     const { container } = render(<DatePicker type='year' range />);
@@ -1127,7 +1127,7 @@ describe('DatePicker[Range]', () => {
     const resultTexts = container
       .querySelector(resultWrapper)
       ?.querySelectorAll(`${resultText} input`) as NodeListOf<Element>;
-    attributesTest(resultTexts[0], 'value', `${year}-${getFormatTime(Number(cell.textContent))}`);
+      inputValueTest(resultTexts[0], `${year}-${getFormatTime(Number(cell.textContent))}`);
     fireEvent.click(
       pickers[1]
         .querySelector(pickerBody)
@@ -1137,7 +1137,7 @@ describe('DatePicker[Range]', () => {
     await waitFor(async () => {
       await delay(300);
     });
-    attributesTest(resultTexts[1], 'placeholder', 'End month');
+    inputPlaceholderTest(resultTexts[1], 'End month');
     const cellOther = pickers[1]
       .querySelector(pickerBody)
       ?.querySelectorAll('tr')[1]
@@ -1146,7 +1146,7 @@ describe('DatePicker[Range]', () => {
     await waitFor(async () => {
       await delay(300);
     });
-    attributesTest(resultTexts[1], 'value', `${year}-${getFormatTime(Number(cellOther.textContent))}`);
+    inputValueTest(resultTexts[1], `${year}-${getFormatTime(Number(cellOther.textContent))}`);
   });
   test('should render when set range is number and click order to change', async () => {
     const { container } = render(<DatePicker range={86400 * 100} type='month' />);
@@ -1170,7 +1170,7 @@ describe('DatePicker[Range]', () => {
     const resultTexts = container
       .querySelector(resultWrapper)
       ?.querySelectorAll(`${resultText} input`) as NodeListOf<Element>;
-    attributesTest(resultTexts[1], 'value', `${year}-${getFormatTime(Number(cell.textContent))}`)
+      inputValueTest(resultTexts[1], `${year}-${getFormatTime(Number(cell.textContent))}`)
     fireEvent.click(
       pickers[0]
         .querySelector(pickerBody)
@@ -1180,7 +1180,7 @@ describe('DatePicker[Range]', () => {
     await waitFor(async () => {
       await delay(300);
     });
-    attributesTest(resultTexts[1], 'value', `${year}-${getFormatTime(
+    inputValueTest(resultTexts[1], `${year}-${getFormatTime(
       Number(
         pickers[1].querySelector(pickerBody)?.querySelectorAll('tr')[1].querySelectorAll('td')[0]
           .textContent,
@@ -1267,8 +1267,8 @@ describe('DatePicker[Disable]', () => {
     const datePickerResultWrapper = datePickerWrapper.querySelector(resultWrapper)!;
 
     const resultTexts = datePickerResultWrapper.querySelectorAll(`${resultText} input`);
-    attributesTest(resultTexts[0], 'placeholder', 'Start date');
-    attributesTest(resultTexts[1], 'placeholder', 'End date');
+    inputPlaceholderTest(resultTexts[0], 'Start date');
+    inputPlaceholderTest(resultTexts[1], 'End date');
     classContentTest(datePickerWrapper, wrapperDisabled, false);
     fireEvent.focus(datePickerResultWrapper);
     fireEvent.click(datePickerResultWrapper);
@@ -1305,7 +1305,7 @@ describe('DatePicker[Disable]', () => {
     );
     await waitFor(async () => {
       await delay(300);
-      attributesTest(resultTexts[1], 'placeholder', 'End date');
+      inputPlaceholderTest(resultTexts[1], 'End date');
     });
   });
   test('should render when set disable is function in datetime', async () => {
@@ -1401,19 +1401,19 @@ describe('DatePicker[Disable]', () => {
     fireEvent.click(timeLists[0].querySelectorAll(timeItem)[12]);
     await waitFor(async () => {
       await delay(300);
-      attributesTest(resultTexts[0], 'placeholder', 'Please select time');
+      inputPlaceholderTest(resultTexts[0], 'Please select time');
     });
     fireEvent.click(timeLists[1].querySelectorAll(timeItem)[0]);
     fireEvent.click(timeLists[2].querySelectorAll(timeItem)[0]);
     fireEvent.click(timeLists[0].querySelectorAll(timeItem)[11]);
     await waitFor(async () => {
       await delay(300);
-      attributesTest(resultTexts[0], 'value', '11:00:00');
+      inputValueTest(resultTexts[0], '11:00:00');
     });
     fireEvent.click(timeLists[0].querySelectorAll(timeItem)[12]);
     await waitFor(async () => {
       await delay(300);
-      attributesTest(resultTexts[0], 'value', '11:00:00');
+      inputValueTest(resultTexts[0], '11:00:00');
     });
   });
   // TODO: disabled and disabledTime
@@ -1634,7 +1634,7 @@ describe('DatePicker[AllowSingle]', () => {
     await waitFor(async () => {
       await delay(300);
     });
-    attributesTest(resultTexts[0], 'placeholder', 'Start date');
+    inputPlaceholderTest(resultTexts[0], 'Start date');
   });
   test('should render when set allowSingle', async () => {
     const { container } = render(<DatePicker range type='datetime' allowSingle />);
@@ -1659,7 +1659,7 @@ describe('DatePicker[AllowSingle]', () => {
     await waitFor(async () => {
       await delay(300);
     });
-    attributesTest(resultTexts[0], 'value', `${year}-${month}-${cell.textContent} 00:00:00`)
+    inputValueTest(resultTexts[0], `${year}-${month}-${cell.textContent} 00:00:00`)
   });
 });
 describe('DatePicker[Max/Min]', () => {
@@ -1682,7 +1682,7 @@ describe('DatePicker[Max/Min]', () => {
     await waitFor(async () => {
       await delay(300);
     });
-    attributesTest(resultTexts, 'placeholder', 'Please select date');
+    inputPlaceholderTest(resultTexts, 'Please select date');
     fireEvent.click(
       datePickerPickerWrapper
         .querySelector(pickerHeaderRight)
@@ -1695,7 +1695,7 @@ describe('DatePicker[Max/Min]', () => {
     await waitFor(async () => {
       await delay(300);
     });
-    attributesTest(resultTexts, 'placeholder', 'Please select date');
+    inputPlaceholderTest(resultTexts, 'Please select date');
   });
 });
 describe('DatePicker[Open]', () => {

--- a/packages/shineout/src/date-picker/__test__/datePicker.spec.tsx
+++ b/packages/shineout/src/date-picker/__test__/datePicker.spec.tsx
@@ -10,7 +10,7 @@ import {
   delay,
   displayTest,
   inputValueTest,
-  snapshotTest,
+  inputPlaceholderTest,
   styleContentTest,
   styleTest,
   textContentTest,
@@ -183,6 +183,8 @@ afterAll(() => {
 afterEach(cleanup);
 mountTest(<DatePicker />);
 
+const resultTextInput = `${resultText} input`;
+
 describe('Alert[Base]', () => {
   displayTest(DatePicker, 'ShineoutDatePicker');
   baseTest(DatePicker, wrapper);
@@ -216,8 +218,8 @@ describe('Alert[Base]', () => {
     attributesTest(datePickerWrapper, 'data-soui-type', 'date');
     const datePickerResultWrapper = datePickerWrapper.querySelector(resultWrapper)!;
     attributesTest(datePickerResultWrapper, 'tabindex', '1');
-    const datePickerResult = datePickerResultWrapper.querySelector(result)!;
-    textContentTest(datePickerResult, 'Please select date');
+    const datePickerResult = datePickerResultWrapper.querySelector(resultTextInput)!;
+    attributesTest(datePickerResult, 'placeholder', 'Please select date');
     const datePickerIcon = datePickerResultWrapper.querySelector(icon)!;
     classLengthTest(datePickerIcon, 'svg', 1);
 
@@ -287,7 +289,7 @@ describe('Alert[Base]', () => {
     fireEvent.click(cell);
     await waitFor(async () => {
       await delay(300);
-      textContentTest(datePickerResult, `${year}-${month}-${cell.textContent}`);
+      inputValueTest(datePickerResult, `${year}-${month}-${cell.textContent}`);
       classTest(cell, pickerCellActive);
     });
     fireEvent.click(headerInfos[0]);
@@ -311,16 +313,16 @@ describe('Alert[Base]', () => {
   });
   test('should render when set placeholder', () => {
     const { container } = render(<DatePicker placeholder='hello' />);
-    const datePickerResult = container.querySelector(result)!;
-    textContentTest(datePickerResult, 'hello');
+    const datePickerResult = container.querySelector(resultTextInput)!;
+    inputPlaceholderTest(datePickerResult, 'hello');
   });
   test('should render when set placeholder is array', () => {
     const start = 'start';
     const end = 'end';
     const { container } = render(<DatePicker range placeholder={[start, end]} />);
-    const resultTexts = container.querySelectorAll(resultText);
-    textContentTest(resultTexts[0], start);
-    textContentTest(resultTexts[1], end);
+    const resultTexts = container.querySelectorAll(`${resultText} input`);
+    attributesTest(resultTexts[0], 'placeholder', start);
+    attributesTest(resultTexts[1], 'placeholder', end);
   });
   const sizeClassNamesMap: { [key: string]: string } = {
     small: wrapperSmall,
@@ -379,7 +381,7 @@ describe('DatePicker[Clearable]', () => {
   test('should render default clearable', async () => {
     const { container } = render(<DatePicker />);
     const datePickerResultWrapper = container.querySelector(resultWrapper)!;
-    const datePickerResult = datePickerResultWrapper.querySelector(result)!;
+    const datePickerResult = datePickerResultWrapper.querySelector(resultTextInput)!;
 
     fireEvent.focus(datePickerResultWrapper);
     fireEvent.click(datePickerResultWrapper);
@@ -395,7 +397,7 @@ describe('DatePicker[Clearable]', () => {
     fireEvent.click(cell);
     await waitFor(async () => {
       await delay(300);
-      textContentTest(datePickerResult, `${year}-${month}-${cell.textContent}`);
+      inputValueTest(datePickerResult, `${year}-${month}-${cell.textContent}`);
     });
     fireEvent.mouseDown(datePickerResultWrapper);
     await waitFor(async () => {
@@ -404,7 +406,7 @@ describe('DatePicker[Clearable]', () => {
     });
     await waitFor(async () => {
       await delay(300);
-      textContentTest(datePickerResult, 'Please select date');
+      inputPlaceholderTest(datePickerResult, 'Please select date');
     });
   });
   test('should render when set clearable is false', async () => {
@@ -434,8 +436,8 @@ describe('DatePicker[Clearable]', () => {
     const datePickerWrapper = container.querySelector(wrapper)!;
     const datePickerResultWrapper = datePickerWrapper.querySelector(resultWrapper)!;
 
-    textContentTest(datePickerResultWrapper.querySelector(resultText)!, value)
-    inputValueTest(container.querySelector('input')!, value);
+    const resultInput = datePickerResultWrapper.querySelector(resultTextInput)!;
+    inputValueTest(resultInput, value)
 
     fireEvent.click(datePickerResultWrapper.querySelector(clear)?.querySelector('svg')!);
 
@@ -443,7 +445,7 @@ describe('DatePicker[Clearable]', () => {
       await delay(500);
     });
 
-    inputValueTest(container.querySelector('input')!, 'undefined');
+    inputValueTest(resultInput, '');
   });
 });
 describe('DatePicker[Event]', () => {
@@ -453,8 +455,8 @@ describe('DatePicker[Event]', () => {
     const { container } = render(<DatePicker onChange={changeFn} beforeChange={beforeChangeFn} />);
     const datePickerWrapper = container.querySelector(wrapper)!;
     const datePickerResultWrapper = datePickerWrapper.querySelector(resultWrapper)!;
-    const datePickerResult = datePickerResultWrapper.querySelector(result)!;
-    textContentTest(datePickerResult, 'Please select date');
+    const datePickerResult = datePickerResultWrapper.querySelector(resultTextInput)!;
+    attributesTest(datePickerResult, 'placeholder', 'Please select date');
     fireEvent.focus(datePickerResultWrapper);
     fireEvent.click(datePickerResultWrapper);
     await waitFor(async () => {
@@ -471,7 +473,7 @@ describe('DatePicker[Event]', () => {
     fireEvent.click(cell);
     await waitFor(async () => {
       await delay(300);
-      textContentTest(datePickerResult, `${year}-${month}-${cell.textContent}`);
+      inputValueTest(datePickerResult, `${year}-${month}-${cell.textContent}`);
       expect(changeFn.mock.calls.length).toBe(1);
       expect(beforeChangeFn.mock.calls.length).toBe(1);
     });
@@ -480,8 +482,8 @@ describe('DatePicker[Event]', () => {
     const { container } = render(<DatePickerControlled />);
     const datePickerWrapper = container.querySelector(wrapper)!;
     const datePickerResultWrapper = datePickerWrapper.querySelector(resultWrapper)!;
-    const datePickerResult = datePickerResultWrapper.querySelector(result)!;
-    textContentTest(datePickerResult, 'Select date');
+    const datePickerResult = datePickerResultWrapper.querySelector(resultTextInput)!;
+    attributesTest(datePickerResult, 'placeholder', 'Select date');
     fireEvent.focus(datePickerResultWrapper);
     fireEvent.click(datePickerResultWrapper);
     await waitFor(async () => {
@@ -498,7 +500,7 @@ describe('DatePicker[Event]', () => {
     fireEvent.click(cell);
     await waitFor(async () => {
       await delay(300);
-      textContentTest(datePickerResult, `${year}-${month}-${cell.textContent}`);
+      inputValueTest(datePickerResult, `${year}-${month}-${cell.textContent}`);
     });
   });
   test('should render when set onBlur', async () => {
@@ -583,14 +585,14 @@ describe('DatePicker[Event]', () => {
     await waitFor(async () => {
       await delay(300);
     });
-    const results = datePickerResultWrapper.querySelectorAll(resultText);
-    textContentTest(results[0], `${year}-${month}-${cell.textContent} 00:00:00`);
+    const results = datePickerResultWrapper.querySelectorAll(`${resultText} input`);
+    attributesTest(results[0], 'value', `${year}-${month}-${cell.textContent} 00:00:00`);
     fireEvent.doubleClick(cell);
     await waitFor(async () => {
       await delay(300);
     });
-    textContentTest(results[0], `${year}-${month}-${cell.textContent} 00:00:00`);
-    textContentTest(results[1], `${year}-${month}-${cell.textContent} 00:00:00`);
+    attributesTest(results[0], 'value', `${year}-${month}-${cell.textContent} 00:00:00`);
+    attributesTest(results[1], 'value', `${year}-${month}-${cell.textContent} 00:00:00`);
     const endCell = pickers[1]
       .querySelector(pickerBody)
       ?.querySelector('table')
@@ -601,8 +603,8 @@ describe('DatePicker[Event]', () => {
     await waitFor(async () => {
       await delay(300);
     });
-    textContentTest(results[0], `${year}-${month}-${endCell.textContent} 00:00:00`);
-    textContentTest(results[1], `${year}-${month}-${endCell.textContent} 00:00:00`);
+    attributesTest(results[0], 'value', `${year}-${month}-${endCell.textContent} 00:00:00`);
+    attributesTest(results[1], 'value', `${year}-${month}-${endCell.textContent} 00:00:00`);
   });
 });
 describe('DatePicker[Type]', () => {
@@ -611,7 +613,7 @@ describe('DatePicker[Type]', () => {
     const datePickerWrapper = container.querySelector(wrapper)!;
     attributesTest(datePickerWrapper, 'data-soui-type', 'datetime');
     const datePickerResultWrapper = datePickerWrapper.querySelector(resultWrapper)!;
-    const datePickerResult = datePickerResultWrapper.querySelector(result)!;
+    const datePickerResult = datePickerResultWrapper.querySelector(resultTextInput)!;
 
     fireEvent.focus(datePickerResultWrapper);
     fireEvent.click(datePickerResultWrapper);
@@ -627,7 +629,7 @@ describe('DatePicker[Type]', () => {
     fireEvent.click(cell);
     await waitFor(async () => {
       await delay(300);
-      textContentTest(datePickerResult, `${year}-${month}-${cell.textContent} 00:00:00`);
+      inputValueTest(datePickerResult, `${year}-${month}-${cell.textContent} 00:00:00`);
       expect(datePickerWrapper.querySelector(pickerFooter)).toBeInTheDocument();
     });
     const datepickerFooterTime = datePickerWrapper.querySelector(pickerFooterTime)!;
@@ -641,14 +643,14 @@ describe('DatePicker[Type]', () => {
     fireEvent.click(item);
     classTest(item, timeItemActive);
     await waitFor(async () => [await delay(300)]);
-    textContentTest(datePickerResult, `${year}-${month}-${cell.textContent} 01:00:00`);
+    inputValueTest(datePickerResult, `${year}-${month}-${cell.textContent} 01:00:00`);
   });
   test('should render when set type is week', async () => {
     const { container } = render(<DatePicker type='week' />);
     const datePickerWrapper = container.querySelector(wrapper)!;
     attributesTest(datePickerWrapper, 'data-soui-type', 'week');
     const datePickerResultWrapper = datePickerWrapper.querySelector(resultWrapper)!;
-    const datePickerResult = datePickerResultWrapper.querySelector(result)!;
+    const datePickerResult = datePickerResultWrapper.querySelector(resultTextInput)!;
     fireEvent.focus(datePickerResultWrapper);
     fireEvent.click(datePickerResultWrapper);
     await waitFor(async () => {
@@ -666,7 +668,7 @@ describe('DatePicker[Type]', () => {
     });
     fireEvent.click(tbody.querySelectorAll('tr')[2].querySelectorAll('td')[3]);
     await waitFor(async () => {
-      textContentTest(
+      inputValueTest(
         datePickerResult,
         `${year}-${tbody.querySelectorAll('tr')[2].querySelector('th')?.textContent}`,
       );
@@ -700,7 +702,7 @@ describe('DatePicker[Type]', () => {
     const datePickerWrapper = container.querySelector(wrapper)!;
     attributesTest(datePickerWrapper, 'data-soui-type', 'month');
     const datePickerResultWrapper = datePickerWrapper.querySelector(resultWrapper)!;
-    const datePickerResult = datePickerResultWrapper.querySelector(result)!;
+    const datePickerResult = datePickerResultWrapper.querySelector(resultTextInput)!;
     fireEvent.focus(datePickerResultWrapper);
     fireEvent.click(datePickerResultWrapper);
     await waitFor(async () => {
@@ -741,7 +743,7 @@ describe('DatePicker[Type]', () => {
     fireEvent.click(tbody.querySelectorAll('tr')[0].querySelectorAll('td')[0]);
     await waitFor(async () => {
       await delay(300);
-      textContentTest(datePickerResult, `${year}-01`);
+      inputValueTest(datePickerResult, `${year}-01`);
     });
   });
   test('should render when set type is quarter', async () => {
@@ -749,7 +751,7 @@ describe('DatePicker[Type]', () => {
     const datePickerWrapper = container.querySelector(wrapper)!;
     attributesTest(datePickerWrapper, 'data-soui-type', 'quarter');
     const datePickerResultWrapper = datePickerWrapper.querySelector(resultWrapper)!;
-    const datePickerResult = datePickerResultWrapper.querySelector(result)!;
+    const datePickerResult = datePickerResultWrapper.querySelector(resultTextInput)!;
     fireEvent.focus(datePickerResultWrapper);
     fireEvent.click(datePickerResultWrapper);
     await waitFor(async () => {
@@ -783,7 +785,7 @@ describe('DatePicker[Type]', () => {
     fireEvent.click(tbody.querySelector('tr')?.querySelectorAll('td')[0] as Element);
     await waitFor(async () => {
       await delay(300);
-      textContentTest(datePickerResult, `${year}-Q1`);
+      inputValueTest(datePickerResult, `${year}-Q1`);
     });
   });
   test('should render when set type is year', async () => {
@@ -791,7 +793,7 @@ describe('DatePicker[Type]', () => {
     const datePickerWrapper = container.querySelector(wrapper)!;
     attributesTest(datePickerWrapper, 'data-soui-type', 'year');
     const datePickerResultWrapper = datePickerWrapper.querySelector(resultWrapper)!;
-    const datePickerResult = datePickerResultWrapper.querySelector(result)!;
+    const datePickerResult = datePickerResultWrapper.querySelector(resultTextInput)!;
     fireEvent.focus(datePickerResultWrapper);
     fireEvent.click(datePickerResultWrapper);
     await waitFor(async () => {
@@ -828,7 +830,7 @@ describe('DatePicker[Type]', () => {
     fireEvent.click(tbody.querySelectorAll('tr')[1]?.querySelectorAll('td')[0] as Element);
     await waitFor(async () => {
       await delay(300);
-      textContentTest(datePickerResult, '2022');
+      inputValueTest(datePickerResult, '2022');
     });
   });
   test('should render when set type is time', async () => {
@@ -836,7 +838,7 @@ describe('DatePicker[Type]', () => {
     const datePickerWrapper = container.querySelector(wrapper)!;
     attributesTest(datePickerWrapper, 'data-soui-type', 'time');
     const datePickerResultWrapper = datePickerWrapper.querySelector(resultWrapper)!;
-    const datePickerResult = datePickerResultWrapper.querySelector(result)!;
+    const datePickerResult = datePickerResultWrapper.querySelector(resultTextInput)!;
 
     fireEvent.focus(datePickerResultWrapper);
     fireEvent.click(datePickerResultWrapper);
@@ -856,7 +858,7 @@ describe('DatePicker[Type]', () => {
     fireEvent.click(lists[0].querySelectorAll(timeItem)[3]);
     await waitFor(async () => {
       await delay(300);
-      textContentTest(datePickerResult, '03:00:00');
+      inputValueTest(datePickerResult, '03:00:00');
       classTest(lists[0].querySelectorAll(timeItem)[3]!, timeItemActive);
     });
   });
@@ -864,21 +866,22 @@ describe('DatePicker[Type]', () => {
 describe('DatePicker[Value/DefaultValue/DefaultTime]', () => {
   test('should render when set defaultValue', () => {
     const { container } = render(<DatePicker defaultValue={Now} />);
-    textContentTest(container.querySelector(resultText)!, `${year}-${month}-${day}`);
+    attributesTest(container.querySelector(resultTextInput)!, 'value', `${year}-${month}-${day}`);
   });
   test('should render when set defaultValue is array', () => {
     const { container } = render(<DatePicker range defaultValue={[Now, Now]} />);
-    textContentTest(container.querySelectorAll(resultText)[0], `${year}-${month}-${day}`);
-    textContentTest(container.querySelectorAll(resultText)[1], `${year}-${month}-${day}`);
+
+    attributesTest(container.querySelectorAll(resultTextInput)[0], 'value', `${year}-${month}-${day}`);
+    attributesTest(container.querySelectorAll(resultTextInput)[1], 'value', `${year}-${month}-${day}`);
   });
   test('should render when set value', () => {
     const { container } = render(<DatePicker value={Now} />);
-    textContentTest(container.querySelector(resultText)!, `${year}-${month}-${day}`);
+    attributesTest(container.querySelector(resultTextInput)!, 'value', `${year}-${month}-${day}`);
   });
   test('should render when set value is array', () => {
     const { container } = render(<DatePicker range value={[Now, Now]} />);
-    textContentTest(container.querySelectorAll(resultText)[0], `${year}-${month}-${day}`);
-    textContentTest(container.querySelectorAll(resultText)[1], `${year}-${month}-${day}`);
+    attributesTest(container.querySelectorAll(resultTextInput)[0], 'value', `${year}-${month}-${day}`);
+    attributesTest(container.querySelectorAll(resultTextInput)[1], 'value', `${year}-${month}-${day}`);
   });
   test('should render when set value and defaultValue', () => {
     const nowDate = new Date();
@@ -895,10 +898,7 @@ describe('DatePicker[Value/DefaultValue/DefaultTime]', () => {
         <DatePicker defaultValue={Now} value={nowDate.getTime()} />,
     );
 
-    textContentTest(
-        container.querySelector(resultText)!,
-        expectedDateString,
-    );
+    attributesTest(container.querySelector(resultTextInput)!, 'value', expectedDateString);
   });
   test('should render when set defaultTime', async () => {
     const defaultTime = '10:01:02';
@@ -916,10 +916,7 @@ describe('DatePicker[Value/DefaultValue/DefaultTime]', () => {
       ?.querySelectorAll('tr')[3]
       .querySelectorAll('td')[0] as Element;
     fireEvent.click(cell);
-    textContentTest(
-      container.querySelector(resultText)!,
-      `${year}-${month}-${cell.textContent} ${defaultTime}`,
-    );
+    attributesTest(container.querySelector(resultTextInput)!, 'value', `${year}-${month}-${cell.textContent} ${defaultTime}`);
   });
 });
 describe('DatePicker[Format]', () => {
@@ -927,7 +924,7 @@ describe('DatePicker[Format]', () => {
     const errorSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     const { container, rerender } = render(<DatePicker type='time' format='HH:mm' />);
     const datePickerResultWrapper = container.querySelector(resultWrapper)!;
-    const datePickerResult = container.querySelector(result)!;
+    const datePickerResult = container.querySelector(resultTextInput)!;
     fireEvent.focus(datePickerResultWrapper);
     fireEvent.click(datePickerResultWrapper);
     await waitFor(async () => {
@@ -938,7 +935,7 @@ describe('DatePicker[Format]', () => {
     fireEvent.click(lists[0].querySelectorAll(timeItem)[3]);
     await waitFor(async () => {
       await delay(300);
-      textContentTest(datePickerResult, '03:00');
+      inputValueTest(datePickerResult, '03:00');
     });
     rerender(<DatePicker type='time' format='hh:mm a' />);
     fireEvent.focus(datePickerResultWrapper);
@@ -949,7 +946,7 @@ describe('DatePicker[Format]', () => {
     fireEvent.click(lists[0].querySelectorAll(timeItem)[3]);
     await waitFor(async () => {
       await delay(300);
-      textContentTest(datePickerResult, '03:00 AM');
+      inputValueTest(datePickerResult, '03:00 AM');
     });
     expect(errorSpy).toHaveBeenCalledWith('invalid datepicker format: hh:mm a please use hh:mm A');
   });
@@ -959,8 +956,8 @@ describe('DatePicker[Format]', () => {
     );
     const datePickerWrapper = container.querySelector(wrapper)!;
     const datePickerResultWrapper = datePickerWrapper.querySelector(resultWrapper)!;
-    const datePickerResult = datePickerResultWrapper.querySelector(result)!;
-    textContentTest(datePickerResult, String(Now));
+    const datePickerResult = datePickerResultWrapper.querySelector(resultTextInput)!;
+    inputValueTest(datePickerResult, String(Now));
     rerender(
       <DatePicker
         format='x'
@@ -969,7 +966,7 @@ describe('DatePicker[Format]', () => {
         formatResult={'YYYY-MM-DD HH:mm:ss'}
       />,
     );
-    textContentTest(datePickerResult, `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`);
+    inputValueTest(datePickerResult, `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`);
   });
 });
 describe('DatePicker[Step]', () => {
@@ -1022,10 +1019,10 @@ describe('DatePicker[Range]', () => {
     const datePickerWrapper = container.querySelector(pickerWrapper)!;
     const datePickerResult = datePickerResultWrapper.querySelector(result);
     textContentTest(datePickerResult?.querySelector(resultSeparator) as Element, '~');
-    const DatePickTexts = datePickerResult?.querySelectorAll(resultText) as NodeListOf<Element>;
+    const DatePickTexts = datePickerResult?.querySelectorAll(resultTextInput) as NodeListOf<Element>;
     expect(DatePickTexts?.length).toBe(2);
-    textContentTest(DatePickTexts[0], 'Start quarter');
-    textContentTest(DatePickTexts[1], 'End quarter');
+    attributesTest(DatePickTexts[0], 'placeholder', 'Start quarter');
+    attributesTest(DatePickTexts[1], 'placeholder', 'End quarter');
     const pickers = datePickerWrapper.querySelectorAll(picker);
     expect(pickers.length).toBe(2);
     fireEvent.click(pickers[0].querySelectorAll('td')[2]);
@@ -1033,13 +1030,13 @@ describe('DatePicker[Range]', () => {
     await waitFor(async () => {
       await delay(300);
     });
-    textContentTest(DatePickTexts[0], `${year}-Q3`);
-    textContentTest(DatePickTexts[1], `${year}-Q4`);
+    attributesTest(DatePickTexts[0], 'value', `${year}-Q3`);
+    attributesTest(DatePickTexts[1], 'value', `${year}-Q4`);
   });
   test('should render when set range and type is year', async () => {
     const { container } = render(<DatePicker type='year' range />);
     const datePickerResultWrapper = container.querySelector(resultWrapper)!;
-    const results = datePickerResultWrapper.querySelectorAll(resultText);
+    const results = datePickerResultWrapper.querySelectorAll(resultTextInput);
     fireEvent.focus(datePickerResultWrapper);
     fireEvent.click(datePickerResultWrapper);
     await waitFor(async () => {
@@ -1063,15 +1060,17 @@ describe('DatePicker[Range]', () => {
     await waitFor(async () => {
       await delay(300);
     });
-    textContentTest(
+    attributesTest(
       results[0],
+      'value',
       pickers[0].querySelector('tbody')?.querySelectorAll('tr')[1].querySelectorAll('td')[2]
-        .textContent,
+      .textContent as string,
     );
-    textContentTest(
+    attributesTest(
       results[1],
+      'value',
       pickers[1].querySelector('tbody')?.querySelectorAll('tr')[1].querySelectorAll('td')[2]
-        .textContent,
+      .textContent as string,
     );
     fireEvent.focus(datePickerResultWrapper);
     fireEvent.click(datePickerResultWrapper);
@@ -1093,15 +1092,17 @@ describe('DatePicker[Range]', () => {
     await waitFor(async () => {
       await delay(300);
     });
-    textContentTest(
+    attributesTest(
       results[0],
+      'value',
       pickers[0].querySelector('tbody')?.querySelectorAll('tr')[0].querySelectorAll('td')[2]
-        .textContent,
+        .textContent as string,
     );
-    textContentTest(
+    attributesTest(
       results[1],
+      'value',
       pickers[1].querySelector('tbody')?.querySelectorAll('tr')[2].querySelectorAll('td')[2]
-        .textContent,
+        .textContent as string,
     );
   });
   test('should render when set range is number', async () => {
@@ -1125,8 +1126,8 @@ describe('DatePicker[Range]', () => {
     });
     const resultTexts = container
       .querySelector(resultWrapper)
-      ?.querySelectorAll(resultText) as NodeListOf<Element>;
-    textContentTest(resultTexts[0], `${year}-${getFormatTime(Number(cell.textContent))}`);
+      ?.querySelectorAll(`${resultText} input`) as NodeListOf<Element>;
+    attributesTest(resultTexts[0], 'value', `${year}-${getFormatTime(Number(cell.textContent))}`);
     fireEvent.click(
       pickers[1]
         .querySelector(pickerBody)
@@ -1136,7 +1137,7 @@ describe('DatePicker[Range]', () => {
     await waitFor(async () => {
       await delay(300);
     });
-    textContentTest(resultTexts[1], 'End month');
+    attributesTest(resultTexts[1], 'placeholder', 'End month');
     const cellOther = pickers[1]
       .querySelector(pickerBody)
       ?.querySelectorAll('tr')[1]
@@ -1145,7 +1146,7 @@ describe('DatePicker[Range]', () => {
     await waitFor(async () => {
       await delay(300);
     });
-    textContentTest(resultTexts[1], `${year}-${getFormatTime(Number(cellOther.textContent))}`);
+    attributesTest(resultTexts[1], 'value', `${year}-${getFormatTime(Number(cellOther.textContent))}`);
   });
   test('should render when set range is number and click order to change', async () => {
     const { container } = render(<DatePicker range={86400 * 100} type='month' />);
@@ -1168,8 +1169,8 @@ describe('DatePicker[Range]', () => {
     });
     const resultTexts = container
       .querySelector(resultWrapper)
-      ?.querySelectorAll(resultText) as NodeListOf<Element>;
-    textContentTest(resultTexts[1], `${year}-${getFormatTime(Number(cell.textContent))}`);
+      ?.querySelectorAll(`${resultText} input`) as NodeListOf<Element>;
+    attributesTest(resultTexts[1], 'value', `${year}-${getFormatTime(Number(cell.textContent))}`)
     fireEvent.click(
       pickers[0]
         .querySelector(pickerBody)
@@ -1179,15 +1180,12 @@ describe('DatePicker[Range]', () => {
     await waitFor(async () => {
       await delay(300);
     });
-    textContentTest(
-      resultTexts[1],
-      `${year}-${getFormatTime(
-        Number(
-          pickers[1].querySelector(pickerBody)?.querySelectorAll('tr')[1].querySelectorAll('td')[0]
-            .textContent,
-        ),
-      )}`,
-    );
+    attributesTest(resultTexts[1], 'value', `${year}-${getFormatTime(
+      Number(
+        pickers[1].querySelector(pickerBody)?.querySelectorAll('tr')[1].querySelectorAll('td')[0]
+          .textContent,
+      ),
+    )}`)
   });
 });
 describe('DatePicker[QuickSelect]', () => {
@@ -1234,11 +1232,6 @@ describe('DatePicker[QuickSelect]', () => {
     fireEvent.click(quickPickerItems[2]);
     await waitFor(async () => {
       await delay(300);
-      console.log('======================')
-      // console.log('1: >>', datePickerPickers[1].querySelectorAll(pickerHeaderInfo)[1])
-      console.log('month: >>', month)
-      console.log('2: >>', `${Number(month) + 1}`)
-      console.log('======================')
       textContentTest(
         datePickerPickers[1].querySelectorAll(pickerHeaderInfo)[1],
         `${Number(month) + 1}`,
@@ -1273,9 +1266,9 @@ describe('DatePicker[Disable]', () => {
     const datePickerWrapper = container.querySelector(wrapper)!;
     const datePickerResultWrapper = datePickerWrapper.querySelector(resultWrapper)!;
 
-    const resultTexts = datePickerResultWrapper.querySelectorAll(resultText);
-    textContentTest(resultTexts[0], 'Start date');
-    textContentTest(resultTexts[1], 'End date');
+    const resultTexts = datePickerResultWrapper.querySelectorAll(`${resultText} input`);
+    attributesTest(resultTexts[0], 'placeholder', 'Start date');
+    attributesTest(resultTexts[1], 'placeholder', 'End date');
     classContentTest(datePickerWrapper, wrapperDisabled, false);
     fireEvent.focus(datePickerResultWrapper);
     fireEvent.click(datePickerResultWrapper);
@@ -1301,7 +1294,8 @@ describe('DatePicker[Disable]', () => {
     );
     await waitFor(async () => {
       await delay(300);
-      expect(resultTexts[0].textContent).not.toBe('Start date');
+      const inputEl = resultTexts[0] as HTMLInputElement
+      expect(inputEl.value).not.toBe('');
     });
     fireEvent.click(
       pickers[1]
@@ -1311,7 +1305,7 @@ describe('DatePicker[Disable]', () => {
     );
     await waitFor(async () => {
       await delay(300);
-      textContentTest(resultTexts[1], 'End date');
+      attributesTest(resultTexts[1], 'placeholder', 'End date');
     });
   });
   test('should render when set disable is function in datetime', async () => {
@@ -1331,7 +1325,7 @@ describe('DatePicker[Disable]', () => {
     await waitFor(async () => {
       await delay(300);
     });
-    const resultTexts = datePickerResultWrapper.querySelectorAll(resultText);
+    const resultTexts = datePickerResultWrapper.querySelectorAll(`${resultText} input`);
     const datePickerPickerWrapper = datePickerWrapper.querySelector(pickerWrapper)!;
     const pickTableBody = datePickerPickerWrapper.querySelector(pickerBody)?.querySelector('tbody');
     const tds = pickTableBody
@@ -1343,7 +1337,8 @@ describe('DatePicker[Disable]', () => {
     fireEvent.click(tds[6]);
     await waitFor(async () => {
       await delay(300);
-      expect(resultTexts[0].textContent).toBe('Please select date');
+      const inputEl = resultTexts[0] as HTMLInputElement
+      expect(inputEl.value).toBe('');
     });
   });
   test('should render when set disbale is function in time', async () => {
@@ -1359,7 +1354,7 @@ describe('DatePicker[Disable]', () => {
     const datePickerWrapper = container.querySelector(wrapper)!;
     const datePickerResultWrapper = datePickerWrapper.querySelector(resultWrapper)!;
 
-    const resultTexts = datePickerResultWrapper.querySelectorAll(resultText);
+    const resultTexts = datePickerResultWrapper.querySelectorAll(`${resultText} input`);
 
     fireEvent.focus(datePickerResultWrapper);
     fireEvent.click(datePickerResultWrapper);
@@ -1373,12 +1368,14 @@ describe('DatePicker[Disable]', () => {
     fireEvent.click(timeListsItems[2]);
     await waitFor(async () => {
       await delay(300);
-      expect(resultTexts[0].textContent).toBe('02:00:00');
+      const inputEl = resultTexts[0] as HTMLInputElement
+      expect(inputEl.value).toBe('02:00:00');
     });
     fireEvent.click(timeListsItems[17]);
     await waitFor(async () => {
       await delay(300);
-      expect(resultTexts[0].textContent).toBe('02:00:00');
+      const inputEl = resultTexts[0] as HTMLInputElement
+      expect(inputEl.value).toBe('02:00:00');
     });
     timeListsItems.forEach((item, index) => {
       if (index < 16) return;
@@ -1392,7 +1389,7 @@ describe('DatePicker[Disable]', () => {
     const datePickerWrapper = container.querySelector(wrapper)!;
     const datePickerResultWrapper = datePickerWrapper.querySelector(resultWrapper)!;
 
-    const resultTexts = datePickerResultWrapper.querySelectorAll(resultText);
+    const resultTexts = datePickerResultWrapper.querySelectorAll(`${resultText} input`);
 
     fireEvent.focus(datePickerResultWrapper);
     fireEvent.click(datePickerResultWrapper);
@@ -1404,19 +1401,19 @@ describe('DatePicker[Disable]', () => {
     fireEvent.click(timeLists[0].querySelectorAll(timeItem)[12]);
     await waitFor(async () => {
       await delay(300);
-      expect(resultTexts[0].textContent).toBe('Please select time');
+      attributesTest(resultTexts[0], 'placeholder', 'Please select time');
     });
     fireEvent.click(timeLists[1].querySelectorAll(timeItem)[0]);
     fireEvent.click(timeLists[2].querySelectorAll(timeItem)[0]);
     fireEvent.click(timeLists[0].querySelectorAll(timeItem)[11]);
     await waitFor(async () => {
       await delay(300);
-      expect(resultTexts[0].textContent).toBe('11:00:00');
+      attributesTest(resultTexts[0], 'value', '11:00:00');
     });
     fireEvent.click(timeLists[0].querySelectorAll(timeItem)[12]);
     await waitFor(async () => {
       await delay(300);
-      expect(resultTexts[0].textContent).toBe('11:00:00');
+      attributesTest(resultTexts[0], 'value', '11:00:00');
     });
   });
   // TODO: disabled and disabledTime
@@ -1618,7 +1615,7 @@ describe('DatePicker[AllowSingle]', () => {
     const { container } = render(<DatePicker range type='datetime' />);
     const datePickerWrapper = container.querySelector(wrapper)!;
     const datePickerResultWrapper = datePickerWrapper.querySelector(resultWrapper)!;
-    const resultTexts = datePickerResultWrapper.querySelectorAll(resultText);
+    const resultTexts = datePickerResultWrapper.querySelectorAll(`${resultText} input`);
 
     fireEvent.focus(datePickerResultWrapper);
     fireEvent.click(datePickerResultWrapper);
@@ -1637,13 +1634,13 @@ describe('DatePicker[AllowSingle]', () => {
     await waitFor(async () => {
       await delay(300);
     });
-    textContentTest(resultTexts[0], 'Start date');
+    attributesTest(resultTexts[0], 'placeholder', 'Start date');
   });
   test('should render when set allowSingle', async () => {
     const { container } = render(<DatePicker range type='datetime' allowSingle />);
     const datePickerWrapper = container.querySelector(wrapper)!;
     const datePickerResultWrapper = datePickerWrapper.querySelector(resultWrapper)!;
-    const resultTexts = datePickerResultWrapper.querySelectorAll(resultText);
+    const resultTexts = datePickerResultWrapper.querySelectorAll(`${resultText} input`);
 
     fireEvent.focus(datePickerResultWrapper);
     fireEvent.click(datePickerResultWrapper);
@@ -1662,7 +1659,7 @@ describe('DatePicker[AllowSingle]', () => {
     await waitFor(async () => {
       await delay(300);
     });
-    textContentTest(resultTexts[0], `${year}-${month}-${cell.textContent} 00:00:00`);
+    attributesTest(resultTexts[0], 'value', `${year}-${month}-${cell.textContent} 00:00:00`)
   });
 });
 describe('DatePicker[Max/Min]', () => {
@@ -1673,7 +1670,7 @@ describe('DatePicker[Max/Min]', () => {
     const { container } = render(<DatePicker min={now} type='datetime' max={now + 4 * 86400000} />);
     const datePickerWrapper = container.querySelector(wrapper)!;
     const datePickerResultWrapper = datePickerWrapper.querySelector(resultWrapper)!;
-    const resultTexts = datePickerResultWrapper.querySelector(resultText)!;
+    const resultTexts = datePickerResultWrapper.querySelector(`${resultText} input`)!;
 
     fireEvent.focus(datePickerResultWrapper);
     fireEvent.click(datePickerResultWrapper);
@@ -1685,7 +1682,7 @@ describe('DatePicker[Max/Min]', () => {
     await waitFor(async () => {
       await delay(300);
     });
-    textContentTest(resultTexts, 'Please select date');
+    attributesTest(resultTexts, 'placeholder', 'Please select date');
     fireEvent.click(
       datePickerPickerWrapper
         .querySelector(pickerHeaderRight)
@@ -1698,7 +1695,7 @@ describe('DatePicker[Max/Min]', () => {
     await waitFor(async () => {
       await delay(300);
     });
-    textContentTest(resultTexts, 'Please select date');
+    attributesTest(resultTexts, 'placeholder', 'Please select date');
   });
 });
 describe('DatePicker[Open]', () => {

--- a/packages/shineout/src/drawer/__test__/__snapshots__/drawer.spec.tsx.snap
+++ b/packages/shineout/src/drawer/__test__/__snapshots__/drawer.spec.tsx.snap
@@ -687,11 +687,12 @@ exports[`Drawer[Base] should render correctly about full screen 1`] = `
                           <span
                             class="soui-datePicker-result-text-padding"
                           >
-                            <span
-                              class="soui-datePicker-placeholder"
-                            >
-                              please select date
-                            </span>
+                            <input
+                              autocomplete="off"
+                              placeholder="please select date"
+                              readonly=""
+                              value=""
+                            />
                           </span>
                           <div
                             class="soui-datePicker-result-text-bg"

--- a/packages/shineout/src/tests/utils.tsx
+++ b/packages/shineout/src/tests/utils.tsx
@@ -120,6 +120,10 @@ export function inputValueTest(element: Element, value: string) {
   attributesTest(element, 'value', value);
 }
 
+export function inputPlaceholderTest(element: Element, value: string) {
+  attributesTest(element, 'placeholder', value);
+}
+
 export function displayTest(Component: React.FC, displayName: string) {
   test('should start with Shineout display', () => {
     expect(Component.displayName).toBe(displayName);


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others


### Changelog
- 优化 Datepicker 的结果展示区域，改为不换行展示

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新特性**
  - 在`Input`组件中新增`readOnly`属性，允许以只读状态渲染。
  - 更新`Datepicker`组件的结果显示，确保信息以单行展示，提升可读性。

- **错误修复**
  - 修复了`Datepicker`组件结果区域的显示问题。

- **测试**
  - 更新了`DatePicker`组件的测试逻辑，增强了对输入元素`placeholder`和`value`属性的验证。
  - 新增`inputPlaceholderTest`函数，以测试HTML元素的`placeholder`属性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->