### PR TITLE
fix: 修复 `Tree` 组件在开启 `loader` 情况下设置 `defaultExpandAll` 展开状态异常和 `setActive` 多次触发的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.4.3-beta.1",
+  "version": "3.4.3-beta.3",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/tree/tree-content.type.ts
+++ b/packages/base/src/tree/tree-content.type.ts
@@ -18,7 +18,11 @@ export interface TreeContextProps<DataItem, Value extends KeygenResult[]>
   childrenKey: keyof DataItem;
   renderItem: TreeRenderItemType<DataItem>;
   childrenClass?: ((data: DataItem) => string) | string;
-  bindNode: (id: KeygenResult, update: UpdateFunc) => { expanded: boolean; active: boolean };
+  bindNode: (
+    id: KeygenResult,
+    update: UpdateFunc,
+    data: DataItem,
+  ) => { expanded: boolean; active: boolean };
   bindContent: React.RefObject<HTMLDivElement>;
   fetching: boolean;
   inlineNode?: boolean;

--- a/packages/base/src/tree/tree-list.tsx
+++ b/packages/base/src/tree/tree-list.tsx
@@ -31,6 +31,7 @@ const List = <DataItem, Value extends KeygenResult[]>(props: TreeListProps<DataI
     childrenKey,
     inlineNode,
     highlight,
+    defaultExpandAll,
     loader,
     onNodeClick,
     onToggle,
@@ -76,7 +77,7 @@ const List = <DataItem, Value extends KeygenResult[]>(props: TreeListProps<DataI
         line={line}
         keygen={keygen}
         listComponent={List}
-
+        defaultExpandAll={defaultExpandAll}
         isControlled={isControlled}
         mode={mode}
         active={active}

--- a/packages/base/src/tree/tree-list.type.ts
+++ b/packages/base/src/tree/tree-list.type.ts
@@ -11,6 +11,7 @@ export interface TreeListProps<DataItem, Value extends KeygenResult[]>
   expanded: boolean;
   childrenKey: keyof DataItem;
   parentClickExpand?: boolean;
+  defaultExpandAll?: boolean;
   doubleClickExpand?: boolean;
   childrenClassName?: string;
   expandIcons?: (React.ReactNode | ((d: DataItem) => React.ReactNode))[];
@@ -23,7 +24,11 @@ export interface TreeListProps<DataItem, Value extends KeygenResult[]>
   dragSibling?: boolean;
   dragHoverExpand?: boolean;
   childrenClass: (data: DataItem) => string | undefined;
-  bindNode: (id: KeygenResult, update: UpdateFunc) => { expanded: boolean; active: boolean };
+  bindNode: (
+    id: KeygenResult,
+    update: UpdateFunc,
+    data: DataItem,
+  ) => { expanded: boolean; active: boolean };
   renderItem: TreeRenderItemType<DataItem>;
   loader?: (key: KeygenResult, data: DataItem) => void;
   onNodeClick: (data: DataItem, id: KeygenResult) => void;

--- a/packages/base/src/tree/tree-node.tsx
+++ b/packages/base/src/tree/tree-node.tsx
@@ -82,7 +82,6 @@ const Node = <DataItem, Value extends KeygenResult[]>(props: TreeNodeProps<DataI
     dragImageStyle,
   });
 
-
   const children = data[childrenKey] as DataItem[];
   const hasChildren = children && children.length > 0;
 

--- a/packages/base/src/tree/tree-node.type.ts
+++ b/packages/base/src/tree/tree-node.type.ts
@@ -24,7 +24,11 @@ export interface TreeNodeProps<DataItem, Value extends KeygenResult[]>
   contentClass?: string | ((data: DataItem) => string);
   expandIcons?: (React.ReactNode | ((d: DataItem) => React.ReactNode))[];
   childrenClass: (data: DataItem) => string | undefined;
-  bindNode: (id: KeygenResult, update: UpdateFunc) => { expanded: boolean; active: boolean };
+  bindNode: (
+    id: KeygenResult,
+    update: UpdateFunc,
+    data: DataItem,
+  ) => { expanded: boolean; active: boolean };
   onNodeClick: (data: DataItem, id: KeygenResult) => void;
   renderItem: TreeRenderItemType<DataItem>;
   listComponent: (props: TreeListProps<DataItem, Value>) => JSX.Element | null;

--- a/packages/base/src/tree/tree-root.type.ts
+++ b/packages/base/src/tree/tree-root.type.ts
@@ -6,7 +6,11 @@ export interface TreeRootProps<DataItem, Value extends KeygenResult[]>
   jssStyle?: JsstyleType;
   line: boolean;
   childrenClass: (data: DataItem) => string | undefined;
-  bindNode: (id: KeygenResult, update: UpdateFunc) => { expanded: boolean; active: boolean };
+  bindNode: (
+    id: KeygenResult,
+    update: UpdateFunc,
+    data: DataItem,
+  ) => { expanded: boolean; active: boolean };
   parentClickExpand?: boolean;
   doubleClickExpand?: boolean;
   childrenKey: ObjectKey<DataItem>;
@@ -27,6 +31,7 @@ export interface TreeRootProps<DataItem, Value extends KeygenResult[]>
   loader?: (key: KeygenResult, data: DataItem) => void;
   inlineNode?: boolean;
   highlight?: boolean;
+  defaultExpandAll?: boolean;
   onDragStart?: (e: React.DragEvent, data: DataItem) => void;
   onDragEnd?: (e: React.DragEvent, data: DataItem) => void;
   onDragOver?: (e: React.DragEvent, data: DataItem) => void;

--- a/packages/base/src/tree/tree.tsx
+++ b/packages/base/src/tree/tree.tsx
@@ -105,9 +105,12 @@ const Tree = <DataItem, Value extends KeygenResult[]>(props: TreeProps<DataItem,
     });
   };
 
-  const handleUpdateActive = (active?: KeygenResult) => {
+  const handleUpdateActive = (active?: KeygenResult, item?: DataItem) => {
     setActive(active);
-    propSetActive?.(active);
+
+    if (active !== props.active) {
+      propSetActive?.(active, item);
+    }
 
     datum.updateMap.forEach((update, id) => {
       update('active', id === active);
@@ -115,7 +118,7 @@ const Tree = <DataItem, Value extends KeygenResult[]>(props: TreeProps<DataItem,
   };
 
   const handleNodeClick = (node: DataItem, id: KeygenResult) => {
-    handleUpdateActive(id);
+    handleUpdateActive(id, node);
 
     if (onClick) {
       onClick(node, id, datum.getPath(id));
@@ -197,7 +200,9 @@ const Tree = <DataItem, Value extends KeygenResult[]>(props: TreeProps<DataItem,
 
   useEffect(() => {
     // 首次渲染不更新
-    if (!context.mounted) {return;}
+    if (!context.mounted) {
+      return;
+    }
     if (!props.expanded) return;
     handleUpdateExpanded(expanded);
   }, [expanded]);
@@ -229,6 +234,7 @@ const Tree = <DataItem, Value extends KeygenResult[]>(props: TreeProps<DataItem,
           contentClass={contentClass}
           expanded={expanded}
           expandIcons={expandIcons}
+          defaultExpandAll={defaultExpandAll}
           childrenClass={util.isFunc(childrenClass) ? childrenClass : () => childrenClass}
           bindNode={datum.bindNode}
           childrenKey={childrenKey}

--- a/packages/base/src/tree/tree.type.ts
+++ b/packages/base/src/tree/tree.type.ts
@@ -98,7 +98,7 @@ export interface TreeProps<DataItem, Value extends any[]>
    * @cn 设置激活节点的key
    * @version 3.4.0
    */
-  setActive?: (key?: KeygenResult) => void;
+  setActive?: (key: KeygenResult | undefined, data?: DataItem) => void;
   /**
    * @en If need to double-click to expand
    * @cn 双击是否展开节点

--- a/packages/hooks/src/components/use-tree/use-tree-node.ts
+++ b/packages/hooks/src/components/use-tree/use-tree-node.ts
@@ -44,7 +44,7 @@ const useTreeNode = <DataItem, Value>(props: BaseTreeNodeProps<DataItem, Value>)
   };
 
   useEffect(() => {
-    const { active, expanded: nextExpanded } = bindNode(id, update);
+    const { active, expanded: nextExpanded } = bindNode(id, update, data);
     setActive(active);
     setExpanded(nextExpanded);
   }, []);

--- a/packages/hooks/src/components/use-tree/use-tree-node.type.ts
+++ b/packages/hooks/src/components/use-tree/use-tree-node.type.ts
@@ -17,7 +17,11 @@ export interface BaseTreeNodeProps<DataItem, Value> {
   element: React.RefObject<HTMLDivElement>;
   dragImageSelector: (data?: DataItem) => string | undefined;
   dragImageStyle?: React.CSSProperties;
-  bindNode: (id: KeygenResult, update: UpdateFunc) => { expanded: boolean; active: boolean };
+  bindNode: (
+    id: KeygenResult,
+    update: UpdateFunc,
+    data: DataItem,
+  ) => { expanded: boolean; active: boolean };
   content: HTMLDivElement | null;
   loader?: (key: KeygenResult, data: DataItem) => void;
   onToggle?: (id: Value, expanded: boolean) => void;

--- a/packages/hooks/src/components/use-tree/use-tree.ts
+++ b/packages/hooks/src/components/use-tree/use-tree.ts
@@ -104,7 +104,8 @@ const useTree = <DataItem>(props: BaseTreeProps<DataItem>) => {
     if (defaultExpandAll) {
       const shouldDefaultExpand =
         defaultExpandAll &&
-        isArray(item[childrenKey] && (item[childrenKey] as DataItem[]).length > 0);
+        isArray(item[childrenKey]) &&
+        (item[childrenKey] as DataItem[]).length > 0;
       return { active: isActive, expanded: shouldDefaultExpand };
     }
     return { active: isActive, expanded: !!(expandeds && expandeds.indexOf(id) >= 0) };

--- a/packages/hooks/src/components/use-tree/use-tree.ts
+++ b/packages/hooks/src/components/use-tree/use-tree.ts
@@ -96,13 +96,16 @@ const useTree = <DataItem>(props: BaseTreeProps<DataItem>) => {
   });
 
   // 注册节点
-  const bindNode = (id: KeygenResult, update: UpdateFunc) => {
+  const bindNode = (id: KeygenResult, update: UpdateFunc, item: DataItem) => {
     context.updateMap.set(id, update);
     const isActive = activeProp === id;
     const expandeds = expanded;
 
     if (defaultExpandAll) {
-      return { active: isActive, expanded: true };
+      const shouldDefaultExpand =
+        defaultExpandAll &&
+        isArray(item[childrenKey] && (item[childrenKey] as DataItem[]).length > 0);
+      return { active: isActive, expanded: shouldDefaultExpand };
     }
     return { active: isActive, expanded: !!(expandeds && expandeds.indexOf(id) >= 0) };
   };
@@ -234,9 +237,9 @@ const useTree = <DataItem>(props: BaseTreeProps<DataItem>) => {
       // 重复 id 警告
       if (context.dataMap.get(id)) {
         console.error(`There is already a key "${id}" exists. The key must be unique.`);
-        continue
+        continue;
       }
-      
+
       // 制作 data mapping
       context.dataMap.set(id, item);
 

--- a/packages/hooks/src/components/use-tree/use-tree.type.ts
+++ b/packages/hooks/src/components/use-tree/use-tree.type.ts
@@ -129,7 +129,11 @@ export interface TreeDatum<DataItem> {
   setValue: (value?: KeygenResult[]) => void;
   setData: (data?: DataItem[]) => void;
   isDisabled: (id: KeygenResult) => boolean;
-  bindNode: (id: KeygenResult, update: UpdateFunc) => { active: boolean; expanded: boolean };
+  bindNode: (
+    id: KeygenResult,
+    update: UpdateFunc,
+    data: DataItem,
+  ) => { active: boolean; expanded: boolean };
   getDataById: (
     id: KeygenResult,
   ) => DataItem | { IS_NOT_MATCHED_VALUE: boolean; value: KeygenResult } | null;

--- a/packages/shineout/src/tree/__doc__/changelog.cn.md
+++ b/packages/shineout/src/tree/__doc__/changelog.cn.md
@@ -1,3 +1,16 @@
+## 3.4.3-beta.3
+2024-09-29
+
+### 🐞 BugFix
+
+- 修复 `Tree` 组件在开启 `loader` 情况下设置 `defaultExpandAll` 展开状态异常的问题 ([#699](https://github.com/sheinsight/shineout-next/pull/699))
+- 修复 `Tree` 组件 `setActive` 会触发多次的问题 ([#699](https://github.com/sheinsight/shineout-next/pull/699))
+
+### 🆕 Feature
+
+- `Tree` 组件 `setActive` 新增第二参当前选中节点数据数的返回 ([#699](https://github.com/sheinsight/shineout-next/pull/699))
+- 新增 `Tree` 类型 `KeygenResult` 导出 ([#699](https://github.com/sheinsight/shineout-next/pull/699))
+
 ## 3.4.2
 2024-09-29
 

--- a/packages/shineout/src/tree/interface.ts
+++ b/packages/shineout/src/tree/interface.ts
@@ -1,1 +1,2 @@
 export type { TreeProps as Props } from './tree.type';
+export type { KeygenResult } from '@sheinx/hooks';


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [x] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Changelog

- 修复 `Tree` 组件在开启 `loader` 情况下设置 `defaultExpandAll` 展开状态异常的问题
- 修复 `Tree` 组件 `setActive` 会触发多次的问题
- 新增 `Tree` 类型 `KeygenResult` 导出
- `Tree` 组件 `setActive` 新增第二参当前选中节点数据数的返回

### Other information

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 在树组件中添加了 `defaultExpandAll` 属性，允许用户配置树节点的默认展开行为。
  - 更新了 `bindNode` 方法，新增参数 `data`，增强了树节点的交互能力。

- **Bug 修复**
  - 优化了 `handleUpdateActive` 方法，确保状态更新逻辑更准确。

- **文档**
  - 导出 `KeygenResult` 类型，扩展了可用类型供其他模块使用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->