### PR TITLE
fix: 修正List和Select组件onChange的第2参的ts类型; 修正Tag的color的枚举类型

### DIFF
--- a/packages/base/src/list/list.type.ts
+++ b/packages/base/src/list/list.type.ts
@@ -148,7 +148,7 @@ export interface ListSelectProps<DataItem, Value> {
    * @en Select the row ,rowData is the selected data, rowIndex is the selected row number. If the data needs to be formatted, it is recommended to configure format
    * @cn 选择行。rowData 为选中的数据，rowIndex 为选中行号。如果需要数据需要格式化的处理，建议配置 format。
    */
-  onChange?: (value: Value, data: DataItem | DataItem[]) => void;
+  onChange?: (value: Value, data: DataItem, checked: boolean) => void;
   /**
    * @en By default, the result of the format function is used to compare whether it matches. In some cases (for example, whe an object that returns the original data is updated, an different option with the same value  is generated), the prediction function needs to be used to determine whether match
    * @cn 默认使用 format 函数执行的结果来比较是否匹配，在某些情况下（例如返回原始数据的对象，更新数据时，生成了一个值相同，非同一个对象的选项），需要借助 prediction 函数来判断是否匹配

--- a/packages/base/src/tag/tag.type.ts
+++ b/packages/base/src/tag/tag.type.ts
@@ -14,6 +14,7 @@ export type TagColorType =
   | 'magenta'
   | 'indigo'
   | 'tangerine'
+  | 'lemon'
   | 'neon';
 
 export type TagType = 'default' | 'info' | 'success' | 'warning' | 'danger';

--- a/packages/hooks/src/components/use-select/use-select.type.ts
+++ b/packages/hooks/src/components/use-select/use-select.type.ts
@@ -58,7 +58,7 @@ export interface BaseSelectProps<DataItem, Value> {
    * @en Change callback
    * @cn 值改变回调
    */
-  onChange?: (value: Value, data?: DataItem | DataItem[], checked?: boolean) => void;
+  onChange?: (value: Value, data?: DataItem, checked?: boolean) => void;
 
   /**
    * @en Group by

--- a/packages/shineout/src/list/__example__/04-select.tsx
+++ b/packages/shineout/src/list/__example__/04-select.tsx
@@ -61,8 +61,8 @@ const App: React.FC = () => {
     return 'indeterminate';
   };
 
-  const onChange: ListOnChange = (selectedValue) => {
-    console.log('selectValue: ', selectedValue);
+  const onChange: ListOnChange = (selectedValue, selectedDataItem, checked) => {
+    console.log('selectValue, selectedDataItem, checked: ', selectedValue, selectedDataItem, checked);
     setValue(selectedValue);
   };
 

--- a/packages/shineout/src/tag/__example__/s-004-color.tsx
+++ b/packages/shineout/src/tag/__example__/s-004-color.tsx
@@ -7,10 +7,14 @@
  *    -- Note that the `type` property will be deprecated, and the `color` property also supports the style of the same property value as type
  */
 
-import { Tag } from 'shineout';
+import { TYPE, Tag } from 'shineout';
+
+type TagColorType = Exclude<TYPE.Tag.Props['color'], undefined>
+type TagModeType = Exclude<TYPE.Tag.Props['mode'], undefined>
+
 export default () => {
-  const TagColor = ['tangerine', 'magenta', 'purple', 'indigo', 'cyan', 'neon', 'lemon', 'brown'];
-  const TagMode = ['bright', 'fill', 'outline', 'brightOutline'];
+  const TagColor: TagColorType[] = ['tangerine', 'magenta', 'purple', 'indigo', 'cyan', 'neon', 'lemon', 'brown'];
+  const TagMode: TagModeType[] = ['bright', 'fill', 'outline', 'brightOutline'];
 
   const capitalizeFirstLetter = (str: string) => {
     return str.charAt(0).toUpperCase() + str.slice(1);
@@ -22,7 +26,7 @@ export default () => {
         return (
           <div key={midx} style={{ marginBottom: 24 }}>
             {TagColor.map((color, cidx) => (
-              <Tag mode={mode as any} key={cidx} color={color as any}>
+              <Tag mode={mode} key={cidx} color={color}>
                 {capitalizeFirstLetter(color)}
               </Tag>
             ))}


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog
- 修正Select组件onChange的第2参的ts类型
- 修正List组件onChange的第2参的ts类型
- 修正Tag的color的枚举类型

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
  - 更新了列表组件的选择功能，允许更详细的选择状态记录。
  - 新增了“柠檬”颜色选项，扩展了标签的自定义颜色范围。

- **变更**
  - 修改了选择项的`onChange`方法签名，以支持单个数据项及其选中状态的传递。
  - 更新了标签组件的颜色和模式处理，增强了类型安全性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->