### PR TITLE
feat: Input.Group 同步支持 onBlur 事件

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.4.3-beta.3",
+  "version": "3.4.3-beta.4",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/input/input-group.tsx
+++ b/packages/base/src/input/input-group.tsx
@@ -16,12 +16,20 @@ export default (props: InputGroupProps) => {
     eventMap: new WeakMap(),
     propsMap: new WeakMap(),
   });
-  const { size, disabled, status, error } = useWithFormConfig(props);
+  const { size, disabled, status, error, onBlur } = useWithFormConfig(props);
 
   const getProps = (child: React.ReactElement) => {
+    const onChildBlur = (e: React.FocusEvent<HTMLElement>) => {
+      const childBlurEvent = child.props.onBlur;
+      if (childBlurEvent) {
+        childBlurEvent(e);
+      }
+      onBlur?.(e);
+    };
+
     ref.current.propsMap.set(child, {
       onFocus: child.props.onFocus,
-      onBlur: child.props.onBlur,
+      onBlur: onChildBlur,
     });
     if (!ref.current.eventMap.get(child)) {
       ref.current.eventMap.set(child, {

--- a/packages/base/src/input/input-group.type.ts
+++ b/packages/base/src/input/input-group.type.ts
@@ -17,5 +17,10 @@ export interface InputGroupProps {
    * @private 内部属性
    */
   error?: string | { message?: string };
+  /**
+   * @en The callback of blur
+   * @cn 失去焦点后的回调
+   */
+  onBlur?: React.FocusEventHandler;
   status?: CommonType['status'];
 }

--- a/packages/shineout/src/input/__doc__/changelog.cn.md
+++ b/packages/shineout/src/input/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.4.3-beta.4
+2024-10-09
+
+### 🐞 BugFix
+
+- `Input.Group` 同步支持 `onBlur` 事件 ([#701](https://github.com/sheinsight/shineout-next/pull/701))
+
 ## 3.4.2
 2024-09-29
 

--- a/packages/theme/src/token/figma.js
+++ b/packages/theme/src/token/figma.js
@@ -1281,13 +1281,6 @@ const figma = [
     locked: true,
   },
   {
-    name: '50%/radius',
-    value: '50%',
-    describe: '50% 全圆角',
-    token: 'Radius-50%',
-    locked: true,
-  },
-  {
     name: '基础阴影',
     value: '0px 2px 5px rgba(2, 11, 24, 0.1)',
     describe: '表格拖拽、树组件拖拽',

--- a/packages/theme/src/token/token.ts
+++ b/packages/theme/src/token/token.ts
@@ -186,7 +186,6 @@ const Token: Tokens = {
   'Radius-8': '8px',
   'Radius-12': '12px',
   'Radius-1000': '1000px',
-  'Radius-50%': '50%',
   'Shadow-1': '0px 2px 5px rgba(2, 11, 24, 0.1)',
   'Shadow-2': '0px 4px 10px rgba(2, 11, 24, 0.1)',
   'Shadow-3': '0px 8px 20px rgba(2, 11, 24, 0.1)',

--- a/packages/theme/src/token/type.ts
+++ b/packages/theme/src/token/type.ts
@@ -1283,13 +1283,6 @@ export interface Tokens {
   /**
    * @type {string}
    * @categoty string
-   * @default '50%'
-   * @description 50% 全圆角
-   */
-  'Radius-50%': string;
-  /**
-   * @type {string}
-   * @categoty string
    * @default '0px 2px 5px rgba(2, 11, 24, 0.1)'
    * @description 表格拖拽、树组件拖拽
    */


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

- Input.Group 同步支持 onBlur 事件

### Changelog

<!-- - Fix `Component` ... -->

### Other information

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 更新了 `InputGroup` 组件以更有效地处理失去焦点事件，新增了 `onBlur` 属性。
	- 添加了 `onChildBlur` 函数，确保子元素的失去焦点事件处理器与新的 `onBlur` 处理器按顺序执行。
	- 移除了与圆角半径相关的 `50%` 令牌，简化了设计令牌的定义。

- **文档**
	- 在 `InputGroupProps` 接口中添加了 `onBlur` 属性的文档注释，提供中英文说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->