### PR TITLE
fix: 修复 `Select` 开启absolute和multiple之后，下拉框较长选项的文字与勾选图标重叠的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.4.3-beta.3",
+  "version": "3.4.3-beta.5",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/select/list.tsx
+++ b/packages/base/src/select/list.tsx
@@ -34,6 +34,7 @@ const List = <DataItem, Value>(props: BaseListProps<DataItem, Value>) => {
     [styles.controlMouse]: controlType === 'mouse',
     [styles.controlKeyboard]: controlType === 'keyboard',
     [styles.dynamicList]: dynamicVirtual,
+    [styles.multipleList]: multiple,
   });
   const [hoverIndex, setHoverIndex] = useState(hideCreateOption ? -1 : 0);
   const virtualRef = useRef<VirtualListType>({

--- a/packages/base/src/select/select.type.ts
+++ b/packages/base/src/select/select.type.ts
@@ -53,6 +53,7 @@ export type SelectClasses = {
   arrowIcon: string;
   ellipsis: string;
   multiple: string;
+  multipleList: string;
   dynamicList: string;
   loading: string;
   checkedIcon: string;

--- a/packages/shineout-style/src/select/select.ts
+++ b/packages/shineout-style/src/select/select.ts
@@ -342,9 +342,6 @@ const selectStyle: JsStyles<SelectClassType> = {
     marginBottom: token.selectPlaceholderMarginY,
   },
   multiple: {
-    '& $optionInner': {
-      paddingRight: token.selectOptionInnerPaddingRight,
-    },
     '& $compressedWrapper': {
       flexWrap: 'nowrap',
     },
@@ -355,6 +352,11 @@ const selectStyle: JsStyles<SelectClassType> = {
   },
   multipleCompressedWrapper: {
     flexWrap: 'nowrap',
+  },
+  multipleList: {
+    '& $optionInner': {
+      paddingRight: token.selectOptionInnerPaddingRight,
+    },
   },
   loading: {
     padding: 10,

--- a/packages/shineout/src/select/__doc__/changelog.cn.md
+++ b/packages/shineout/src/select/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.4.3-beta.5
+2024-10-09
+
+### 🐞 BugFix
+- 修复 `Select` 开启absolute和multiple之后，下拉框较长选项的文字与勾选图标重叠的问题 ([#703](https://github.com/sheinsight/shineout-next/pull/703))
+
 ## 3.4.2
 2024-09-29
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Changelog
- 修复 `Select` 开启absolute和multiple之后，下拉框较长选项的文字与勾选图标重叠的问题