### PR TITLE
fix: 修复 `Image` 组件默认值错误的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.4.3-beta.7",
+  "version": "3.4.3-beta.8",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/image/image.tsx
+++ b/packages/base/src/image/image.tsx
@@ -24,7 +24,7 @@ const Image = (props: ImageProps) => {
     title,
     style,
     error,
-    target,
+    target = '_modal',
     jssStyle,
     className,
     placeholder,

--- a/packages/shineout/src/image/__doc__/changelog.cn.md
+++ b/packages/shineout/src/image/__doc__/changelog.cn.md
@@ -1,0 +1,7 @@
+## 3.4.3-beta.8
+2024-10-11
+
+### 🐞 BugFix
+
+- 修复 `Image` 组件默认值错误的问题 ([#708](https://github.com/sheinsight/shineout-next/pull/708))
+

--- a/packages/shineout/src/image/__test__/__snapshots__/image.spec.tsx.snap
+++ b/packages/shineout/src/image/__test__/__snapshots__/image.spec.tsx.snap
@@ -221,6 +221,7 @@ exports[`Image[Shape] should render correctly about shape is circle 1`] = `
 <div
   class="soui-image-image soui-image-fill soui-image-circle"
   style="width: 128px; padding-bottom: 128px;"
+  target="_modal"
 >
   <div
     class="soui-image-inner"
@@ -233,6 +234,7 @@ exports[`Image[Shape] should render correctly about shape is rounded 1`] = `
 <div
   class="soui-image-image soui-image-fill soui-image-rounded"
   style="width: 128px; padding-bottom: 128px;"
+  target="_modal"
 >
   <div
     class="soui-image-inner"
@@ -245,6 +247,7 @@ exports[`Image[Shape] should render correctly about shape is thumbnail 1`] = `
 <div
   class="soui-image-image soui-image-fill soui-image-thumbnail"
   style="width: 128px; padding-bottom: 128px;"
+  target="_modal"
 >
   <div
     class="soui-image-inner"

--- a/packages/shineout/src/upload/__test__/__snapshots__/upload.spec.tsx.snap
+++ b/packages/shineout/src/upload/__test__/__snapshots__/upload.spec.tsx.snap
@@ -225,6 +225,7 @@ exports[`Upload[Base] should render correctly about confirm 1`] = `
       <div
         class="soui-upload-image-bg soui-image-image soui-image-center soui-image-rounded"
         style="width: auto; padding-bottom: 0px;"
+        target="_modal"
       >
         <div
           class="soui-image-default-placeholder"
@@ -641,6 +642,7 @@ exports[`Upload[Base] should render correctly about recover 1`] = `
       <div
         class="soui-upload-image-bg soui-image-image soui-image-center soui-image-rounded"
         style="width: auto; padding-bottom: 0px;"
+        target="_modal"
       >
         <div
           class="soui-image-default-placeholder"


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others


### Changelog

- 修复 `Image` 组件默认值错误的问题

### Other information

1.x 2.x 默认为弹窗打开图片，< 3.4.3 版本默认值为当前页面打开
修复方式：将 3.x 的行为与老版本保持一致

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 在`Image`组件的属性中引入了`target`的默认值，默认设置为`'_modal'`。
  
- **版本更新**
	- 将版本号从`3.4.3-beta.7`更新至`3.4.3-beta.8`。

- **错误修复**
	- 修复了与`Image`组件相关的默认值错误。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->