### PR TITLE
fix: 修复 `Tag` 组件在点击关闭时触发 onClick 的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.4.3-beta.10",
+  "version": "3.4.3-beta.11",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/tag/use-tag.ts
+++ b/packages/base/src/tag/use-tag.ts
@@ -66,6 +66,7 @@ const useTag = (props: BaseTagProps) => {
   };
 
   const handleClose = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
     if (disabled || dismiss !== Finish) {
       return;
     }

--- a/packages/shineout/src/tag/__doc__/changelog.cn.md
+++ b/packages/shineout/src/tag/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.4.3-beta.11
+2024-10-12
+### 🐞 BugFix
+
+- 修复 `Tag` 组件在 `onClose` 时触发 onClick 的问题 ([#712](https://github.com/sheinsight/shineout-next/pull/712)) 
+
 ## 3.4.2
 2024-09-29
 ### 🐞 BugFix


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Changelog

- 修复 Tag 组件在点击关闭时触发 onClick 的问题

### Other information

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- 修复了标签关闭操作的事件处理，确保关闭操作不会触发父元素上的其他事件监听器。
- **版本更新**
	- 将版本号从 "3.4.3-beta.10" 更新至 "3.4.3-beta.11"。
- **文档更新**
	- 在变更日志中添加了版本 "3.4.3-beta.11" 的新条目，记录了相关的修复信息。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->