### PR TITLE
fix: 修复 `Table` 的width和ColumnItem的width的类型问题

### DIFF
--- a/packages/base/src/table/colgroup.tsx
+++ b/packages/base/src/table/colgroup.tsx
@@ -1,6 +1,6 @@
 interface ColgroupProps {
-  colgroup?: (number | undefined)[];
-  columns?: { key: string | number; width?: number }[];
+  colgroup?: (number | string | undefined)[];
+  columns?: { key: string | number; width?: number | string }[];
   shouldLastColAuto: boolean;
 }
 const Colgroup = (props: ColgroupProps) => {

--- a/packages/base/src/table/table.type.ts
+++ b/packages/base/src/table/table.type.ts
@@ -227,7 +227,7 @@ export interface TableProps<DataItem, Value>
    * @en TThe total width of the table, which defaults to the container width, must not be less than the sum of width set in columns
    * @cn 表格总宽度，默认为容器宽度，不可小于 columns 中设置的 width 之和
    */
-  width?: number;
+  width?: number | string;
   /**
    * @en array，see TableColumn
    * @cn 数组，见 TableColumn

--- a/packages/base/src/table/tbody.type.ts
+++ b/packages/base/src/table/tbody.type.ts
@@ -26,7 +26,7 @@ export interface TbodyProps
   > {
   columns: TableFormatColumn<any>[];
   data: any[];
-  colgroup: (number | undefined)[];
+  colgroup: (number | string | undefined)[];
   isScrollX: boolean;
   currentIndex?: number;
   expandHideCol: UseColumnsResult['expandHideCol'];

--- a/packages/base/src/table/tfoot.tsx
+++ b/packages/base/src/table/tfoot.tsx
@@ -4,7 +4,7 @@ import { TfootProps, SummaryItem } from './tfoot.type';
 import { util } from '@sheinx/hooks';
 import { useConfig } from '../config';
 import type { ObjectType } from '@sheinx/hooks';
-const { isArray } = util;
+const { isArray, toNum } = util;
 
 export default (props: TfootProps) => {
   const tableClasses = props.jssStyle?.table?.();
@@ -22,7 +22,7 @@ export default (props: TfootProps) => {
           transform: `translate3d(${props.fixLeftNum}px, 0, 0)`,
         } as React.CSSProperties;
       }
-      const left = colgroup.slice(0, index).reduce((a, b) => (a || 0) + (b || 0), 0);
+      const left = colgroup.slice(0, index).reduce((a, b) => toNum(a) + toNum(b), 0);
       return {
         left: left,
         position: 'sticky',
@@ -34,7 +34,7 @@ export default (props: TfootProps) => {
           transform: `translate3d(-${props.fixRightNum}px, 0, 0)`,
         } as React.CSSProperties;
       }
-      const right = colgroup.slice(index + colSpan).reduce((a, b) => (a || 0) + (b || 0), 0);
+      const right = colgroup.slice(index + colSpan).reduce((a, b) => toNum(a) + toNum(b), 0);
       return {
         right: right,
         position: 'sticky',

--- a/packages/base/src/table/tfoot.type.ts
+++ b/packages/base/src/table/tfoot.type.ts
@@ -7,5 +7,5 @@ export interface TfootProps
   fixLeftNum?: number;
   fixRightNum?: number;
   columns: TableFormatColumn<any>[];
-  colgroup: (number | undefined)[];
+  colgroup: (number | string | undefined)[];
 }

--- a/packages/base/src/table/thead.tsx
+++ b/packages/base/src/table/thead.tsx
@@ -1,11 +1,13 @@
 import React, { useRef } from 'react';
 import { TheadProps } from './thead.type';
-import { useTableGroup, useDragMock, usePersistFn } from '@sheinx/hooks';
+import { useTableGroup, useDragMock, usePersistFn, util } from '@sheinx/hooks';
 import type { TableFormatColumn, TableHeadColumn, TableGroupColumn } from '@sheinx/hooks';
 import Icons from '../icons';
 import classNames from 'classnames';
 import Checkbox from '../checkbox';
 import { useConfig } from '../config';
+
+const { toNum } = util;
 
 export default (props: TheadProps) => {
   const { colgroup = [], sortInfo, onSorterChange, showSelectAll = true } = props;
@@ -120,7 +122,7 @@ export default (props: TheadProps) => {
           transform: `translate3d(${props.fixLeftNum}px, 0, 0)`,
         } as React.CSSProperties;
       }
-      const left = colgroup.slice(0, index).reduce((a, b) => (a || 0) + (b || 0), 0);
+      const left = colgroup.slice(0, index).reduce((a, b) => toNum(a) + toNum(b), 0);
       return {
         left: left,
         position: 'sticky',
@@ -132,7 +134,7 @@ export default (props: TheadProps) => {
           transform: `translate3d(${0 - props.fixRightNum}px, 0, 0)`,
         } as React.CSSProperties;
       }
-      const right = colgroup.slice(index + colSpan).reduce((a, b) => (a || 0) + (b || 0), 0);
+      const right = colgroup.slice(index + colSpan).reduce((a, b) => toNum(a) + toNum(b), 0);
       return {
         right: right,
         position: 'sticky',

--- a/packages/base/src/table/thead.type.ts
+++ b/packages/base/src/table/thead.type.ts
@@ -22,7 +22,7 @@ export interface TheadProps
   columns: TableFormatColumn<any>[];
   isScrollY?: boolean;
   bordered?: boolean;
-  colgroup: (number | undefined)[];
+  colgroup: (number | string | undefined)[];
   datum: ListDatum;
   fixLeftNum?: number;
   fixRightNum?: number;

--- a/packages/base/src/table/tr.tsx
+++ b/packages/base/src/table/tr.tsx
@@ -9,6 +9,7 @@ import Radio from '../radio';
 import { TbodyProps, UseTableRowResult } from './tbody.type';
 import { useConfig } from '../config';
 
+const { toNum } = util;
 interface TrProps
   extends Pick<
     TbodyProps,
@@ -40,7 +41,7 @@ interface TrProps
   rowIndex: number;
   columns: TableFormatColumn<any>[];
   isScrollX: boolean;
-  colgroup: (number | undefined)[];
+  colgroup: (number | string |undefined)[];
   rawData: any;
   expanded: boolean;
   expandCol: TbodyProps['expandHideCol'] | undefined;
@@ -72,7 +73,7 @@ const Tr = (props: TrProps) => {
           transform: `translate3d(${props.fixLeftNum}px, 0, 0)`,
         } as React.CSSProperties;
       }
-      const left = props.colgroup.slice(0, index).reduce((a, b) => (a || 0) + (b || 0), 0);
+      const left = props.colgroup.slice(0, index).reduce((a, b) => toNum(a) + toNum(b), 0);
       return {
         position: 'sticky',
         left,
@@ -84,7 +85,7 @@ const Tr = (props: TrProps) => {
           transform: `translate3d(${0 - props.fixRightNum}px, 0, 0)`,
         } as React.CSSProperties;
       }
-      const right = props.colgroup.slice(index + colSpan).reduce((a, b) => (a || 0) + (b || 0), 0);
+      const right = props.colgroup.slice(index + colSpan).reduce((a, b) => toNum(a) + toNum(b), 0);
 
       return {
         position: 'sticky',

--- a/packages/base/src/virtual-scroll/scroll.tsx
+++ b/packages/base/src/virtual-scroll/scroll.tsx
@@ -4,7 +4,7 @@ import { useConfig } from '../config';
 
 interface scrollProps {
   scrollHeight: number;
-  scrollWidth: number;
+  scrollWidth: number | string;
   height?: number | string;
   children: React.ReactNode;
   childrenStyle?: React.CSSProperties;

--- a/packages/hooks/src/components/use-table/use-table-layout.tsx
+++ b/packages/hooks/src/components/use-table/use-table-layout.tsx
@@ -6,6 +6,7 @@ import { addResizeObserver } from '../../utils/dom/element';
 import { TableFormatColumn, BaseTableProps } from './use-table.type';
 import { KeygenResult } from '../../common/type';
 import { isFunc, isNumber } from '../../utils/is';
+import { toNum } from '../../utils/number';
 
 const MIN_RESIZABLE_WIDTH = 20;
 
@@ -104,7 +105,7 @@ const useTableLayout = (props: UseTableLayoutProps) => {
     setResizeFlag((v) => (v + 1) % 10);
   };
 
-  const changeColGroup = (cols: Array<number | undefined>, adjust: boolean | 'drag') => {
+  const changeColGroup = (cols: Array<number | string | undefined>, adjust: boolean | 'drag') => {
     // 修改`Table`被display:none时，表格头样式错乱的问题
     if(cols && cols.every((v) => v === 0)) return
 
@@ -120,7 +121,7 @@ const useTableLayout = (props: UseTableLayoutProps) => {
     if (!props.columnResizable) return;
     if (!colgroup) return;
 
-    const deltaX = context.dragWidth - colgroup[index]!;
+    const deltaX = context.dragWidth - toNum(colgroup[index]);
 
     const newColgroup = [...colgroup];
     newColgroup[index] = context.dragWidth;
@@ -170,14 +171,14 @@ const useTableLayout = (props: UseTableLayoutProps) => {
         tempcols = [width];
       } else if (emptyNum === 0) {
         // 都有宽度按照比例分
-        const all = dfWidth.reduce((a, b) => a! + b!, 0)!;
-        tempcols = dfWidth.map((v) => (v! / all) * width);
+        const all = dfWidth.reduce((a, b) => toNum(a) + toNum(b), 0)!;
+        tempcols = dfWidth.map((v) => (toNum(v) / toNum(all)) * width);
       } else {
         // 多余的平分
-        const all = dfWidth.reduce((a, b) => (a || 0) + (b || 0), 0)!;
+        const all = dfWidth.reduce((a, b) => toNum(a) + toNum(b), 0) as number;
         const rest = width - all;
         const agv = rest > 0 ? rest / emptyNum : 0;
-        tempcols = dfWidth.map((v) => (v ? v : agv));
+        tempcols = dfWidth.map((v) => (v ? toNum(v) : agv));
       }
       index += colspanNum;
       newCols = [...newCols, ...tempcols];

--- a/packages/hooks/src/components/use-table/use-table.type.ts
+++ b/packages/hooks/src/components/use-table/use-table.type.ts
@@ -87,7 +87,7 @@ export interface BaseTableProps<Item> {
    * @en TThe total width of the table, which defaults to the container width, must not be less than the sum of width set in columns
    * @cn 表格总宽度，默认为容器宽度，不可小于 columns 中设置的 width 之和
    */
-  width?: number;
+  width?: number | string;
   /**
    * @en controlled expand rows
    * @cn 展开行受控
@@ -264,7 +264,7 @@ export interface TableColumnItem<DataItem> {
    * @en width
    * @cn 列宽
    */
-  width?: number;
+  width?: number | string;
 
   /**
    * @cn 列对应的类名

--- a/packages/hooks/src/utils/number.ts
+++ b/packages/hooks/src/utils/number.ts
@@ -63,3 +63,20 @@ export function sub(num1: number, num2: number) {
   const maxPrediction = Math.max(getNumberPrecision(num1), getNumberPrecision(num2));
   return Number(number.toFixed(maxPrediction));
 }
+
+export function toNum(v: number | string | undefined): number {
+  if (v === undefined || v === null) {
+    return 0;
+  }
+
+  if (typeof v === 'number') {
+    return isNaN(v) ? 0 : v;
+  }
+
+  if (typeof v === 'string') {
+    const parsedValue = parseFloat(v);
+    return isNaN(parsedValue) ? 0 : parsedValue;
+  }
+
+  return 0;
+}

--- a/packages/shineout/src/table/__doc__/changelog.cn.md
+++ b/packages/shineout/src/table/__doc__/changelog.cn.md
@@ -1,3 +1,11 @@
+## 3.4.3
+2024-10-12
+
+### 🐞 BugFix
+
+- 修复 `Table` 的width和ColumnItem的width的类型问题 ([#717](https://github.com/sheinsight/shineout-next/pull/717))
+
+
 ## 3.4.2
 2024-09-29
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Changelog
- 修复 `Table` 的width和ColumnItem的width的类型问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了表格组件的列组和宽度属性，支持更多类型（数字和字符串）。
	- 引入了新的实用函数 `toNum`，确保数值处理的一致性。
- **错误修复**
	- 修复了与表格组件相关的类型问题，特别是表格和列项的宽度设置。
- **文档**
	- 更新了版本3.4.3的变更日志。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->