### PR TITLE
fix: 移除defaultProps的使用

### DIFF
--- a/packages/base/src/checkbox/checkbox-group.tsx
+++ b/packages/base/src/checkbox/checkbox-group.tsx
@@ -6,7 +6,12 @@ import React from 'react';
 import classNames from 'classnames';
 import useWithFormConfig from '../common/use-with-form-config';
 
+const defaultFormat = (d: any) => d;
+const defaultRenderItem = (d: any) => d;
+
+
 const Group = <DataItem, Value extends any[]>(props0: CheckboxGroupProps<DataItem, Value>) => {
+  const {format = defaultFormat, renderItem = defaultRenderItem} = props0
   const props = useWithFormConfig(props0);
   const { children, className, block, keygen, jssStyle, size, style, disabled } = props;
   const checkboxStyle = jssStyle?.checkbox?.();
@@ -25,7 +30,7 @@ const Group = <DataItem, Value extends any[]>(props0: CheckboxGroupProps<DataIte
     prediction: props.prediction,
     separator: props.separator,
     disabled,
-    format: props.format,
+    format: format,
     keygen: props.keygen,
     data: props.data || ([] as DataItem[]),
   };
@@ -51,7 +56,6 @@ const Group = <DataItem, Value extends any[]>(props0: CheckboxGroupProps<DataIte
   });
 
   const getContent = (d: DataItem, index: number) => {
-    const { renderItem } = props;
     if (typeof renderItem === 'string' && d) {
       return (d as any)[renderItem] as unknown as React.ReactNode;
     }
@@ -109,10 +113,6 @@ const Group = <DataItem, Value extends any[]>(props0: CheckboxGroupProps<DataIte
       </div>
     );
   }
-};
-Group.defaultProps = {
-  format: (d: any) => d,
-  renderItem: (d: any) => d,
 };
 
 export default Group;

--- a/packages/base/src/radio/radio-group.tsx
+++ b/packages/base/src/radio/radio-group.tsx
@@ -7,7 +7,11 @@ import classNames from 'classnames';
 import useWithFormConfig from '../common/use-with-form-config';
 import Button from '../button/button';
 
+const defaultFormat = (d: any) => d;
+const defaultRenderItem = (d: any) => d;
+
 const Group = <DataItem, Value>(props0: RadioGroupProps<DataItem, Value>) => {
+  const {format = defaultFormat, renderItem = defaultRenderItem} = props0
   const props = useWithFormConfig(props0);
 
   const { children, className, button, block, keygen, jssStyle, style, size, disabled  } = props;
@@ -26,7 +30,7 @@ const Group = <DataItem, Value>(props0: RadioGroupProps<DataItem, Value>) => {
     onChange: inputAbleProps.onChange,
     prediction: props.prediction,
     disabled,
-    format: props.format,
+    format: format,
     keygen: props.keygen,
     data: props.data || ([] as DataItem[]),
   };
@@ -46,7 +50,6 @@ const Group = <DataItem, Value>(props0: RadioGroupProps<DataItem, Value>) => {
   });
 
   const getContent = (d: DataItem, index: number) => {
-    const { renderItem } = props;
     if (typeof renderItem === 'string') {
       return d[renderItem] as unknown as React.ReactNode;
     }
@@ -133,10 +136,6 @@ const Group = <DataItem, Value>(props0: RadioGroupProps<DataItem, Value>) => {
       {Radios}
     </div>
   );
-};
-Group.defaultProps = {
-  format: (d: any) => d,
-  renderItem: (d: any) => d,
 };
 
 export default Group;

--- a/packages/shineout/src/checkbox/__doc__/changelog.cn.md
+++ b/packages/shineout/src/checkbox/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.4.4-beta.7
+2024-10-16
+### 🐞 BugFix
+
+- 修复`Checkbox.Group`在React 18.3.0以上版本中报defaultProps告警的问题 ([#725](https://github.com/sheinsight/shineout-next/pull/725))
+
+
 ## 3.4.3
 2024-10-14
 ### 🐞 BugFix

--- a/packages/shineout/src/radio/__doc__/changelog.cn.md
+++ b/packages/shineout/src/radio/__doc__/changelog.cn.md
@@ -1,0 +1,5 @@
+## 3.4.4-beta.7
+2024-10-16
+### 🐞 BugFix
+
+- 修复`Radio.Group`在React 18.3.0以上版本中报defaultProps告警的问题 ([#725](https://github.com/sheinsight/shineout-next/pull/725))


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 更新了复选框组和单选框组组件，增加了默认的格式化和渲染函数，提升了组件的灵活性和可配置性。
	- 组件逻辑更加简化，提高了代码的可读性和一致性。
- **错误修复**
	- 修复了在 React 18.3.0 及以上版本中，复选框组和单选框组组件触发的 `defaultProps` 警告问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->