### PR TITLE
fix: 修复 React 18.3.0 以上版本 key 字段报错的问题

### DIFF
--- a/packages/base/src/date-picker/picker.tsx
+++ b/packages/base/src/date-picker/picker.tsx
@@ -47,7 +47,6 @@ const Picker = (props: PickerProps) => {
     const mode = props.mode[index];
 
     const commonProps = {
-      key: position,
       options,
       value: dateArr[index],
       current: currentArr[index],
@@ -85,18 +84,19 @@ const Picker = (props: PickerProps) => {
       secondStep: props.secondStep,
     };
     if (mode === 'quarter') {
-      return <Quarter {...commonProps} />;
+      return <Quarter key={position} {...commonProps} />;
     }
 
     if (mode === 'year') {
-      return <Year {...commonProps} />;
+      return <Year key={position} {...commonProps} />;
     }
     if (mode === 'month') {
-      return <Month {...commonProps} />;
+      return <Month key={position} {...commonProps} />;
     }
     if (mode === 'day') {
       return (
         <Day
+          key={position}
           {...commonProps}
           {...timeProps}
           onDoubleClick={(item, type) => {
@@ -121,9 +121,9 @@ const Picker = (props: PickerProps) => {
       );
     }
     if (mode === 'time') {
-      return <Time {...commonProps} {...timeProps} />;
+      return <Time key={position} {...commonProps} {...timeProps} />;
     }
-    return <Day {...commonProps} {...timeProps} />;
+    return <Day key={position} {...commonProps} {...timeProps} />;
   };
 
   return (
@@ -146,19 +146,17 @@ const Picker = (props: PickerProps) => {
       {range ? (
         <div className={styles?.pickerRange}>
           <div className={styles?.pickerRangeBody}>
-            {
-              ['start', 'end'].map((item) => renderPicker(item as 'start' | 'end'))
-            }
+            {['start', 'end'].map((item) => renderPicker(item as 'start' | 'end'))}
           </div>
-          {
-            props.needConfirm && (
-              <div className={styles?.pickerRangeFooter}>
-                <Confirm closeByConfirm={closeByConfirm} jssStyle={jssStyle} />
-              </div>
-            )
-          }
+          {props.needConfirm && (
+            <div className={styles?.pickerRangeFooter}>
+              <Confirm closeByConfirm={closeByConfirm} jssStyle={jssStyle} />
+            </div>
+          )}
         </div>
-      ) : renderPicker()}
+      ) : (
+        renderPicker()
+      )}
     </div>
   );
 };

--- a/packages/shineout/src/date-picker/__doc__/changelog.cn.md
+++ b/packages/shineout/src/date-picker/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.4.4-beta.2
+2024-10-15
+
+### 🐞 BugFix
+
+- 修复 `Datepicker` 组件 key 值书写问题，解决 React 18.3.0 以上版本 key 字段报错的问题 ([#726](https://github.com/sheinsight/shineout-next/pull/726))
+
 ## 3.4.1
 2024-09-20
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Changelog

- 修复 React 18.3.0 以上版本 key 字段报错的问题

### Other information

React 18.3.0 起，以解构的形式赋予元素 key 会抛出警告 https://github.com/facebook/react/releases/tag/v18.3.0

<img width="764" alt="react" src="https://github.com/user-attachments/assets/b8fcc5a2-eec8-4471-a78b-f0b89e9c3e01">




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 更新了日期选择器组件的版本至 `3.4.4-beta.2`，修复了与 React 18.3.0 及以上版本相关的键值写入问题。
- **错误修复**
	- 修复了日期选择器中的键字段错误，提升了组件的稳定性。
- **文档**
	- 更新了变更日志，详细列出了各版本的更新内容和修复记录。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->