### PR TITLE
fix: 修复框类组件鼠标按下实际失效的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.4.4-beta.2",
+  "version": "3.4.4-beta.3",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/cascader/cascader.tsx
+++ b/packages/base/src/cascader/cascader.tsx
@@ -25,9 +25,6 @@ import useWithFormConfig from '../common/use-with-form-config';
 import useTip from '../common/use-tip';
 import { useConfig, getLocale } from '../config';
 
-const preventDefault = (e: React.MouseEvent) => {
-  e.preventDefault();
-};
 const Cascader = <DataItem, Value extends KeygenResult[]>(
   props0: CascaderProps<DataItem, Value>,
 ) => {
@@ -712,11 +709,6 @@ const Cascader = <DataItem, Value extends KeygenResult[]>(
       onFocus={handleFocus}
       onKeyDown={handleKeyDown}
       ref={targetRef}
-      onMouseDown={(e) => {
-        if (focused && e.target !== inputRef.current) {
-          e.preventDefault();
-        }
-      }}
     >
       {tipNode}
       {renderResult()}
@@ -740,7 +732,6 @@ const Cascader = <DataItem, Value extends KeygenResult[]>(
           type='scale-y'
           duration={'fast'}
           style={pickerWrapperStyle}
-          onMouseDown={preventDefault}
         >
           {renderPanel()}
         </AnimationList>

--- a/packages/base/src/select/select.tsx
+++ b/packages/base/src/select/select.tsx
@@ -27,10 +27,6 @@ import useWithFormConfig from '../common/use-with-form-config';
 import useTip from '../common/use-tip';
 import { getLocale, useConfig } from '../config';
 
-const preventDefault = (e: React.MouseEvent) => {
-  e.preventDefault();
-};
-
 function Select<DataItem, Value>(props0: SelectPropsBase<DataItem, Value>) {
   const props = useWithFormConfig(props0);
   const { locale, direction } = useConfig();
@@ -731,11 +727,6 @@ function Select<DataItem, Value>(props0: SelectPropsBase<DataItem, Value>) {
       onKeyUp={handleKeyUp}
       onBlur={handleBlur}
       onFocus={handleFocus}
-      onMouseDown={(e) => {
-        if (focused && e.target !== inputRef.current) {
-          e.preventDefault();
-        }
-      }}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
@@ -762,7 +753,6 @@ function Select<DataItem, Value>(props0: SelectPropsBase<DataItem, Value>) {
             size === 'large' && styles?.pickerLarge,
           )}
           onAnimationAfterEnter={onAnimationAfterEnter}
-          onMouseDown={preventDefault}
           display={'block'}
           type='scale-y'
           // type='fade'

--- a/packages/base/src/tree-select/tree-select.tsx
+++ b/packages/base/src/tree-select/tree-select.tsx
@@ -25,9 +25,7 @@ import useTip from '../common/use-tip';
 import { getLocale, useConfig } from '../config';
 
 export type TreeSelectValueType = KeygenResult | KeygenResult[];
-const preventDefault = (e: React.MouseEvent) => {
-  e.preventDefault();
-};
+
 const TreeSelect = <DataItem, Value extends TreeSelectValueType>(
   props0: TreeSelectProps<DataItem, Value>,
 ) => {
@@ -656,11 +654,6 @@ const TreeSelect = <DataItem, Value extends TreeSelectValueType>(
       onBlur={handleBlur}
       onFocus={handleFocus}
       onKeyDown={handleKeyDown}
-      onMouseDown={(e) => {
-        if (focused && e.target !== inputRef.current) {
-          e.preventDefault();
-        }
-      }}
     >
       {tipNode}
       {renderResult()}
@@ -678,7 +671,6 @@ const TreeSelect = <DataItem, Value extends TreeSelectValueType>(
       >
         <AnimationList
           onRef={popupRef}
-          onMouseDown={preventDefault}
           show={open}
           className={classNames(styles?.pickerWrapper)}
           display={'block'}

--- a/packages/shineout/src/cascader/__doc__/changelog.cn.md
+++ b/packages/shineout/src/cascader/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.4.4-beta.3
+2024-10-15
+
+### 🐞 BugFix
+- 修复 `Cascader` 组件无法拖拽选中 dom 内容的问题 ([#729](https://github.com/sheinsight/shineout-next/pull/729))
+
+
 ## 3.3.6
 2024-09-02
 

--- a/packages/shineout/src/select/__doc__/changelog.cn.md
+++ b/packages/shineout/src/select/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.4.4-beta.3
+2024-10-15
+
+### 🐞 BugFix
+- 修复 `Select` 组件无法拖拽选中 dom 内容的问题 ([#729](https://github.com/sheinsight/shineout-next/pull/729))
+
 ## 3.4.3
 2024-10-14
 

--- a/packages/shineout/src/tree-select/__doc__/changelog.cn.md
+++ b/packages/shineout/src/tree-select/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.4.4-beta.3
+2024-10-15
+
+### 🐞 BugFix
+- 修复 `TreeSelect` 组件无法拖拽选中 dom 内容的问题 ([#729](https://github.com/sheinsight/shineout-next/pull/729))
+
 ## 3.4.0
 2024-09-19
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

框类组件在触发 onMouseDown 时会引发输入框模式失去焦点，如果阻止事件将引起无法拖拽选中 dom 内容

历史相关修改：https://github.com/sheinsight/shineout-next/pull/304/files#diff-be40b1bfb6fd5e09f38b7996cafc3b4ee2d4f0711825fab2d46e3ecf68e4997d

### Changelog

- 修复框类组件鼠标按下实际失效的问题

### Other information

dom 文本选中 和 输入框保持聚焦 两个行为为互斥交互，无需特地保持 input 聚焦状态

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 优化了 `Cascader`、`Select` 和 `TreeSelect` 组件的鼠标事件处理逻辑，简化了用户交互体验。
- **错误修复**
	- 移除了对默认鼠标事件的阻止，改善了组件的响应性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->