### PR TITLE
fix: 修复 `Popover.Confirm` 的弹出容器的宽度在Table中有可能显示较窄的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.4.4-beta.7",
+  "version": "3.4.4-beta.8",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/utils/position.ts
+++ b/packages/hooks/src/utils/position.ts
@@ -75,22 +75,23 @@ const getPopoverPosition = (
     if (verticalPoint > windowHeight / 2) position = 'top';
     else position = 'bottom';
 
+    // TODO: 暂时移除，另考虑方案
     // 如果渲染了弹出内容，则根据弹出内容宽度计算是否自动调整位置
-    if (popupRect) {
-      if (popupRect?.width / 2 > rect.left) {
-        position += '-left';
-      }
-      if (popupRect?.width / 2 > windowWidth - rect.right) {
-        position += '-right';
-      }
-    } else {
-      // 兜底计算
-      if (horizontalPoint > windowWidth * 0.6) {
-        position += '-right';
-      } else if (horizontalPoint < windowWidth * 0.4) {
-        position += '-left';
-      }
+    // if (popupRect && popupRect?.width) {
+    //   if (popupRect?.width / 2 > rect.left) {
+    //     position += '-left';
+    //   }
+    //   if (popupRect?.width / 2 > windowWidth - rect.right) {
+    //     position += '-right';
+    //   }
+    // } else {
+    // 兜底计算
+    if (horizontalPoint > windowWidth * 0.6) {
+      position += '-right';
+    } else if (horizontalPoint < windowWidth * 0.4) {
+      position += '-left';
     }
+    // }
   }
   return position as PopoverPosition;
 };

--- a/packages/shineout/src/popover/__doc__/changelog.cn.md
+++ b/packages/shineout/src/popover/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.4.4-beta.8
+2024-10-17
+
+### 🐞 BugFix
+- 修复 `Popover.Confirm` 的弹出容器的宽度在Table中有可能显示较窄的问题 ([#736](https://github.com/sheinsight/shineout-next/pull/736))
+
+
 ## 3.4.3
 2024-10-14
 

--- a/packages/shineout/src/textarea/__test__/textarea.spec.tsx
+++ b/packages/shineout/src/textarea/__test__/textarea.spec.tsx
@@ -29,7 +29,6 @@ const {
   wrapperSmall: textareaSmallClassName,
   shadow: textareaShadowClassName,
   info: textareaInfoClassName,
-  infoError: textareaInfoErrorClassName,
   footer: textareaFooterClassName,
   wrapperUnderline: textareaUnderlineClassName,
   wrapperNoBorder: textareaNoBorderClassName,
@@ -152,7 +151,7 @@ describe('Textarea[Info:function]', () => {
     await waitFor(async () => {
       await delay(200);
     });
-    classLengthTest(container, textareaInfoClassName, 1);
+    expect(document.querySelectorAll(textareaInfoClassName).length).toBe(1);
   });
   test('should render tip we want', () => {
     const { container } = render(<TextareaInfoFunction />);
@@ -161,11 +160,13 @@ describe('Textarea[Info:function]', () => {
     fireEvent.change(textareaWrapper, {
       target: { value: 'test' },
     });
-    textContentTest(container.querySelector(textareaInfoClassName)!, 'total is  4');
+    // 示例中把提示信息render到body上了，所以这里需要document.querySelector
+    textContentTest(document.querySelector(textareaInfoClassName)!, 'total is  4');
     fireEvent.change(textareaWrapper, {
       target: { value: 'testtesttesttesttesttest' },
     });
-    classTest(container.querySelector(textareaInfoClassName)!, textareaInfoErrorClassName);
+    // 错误信息时，期望container下没有textareaInfoClassName的元素
+    expect(document.querySelectorAll(textareaInfoClassName).length).toBe(0);
   });
 });
 describe('Textarea[Info:number]', () => {
@@ -178,8 +179,7 @@ describe('Textarea[Info:number]', () => {
   test('should render when not set value', () => {
     const { container } = render(<Textarea info={20} />);
     expect(
-      container.querySelectorAll(textareaInfoClassName).length ||
-        container.querySelectorAll('.' + textareaInfoErrorClassName).length,
+      container.querySelectorAll(textareaInfoClassName).length
     ).toBe(0);
   });
   test('should render tip', () => {
@@ -196,7 +196,8 @@ describe('Textarea[Info:number]', () => {
     fireEvent.change(container.querySelector('textarea') as HTMLTextAreaElement, {
       target: { value: '1234456789012345678901' },
     });
-    textContentTest(container.querySelector('.' + textareaInfoErrorClassName)!, '22 / 20');
+    const selector = `.soui-popover-wrapper[data-soui-type="error"] .soui-popover-text`
+    textContentTest(container.querySelector(selector)!, '22 / 20');
   });
 });
 describe('Textarea[Trim]', () => {


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others


### Changelog
- 修复 `Popover.Confirm` 的弹出容器的宽度在Table中有可能显示较窄的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 更新了版本号至 `3.4.4-beta.8`。
	- 在变更日志中新增了关于 `Popover.Confirm` 组件的修复信息。

- **错误修复**
	- 修复了在表格上下文中 `Popover.Confirm` 弹出容器宽度过窄的问题。
	- 修复了在极端边界情况下 `Popover` 可见性的问题。

- **测试**
	- 更新了 `Textarea` 组件的测试，以反映新的信息和错误显示逻辑。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->