### PR TITLE
fix: 修复 `Popover` 在横滚的Table中有可能弹出位置不准确的问题

### DIFF
--- a/packages/hooks/src/common/use-position-style/index.ts
+++ b/packages/hooks/src/common/use-position-style/index.ts
@@ -155,7 +155,7 @@ export const usePositionStyle = (config: PositionStyleConfig) => {
     }
     let targetPosition = position;
     const rootContainer = getContainer() || document.body;
-    const closestScrollContainer = getClosestScrollContainer(parentElRef.current);
+    const closestScrollContainer = absolute ? null : getClosestScrollContainer(parentElRef.current);
 
     const containerRect = rootContainer.getBoundingClientRect();
     const bodyRect = (document.documentElement || document.body).getBoundingClientRect();

--- a/packages/shineout/src/popover/__doc__/changelog.cn.md
+++ b/packages/shineout/src/popover/__doc__/changelog.cn.md
@@ -3,6 +3,8 @@
 
 ### 🐞 BugFix
 - 修复 `Popover.Confirm` 的弹出容器的宽度在Table中有可能显示较窄的问题 ([#736](https://github.com/sheinsight/shineout-next/pull/736))
+### 🐞 BugFix
+- 修复 `Popover` 在横滚的Table中有可能弹出位置不准确的问题 ([#741](https://github.com/sheinsight/shineout-next/pull/741))
 
 
 ## 3.4.3


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Changelog
- 修复 `Popover` 在横滚的Table中有可能弹出位置不准确的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 无新功能引入，但对绝对定位逻辑进行了细微调整。
  
- **错误修复**
	- 更新了 `Popover` 组件的变更日志，修复了多个版本中的错误，包括：
		- 修复了 `Popover.Confirm` 在表格中显示时的宽度问题。
		- 解决了在水平滚动表格中 `Popover` 位置不准确的问题。
		- 修复了在极限边界情况下 `Popover` 的可见性问题。
		- 修复了 `Popover` 中子元素点击时的事件冒泡问题。
		- 修复了 `autoFocus` 功能导致的页面滚动问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->