### PR TITLE
fix: 修复 Form.Field defaultValue 在部分场景下失效的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.4.4-beta.8",
+  "version": "3.4.4-beta.9",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-form/use-form-control/use-form-control.ts
+++ b/packages/hooks/src/components/use-form/use-form-control/use-form-control.ts
@@ -79,18 +79,38 @@ export default function useFormControl<T>(props: BaseFormControlProps<T>) {
   const update = usePersistFn(
     (formValue: ObjectType = {}, errors: ObjectType, severErrors: ObjectType) => {
       if (!name) return;
-      const value = getValue(name, formValue) as T;
-      const error = getError(name, errors, severErrors);
-      if (error !== errorState) {
-        setErrorState(error);
-      }
-      if (!shallowEqual(value, latestInfo.valueState)) {
-        if (value === undefined && defaultValue !== undefined) {
-          setValueState(defaultValue);
-        } else {
-          setValueState(value);
+
+      if (isArray(name)) {
+        const value = getValue(name, formValue) as T[];
+        const error = getError(name, errors, severErrors);
+        if (error !== errorState) {
+          setErrorState(error);
         }
-        latestInfo.valueState = value;
+        // format defaultValue
+        const dv = isArray(defaultValue) ? defaultValue : [];
+        const nextValue = [] as T[];
+        name.forEach((n, index) => {
+          if (value[index] === undefined && dv[index] !== undefined) {
+            nextValue[index] = dv[index];
+          } else {
+            nextValue[index] = value[index];
+          }
+        });
+        setValueState(nextValue as T);
+      } else {
+        const value = getValue(name, formValue) as T;
+        const error = getError(name, errors, severErrors);
+        if (error !== errorState) {
+          setErrorState(error);
+        }
+        if (!shallowEqual(value, latestInfo.valueState)) {
+          if (value === undefined && defaultValue !== undefined) {
+            setValueState(defaultValue);
+          } else {
+            setValueState(value);
+          }
+          latestInfo.valueState = value;
+        }
       }
     },
   );

--- a/packages/shineout/src/form/__doc__/changelog.cn.md
+++ b/packages/shineout/src/form/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.4.4-beta.9
+2024-10-22
+### 🐞 BugFix
+
+- 修复 `Form.Field` 设置了 `defaultValue` 后在部分场景下失效的问题 ([#742](https://github.com/sheinsight/shineout-next/pull/742))
+
 ## 3.4.4-beta.6
 2024-10-16
 ### 🐞 BugFix


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Changelog

- 修复 Form.Field defaultValue 在部分场景下失效的问题

### Other information

Form.Field 的 name 为数组，比如 ["a","b"]，defaultValue 为数组，且只有一个初始值，比如 [{name:'xxx',title:'xxx'}]。接口来的数据里不包含 a b 字段，比如 setValue({c:'xxx'})， 导致 defaultValue 不生效

