### PR TITLE
fix: 修复 List 组件配置分页信息后报错、数据为空样式异常的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.4.4-beta.9",
+  "version": "3.4.4-beta.10",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/list/list.tsx
+++ b/packages/base/src/list/list.tsx
@@ -26,6 +26,7 @@ const List = <DataItem, Value extends any[]>(props: ListProps<DataItem, Value>) 
     pagination = {},
   } = props;
   const listClasses = props.jssStyle?.list?.();
+  const isEmpty = !util.isArray(data) || data.length <= 0;
 
   const inputAble = useInputAble({
     value: props.value,
@@ -163,6 +164,8 @@ const List = <DataItem, Value extends any[]>(props: ListProps<DataItem, Value>) 
   });
 
   const renderList = () => {
+    if (isEmpty) return null;
+
     if (props.fixed)
       return (
         <>
@@ -193,6 +196,7 @@ const List = <DataItem, Value extends any[]>(props: ListProps<DataItem, Value>) 
   const wrapperClass = classNames(
     props.className,
     listClasses?.wrapper,
+    isEmpty && listClasses?.wrapperEmpty,
     props.bordered && listClasses?.wrapperBordered,
     props.size === 'small' && listClasses?.wrapperSmall,
     props.size === 'large' && listClasses?.wrapperLarge,

--- a/packages/base/src/list/list.type.ts
+++ b/packages/base/src/list/list.type.ts
@@ -4,12 +4,14 @@ import { CommonType } from '../common/type';
 import { PaginationProps, PaginationJssStyle } from '../pagination/pagination.type';
 import { CheckboxClasses } from '../checkbox/checkbox.type';
 import { SpinClasses } from '../spin/spin.type';
+import { SelectClasses } from '../select/select.type';
 import { EmptyClasses } from '../empty/empty.type';
 import { ImageJssStyleType } from '../image/image.type';
 import { BaseItemClasses } from './base-item.type';
 
 export interface ListClasses extends BaseItemClasses {
   wrapper: string;
+  wrapperEmpty: string;
   wrapperBordered: string;
   wrapperStriped: string;
   wrapperSmall: string;
@@ -27,6 +29,7 @@ export interface ListClasses extends BaseItemClasses {
 export interface listJssStyle extends PaginationJssStyle, ImageJssStyleType {
   list?: () => ListClasses;
   checkbox?: () => CheckboxClasses;
+  select?: () => SelectClasses;
   spin?: () => SpinClasses;
   empty?: () => EmptyClasses;
 }

--- a/packages/shineout-style/src/list/list.ts
+++ b/packages/shineout-style/src/list/list.ts
@@ -16,6 +16,9 @@ const listStyle: JsStyles<ListClassType> = {
     border: `${token.listBorderWidth} solid ${token.listBorderColor}`,
     borderRadius: token.listBorderRadius,
   },
+  wrapperEmpty: {
+    justifyContent: 'center',
+  },
   wrapperSmall: {},
   wrapperLarge: {},
   wrapperStriped: {

--- a/packages/shineout/src/list/__doc__/changelog.cn.md
+++ b/packages/shineout/src/list/__doc__/changelog.cn.md
@@ -1,3 +1,11 @@
+## 3.4.4-beta.10
+2024-10-23
+
+### 🐞 BugFix
+
+-  修复 `List` 组件配置分页信息后报错的问题 ([#743](https://github.com/sheinsight/shineout-next/pull/743))
+-  修复 `List` 组件数据为空样式异常的问题 ([#743](https://github.com/sheinsight/shineout-next/pull/743))
+
 ## 3.1.0
 2024-05-09
 

--- a/packages/shineout/src/list/__test__/__snapshots__/list.spec.tsx.snap
+++ b/packages/shineout/src/list/__test__/__snapshots__/list.spec.tsx.snap
@@ -666,11 +666,8 @@ exports[`List[Base] should render correctly about colNum 1`] = `
 
 exports[`List[Base] should render correctly about empty 1`] = `
 <div
-  class="soui-list-wrapper soui-list-wrapper-bordered"
+  class="soui-list-wrapper soui-list-wrapper-empty soui-list-wrapper-bordered"
 >
-  <div
-    class="soui-list-scroll-container"
-  />
   <div
     class="soui-list-empty"
   >

--- a/packages/shineout/src/list/list.tsx
+++ b/packages/shineout/src/list/list.tsx
@@ -10,6 +10,7 @@ import {
   useEmptyStyle,
   useSpinStyle,
   useImageStyle,
+  useSelectStyle,
 } from '@sheinx/shineout-style';
 
 import { ListProps } from './list.type';
@@ -23,6 +24,7 @@ const jssStyle = {
   empty: useEmptyStyle,
   spin: useSpinStyle,
   image: useImageStyle,
+  select: useSelectStyle,
 };
 export default <DataItem, Value extends any[]>(props: ListProps<DataItem, Value>) => {
   return <List jssStyle={jssStyle} {...props} />;


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Changelog

- 修复 List 组件配置分页信息后报错、数据为空样式异常的问题

### Other information

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 增强了列表组件的空状态处理，添加了 `wrapperEmpty` 样式，以便在列表为空时居中显示。
	- 新增了选择组件的样式支持，允许在列表样式中包含选择组件的样式。
- **样式更新**
	- 更新了列表样式以支持空列表的特定样式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->