### PR TITLE
fix: repair spin classname is invalid without tip

### DIFF
--- a/packages/base/src/spin/base.tsx
+++ b/packages/base/src/spin/base.tsx
@@ -7,7 +7,7 @@ import { BaseSpinProps } from './spin.type';
 const { range } = util;
 
 const Spin = (props: BaseSpinProps) => {
-  const { count = 0, render, size: sizeProps, className, jssStyle } = props;
+  const { count = 0, render, size: sizeProps, className, uniqueClassName, jssStyle } = props;
   const styles = jssStyle?.spin?.();
   const config = useConfig();
 
@@ -28,7 +28,7 @@ const Spin = (props: BaseSpinProps) => {
     props.style,
   );
 
-  const classname = classNames(className, styles?.spin);
+  const classname = classNames(className, styles?.spin, uniqueClassName);
 
   if (count < 1 || !render) {
     return <div style={style} className={classname} />;

--- a/packages/base/src/spin/spin.tsx
+++ b/packages/base/src/spin/spin.tsx
@@ -75,7 +75,7 @@ const Spin = (props: SpinProps = {}) => {
     const n = name as keyof typeof Spins;
     if (Spins[n]) {
       const Comp = Spins[n];
-      return <Comp {...props} color={color} style={style} />;
+      return <Comp {...props} color={color} style={style} className={!tip ? className : undefined} />;
     }
 
     return null;

--- a/packages/base/src/spin/spin.type.ts
+++ b/packages/base/src/spin/spin.type.ts
@@ -73,6 +73,7 @@ export interface BaseSpinProps {
   itemClass?: string;
   itemSize?: number | string;
   className?: string;
+  uniqueClassName?: string
 }
 
 export interface SpinProps extends Pick<CommonType, 'className' | 'style'> {

--- a/packages/base/src/spin/spins.tsx
+++ b/packages/base/src/spin/spins.tsx
@@ -44,7 +44,7 @@ const Default = (props: SpinProps) => {
   return (
     <BaseSpin
       {...props}
-      className={spinStyles.default}
+      uniqueClassName={spinStyles.default}
       count={12}
       itemStyle={{ width: sizeSet, borderRadius: sizeSet }}
       render={renderItem}
@@ -60,7 +60,7 @@ const ChasingDots = (props: SpinProps) => {
     <BaseSpin
       {...props}
       count={2}
-      className={spinStyles.chasingDots}
+      uniqueClassName={spinStyles.chasingDots}
       render={renderSvgItem}
     ></BaseSpin>
   );
@@ -71,7 +71,7 @@ const CubeGrid = (props: SpinProps) => {
   const spinStyles = jssStyle?.spin?.() || ({} as SpinClasses);
 
   return (
-    <BaseSpin {...props} count={9} className={spinStyles.cubeGrid} render={renderSimpleItem} />
+    <BaseSpin {...props} count={9} uniqueClassName={spinStyles.cubeGrid} render={renderSimpleItem} />
   );
 };
 
@@ -80,7 +80,7 @@ const DoubleBounce = (props: SpinProps) => {
   const spinStyles = jssStyle?.spin?.() || ({} as SpinClasses);
 
   return (
-    <BaseSpin {...props} count={2} className={spinStyles.doubleBounce} render={renderSimpleItem} />
+    <BaseSpin {...props} count={2} uniqueClassName={spinStyles.doubleBounce} render={renderSimpleItem} />
   );
 };
 
@@ -94,7 +94,7 @@ const FadingCircle = (props: SpinProps) => {
     <BaseSpin
       {...props}
       count={12}
-      className={spinStyles.fadingCircle}
+      uniqueClassName={spinStyles.fadingCircle}
       itemSize={itemSize}
       itemClass={classNames(spinStyles.fade)}
       render={renderSvgItem}
@@ -112,7 +112,7 @@ const ScaleCircle = (props: SpinProps) => {
     <BaseSpin
       {...props}
       count={12}
-      className={spinStyles.fadingCircle}
+      uniqueClassName={spinStyles.fadingCircle}
       itemSize={itemSize}
       itemClass={classNames(spinStyles.scaleCircle)}
       render={renderSvgItem}
@@ -124,7 +124,7 @@ const FourDots = (props: SpinProps) => {
   const { jssStyle } = props;
   const spinStyles = jssStyle?.spin?.() || ({} as SpinClasses);
 
-  return <BaseSpin {...props} count={4} className={spinStyles.fourDots} render={renderSvgItem} />;
+  return <BaseSpin {...props} count={4} uniqueClassName={spinStyles.fourDots} render={renderSvgItem} />;
 };
 
 const Plane = (props: SpinProps) => {
@@ -134,7 +134,7 @@ const Plane = (props: SpinProps) => {
   };
   const spinStyles = jssStyle?.spin?.() || ({} as SpinClasses);
 
-  return <BaseSpin {...props} count={0} style={style} className={spinStyles.plane} />;
+  return <BaseSpin {...props} count={0} style={style} uniqueClassName={spinStyles.plane} />;
 };
 
 const Pulse = (props: SpinProps) => {
@@ -144,7 +144,7 @@ const Pulse = (props: SpinProps) => {
   };
   const spinStyles = jssStyle?.spin?.() || ({} as SpinClasses);
 
-  return <BaseSpin {...props} count={0} style={style} className={spinStyles.pulse} />;
+  return <BaseSpin {...props} count={0} style={style} uniqueClassName={spinStyles.pulse} />;
 };
 
 const Ring = (props: SpinProps) => {
@@ -161,7 +161,7 @@ const Ring = (props: SpinProps) => {
     fontSize: value / 10 + unit,
   };
 
-  return <BaseSpin {...props} count={0} style={style} className={spinStyles.ring} />;
+  return <BaseSpin {...props} count={0} style={style} uniqueClassName={spinStyles.ring} />;
 };
 
 const ThreeBounce = (props: SpinProps) => {
@@ -175,7 +175,7 @@ const ThreeBounce = (props: SpinProps) => {
       count={3}
       itemSize={value / 2 + unit}
       style={{ width: value * 2 + unit, height: 'auto' }}
-      className={spinStyles.threeBounce}
+      uniqueClassName={spinStyles.threeBounce}
       render={renderSvgItem}
     />
   );
@@ -201,7 +201,7 @@ const Wave = (props: SpinProps) => {
       {...props}
       itemStyle={{ width: width + unit, marginRight: margin }}
       count={5}
-      className={spinStyles.wave}
+      uniqueClassName={spinStyles.wave}
       render={renderSimpleItem}
     />
   );
@@ -220,7 +220,7 @@ const ChasingRing = (props: SpinProps) => {
       {...props}
       count={4}
       itemStyle={style}
-      className={spinStyles.chasingRing}
+      uniqueClassName={spinStyles.chasingRing}
       render={renderSimpleItem}
     />
   );

--- a/packages/shineout/src/button/__test__/__snapshots__/button.spec.tsx.snap
+++ b/packages/shineout/src/button/__test__/__snapshots__/button.spec.tsx.snap
@@ -542,7 +542,7 @@ exports[`Button[Base] should render correctly about loading 1`] = `
       class="soui-button-spin"
     >
       <div
-        class="soui-spin-ring soui-spin-spin"
+        class="soui-spin-spin soui-spin-ring"
         style="width: 12px; height: 12px; border-width: 1.2px; font-size: 1.2px;"
       />
     </div>
@@ -561,7 +561,7 @@ exports[`Button[Base] should render correctly about loading 1`] = `
       class="soui-button-spin"
     >
       <div
-        class="soui-spin-ring soui-spin-spin"
+        class="soui-spin-spin soui-spin-ring"
         style="width: 12px; height: 12px; border-width: 1.2px; font-size: 1.2px;"
       />
     </div>

--- a/packages/shineout/src/image/__test__/__snapshots__/image.spec.tsx.snap
+++ b/packages/shineout/src/image/__test__/__snapshots__/image.spec.tsx.snap
@@ -47,7 +47,7 @@ exports[`Image[Group] should render correctly about group 1`] = `
         class="soui-image-default-placeholder"
       >
         <div
-          class="soui-spin-ring soui-spin-spin"
+          class="soui-spin-spin soui-spin-ring"
           style="width: 16px; height: 16px; border-width: 1.6px; border-left-color: #B3B7C1; border-right-color: #B3B7C1; border-bottom-color: #B3B7C1; font-size: 1.6px;"
         />
       </div>
@@ -61,7 +61,7 @@ exports[`Image[Group] should render correctly about group 1`] = `
         class="soui-image-default-placeholder"
       >
         <div
-          class="soui-spin-ring soui-spin-spin"
+          class="soui-spin-spin soui-spin-ring"
           style="width: 16px; height: 16px; border-width: 1.6px; border-left-color: #B3B7C1; border-right-color: #B3B7C1; border-bottom-color: #B3B7C1; font-size: 1.6px;"
         />
       </div>
@@ -75,7 +75,7 @@ exports[`Image[Group] should render correctly about group 1`] = `
         class="soui-image-default-placeholder"
       >
         <div
-          class="soui-spin-ring soui-spin-spin"
+          class="soui-spin-spin soui-spin-ring"
           style="width: 16px; height: 16px; border-width: 1.6px; border-left-color: #B3B7C1; border-right-color: #B3B7C1; border-bottom-color: #B3B7C1; font-size: 1.6px;"
         />
       </div>
@@ -89,7 +89,7 @@ exports[`Image[Group] should render correctly about group 1`] = `
         class="soui-image-default-placeholder"
       >
         <div
-          class="soui-spin-ring soui-spin-spin"
+          class="soui-spin-spin soui-spin-ring"
           style="width: 16px; height: 16px; border-width: 1.6px; border-left-color: #B3B7C1; border-right-color: #B3B7C1; border-bottom-color: #B3B7C1; font-size: 1.6px;"
         />
       </div>

--- a/packages/shineout/src/spin/__test__/__snapshots__/spin.spec.tsx.snap
+++ b/packages/shineout/src/spin/__test__/__snapshots__/spin.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`Spin[Base] should render correctly  1`] = `
   style="width: 20px;"
 >
   <div
-    class="soui-spin-chasing-dots soui-spin-spin"
+    class="soui-spin-spin soui-spin-chasing-dots"
     style="width: 40px; height: 40px;"
   >
     <div
@@ -52,7 +52,7 @@ exports[`Spin[Base] should render correctly  2`] = `
         class="soui-spin-content soui-spin-vertical"
       >
         <div
-          class="soui-spin-chasing-dots soui-spin-spin"
+          class="soui-spin-spin soui-spin-chasing-dots"
           style="width: 16px; height: 16px;"
         >
           <div
@@ -100,7 +100,7 @@ exports[`Spin[Base] should render correctly  2`] = `
         class="soui-spin-content soui-spin-vertical"
       >
         <div
-          class="soui-spin-cube-grid soui-spin-spin"
+          class="soui-spin-spin soui-spin-cube-grid"
           style="width: 16px; height: 16px;"
         >
           <div
@@ -149,7 +149,7 @@ exports[`Spin[Base] should render correctly  2`] = `
         class="soui-spin-content soui-spin-vertical"
       >
         <div
-          class="soui-spin-double-bounce soui-spin-spin"
+          class="soui-spin-spin soui-spin-double-bounce"
           style="width: 16px; height: 16px;"
         >
           <div
@@ -177,7 +177,7 @@ exports[`Spin[Base] should render correctly  2`] = `
         class="soui-spin-content soui-spin-vertical"
       >
         <div
-          class="soui-spin-fading-circle soui-spin-spin"
+          class="soui-spin-spin soui-spin-fading-circle"
           style="width: 16px; height: 16px;"
         >
           <div
@@ -379,7 +379,7 @@ exports[`Spin[Base] should render correctly  2`] = `
         class="soui-spin-content soui-spin-vertical"
       >
         <div
-          class="soui-spin-four-dots soui-spin-spin"
+          class="soui-spin-spin soui-spin-four-dots"
           style="width: 16px; height: 16px;"
         >
           <div
@@ -453,7 +453,7 @@ exports[`Spin[Base] should render correctly  2`] = `
         class="soui-spin-content soui-spin-vertical"
       >
         <div
-          class="soui-spin-plane soui-spin-spin"
+          class="soui-spin-spin soui-spin-plane"
           style="width: 16px; height: 16px;"
         />
         <div
@@ -478,7 +478,7 @@ exports[`Spin[Base] should render correctly  2`] = `
         class="soui-spin-content soui-spin-vertical"
       >
         <div
-          class="soui-spin-pulse soui-spin-spin"
+          class="soui-spin-spin soui-spin-pulse"
           style="width: 16px; height: 16px;"
         />
         <div
@@ -499,7 +499,7 @@ exports[`Spin[Base] should render correctly  2`] = `
         class="soui-spin-content soui-spin-vertical"
       >
         <div
-          class="soui-spin-ring soui-spin-spin"
+          class="soui-spin-spin soui-spin-ring"
           style="width: 16px; height: 16px; border-width: 1.6px; font-size: 1.6px;"
         />
         <div
@@ -520,7 +520,7 @@ exports[`Spin[Base] should render correctly  2`] = `
         class="soui-spin-content soui-spin-vertical"
       >
         <div
-          class="soui-spin-fading-circle soui-spin-spin"
+          class="soui-spin-spin soui-spin-fading-circle"
           style="width: 16px; height: 16px;"
         >
           <div
@@ -722,7 +722,7 @@ exports[`Spin[Base] should render correctly  2`] = `
         class="soui-spin-content soui-spin-vertical"
       >
         <div
-          class="soui-spin-three-bounce soui-spin-spin"
+          class="soui-spin-spin soui-spin-three-bounce"
           style="width: 32px; height: auto;"
         >
           <div
@@ -789,7 +789,7 @@ exports[`Spin[Base] should render correctly  2`] = `
         class="soui-spin-content soui-spin-vertical"
       >
         <div
-          class="soui-spin-wave soui-spin-spin"
+          class="soui-spin-spin soui-spin-wave"
           style="width: 16px; height: 16px;"
         >
           <div
@@ -831,7 +831,7 @@ exports[`Spin[Base] should render correctly  2`] = `
         class="soui-spin-content soui-spin-vertical"
       >
         <div
-          class="soui-spin-chasing-ring soui-spin-spin"
+          class="soui-spin-spin soui-spin-chasing-ring"
           style="width: 16px; height: 16px;"
         >
           <div
@@ -877,7 +877,7 @@ exports[`Spin[Mode] should render correctly  1`] = `
       class="soui-spin-content soui-spin-vertical"
     >
       <div
-        class="soui-spin-ring soui-spin-spin"
+        class="soui-spin-spin soui-spin-ring"
         style="width: 16px; height: 16px; border-width: 1.6px; font-size: 1.6px;"
       />
       <div
@@ -898,7 +898,7 @@ exports[`Spin[Mode] should render correctly  1`] = `
       class="soui-spin-content soui-spin-horizontal"
     >
       <div
-        class="soui-spin-ring soui-spin-spin"
+        class="soui-spin-spin soui-spin-ring"
         style="width: 16px; height: 16px; border-width: 1.6px; font-size: 1.6px;"
       />
       <div
@@ -923,7 +923,7 @@ exports[`Spin[Tip] should render correctly  1`] = `
     class="soui-spin-content soui-spin-vertical"
   >
     <div
-      class="soui-spin-ring soui-spin-spin"
+      class="soui-spin-spin soui-spin-ring"
       style="width: 24px; height: 24px; border-width: 2.4px; font-size: 2.4px;"
     />
     <div

--- a/packages/shineout/src/transfer/__test__/__snapshots__/transfer.spec.tsx.snap
+++ b/packages/shineout/src/transfer/__test__/__snapshots__/transfer.spec.tsx.snap
@@ -5138,7 +5138,7 @@ exports[`Transfer[Base] should render correctly about loading 1`] = `
         class="soui-spin-loading"
       >
         <div
-          class="soui-spin-ring soui-spin-spin"
+          class="soui-transfer-spin-container soui-spin-spin soui-spin-ring"
           style="width: 24px; height: 24px; border-width: 2.4px; font-size: 2.4px;"
         />
       </div>
@@ -5447,7 +5447,7 @@ exports[`Transfer[Base] should render correctly about loading 1`] = `
         class="soui-spin-loading"
       >
         <div
-          class="soui-spin-ring soui-spin-spin"
+          class="soui-transfer-spin-container soui-spin-spin soui-spin-ring"
           style="width: 24px; height: 24px; border-width: 2.4px; font-size: 2.4px;"
         />
       </div>
@@ -5866,7 +5866,7 @@ exports[`Transfer[Base] should render correctly about loading control 1`] = `
         class="soui-spin-loading"
       >
         <div
-          class="soui-spin-ring soui-spin-spin"
+          class="soui-transfer-spin-container soui-spin-spin soui-spin-ring"
           style="width: 24px; height: 24px; border-width: 2.4px; font-size: 2.4px;"
         />
       </div>

--- a/packages/shineout/src/upload/__test__/__snapshots__/upload.spec.tsx.snap
+++ b/packages/shineout/src/upload/__test__/__snapshots__/upload.spec.tsx.snap
@@ -231,7 +231,7 @@ exports[`Upload[Base] should render correctly about confirm 1`] = `
           class="soui-image-default-placeholder"
         >
           <div
-            class="soui-spin-ring soui-spin-spin"
+            class="soui-spin-spin soui-spin-ring"
             style="width: 16px; height: 16px; border-width: 1.6px; border-left-color: #B3B7C1; border-right-color: #B3B7C1; border-bottom-color: #B3B7C1; font-size: 1.6px;"
           />
         </div>
@@ -648,7 +648,7 @@ exports[`Upload[Base] should render correctly about recover 1`] = `
           class="soui-image-default-placeholder"
         >
           <div
-            class="soui-spin-ring soui-spin-spin"
+            class="soui-spin-spin soui-spin-ring"
             style="width: 16px; height: 16px; border-width: 1.6px; border-left-color: #B3B7C1; border-right-color: #B3B7C1; border-bottom-color: #B3B7C1; font-size: 1.6px;"
           />
         </div>


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others


### Changelog
- 修复Spin组件当不存在tip时，className失效问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 在 `Spin` 组件中添加了 `uniqueClassName` 属性，以增强类名生成。
  - 多个旋转变体组件（如 `Default`、`ChasingDots` 等）现在支持 `uniqueClassName` 属性。

- **修复**
  - 组件渲染逻辑优化，确保在有提示时不传递 `className` 属性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->