### PR TITLE
fix: 修复 `Cascader` 开启 expandTrigger 为 hover 或 hover-only 时点击 checkbox 勾选失效的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.4.5-beta.6",
+  "version": "3.4.5-beta.7",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/cascader/node.tsx
+++ b/packages/base/src/cascader/node.tsx
@@ -80,6 +80,8 @@ const CascaderNode = <DataItem, Value extends KeygenResult[]>(
     handleChange(null, !checked);
   };
 
+  const isHoverAble = expandTrigger === 'hover' || expandTrigger === 'hover-only';
+
   const getEvents = () => {
     const events: any = {};
 
@@ -87,7 +89,7 @@ const CascaderNode = <DataItem, Value extends KeygenResult[]>(
       if (!isDisabled || props.mode === 4) events.onClick = handleClick;
     }
 
-    if (expandTrigger === 'hover' || expandTrigger === 'hover-only') {
+    if (isHoverAble) {
       events.onMouseEnter = handlePathChange;
       if (multiple) events.onClick = handleSelect;
     }
@@ -124,7 +126,7 @@ const CascaderNode = <DataItem, Value extends KeygenResult[]>(
             className={styles.optionCheckbox}
             checked={datum.getChecked(id)}
             disabled={isDisabled}
-            onChange={handleChange}
+            onChange={isHoverAble && multiple ? undefined : handleChange}
           />
         )}
         {renderContent()}

--- a/packages/shineout/src/cascader/__doc__/changelog.cn.md
+++ b/packages/shineout/src/cascader/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.4.5-beta.7
+2024-10-30
+
+### 🐞 BugFix
+- 修复 `Cascader` 开启 `expandTrigger` 为 hover 或 hover-only 时点击 checkbox 勾选失效的问题 ([#770](https://github.com/sheinsight/shineout-next/pull/770))
+
 ## 3.4.4
 2024-10-28
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

- 修复 `Cascader` 开启 expandTrigger 为 hover 或 hover-only 时点击 checkbox 勾选失效的问题

### Other information

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了`Cascader`组件的版本至`3.4.5-beta.7`，并修复了在`expandTrigger`属性设置为`hover`或`hover-only`时复选框选择无效的问题。

- **文档**
	- 更新了`Cascader`组件的变更日志，记录了新版本及其修复内容。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->