### PR TITLE
fix: 修复 setConfig 干涉部分组件内部 spin 固有样式的问题

### DIFF
--- a/docs/theme/layout/desktop/menu/index.tsx
+++ b/docs/theme/layout/desktop/menu/index.tsx
@@ -88,6 +88,7 @@ const MenuComponent = () => {
       locale: 'en-US',
       spin: {
         name: 'ring',
+        tip:'啊哈哈哈'
       },
       popupContainer: () => document.getElementById('layout'),
     });

--- a/packages/base/src/button/button.tsx
+++ b/packages/base/src/button/button.tsx
@@ -92,7 +92,7 @@ const Button = (props: ButtonProps) => {
 
   let loadingEl: React.ReactNode = (
     <div className={buttonStyle.spin}>
-      <Spin size={getSpinSize()} jssStyle={jssStyle} name='ring'></Spin>
+      <Spin size={getSpinSize()} jssStyle={jssStyle} name='ring' ignoreConfig></Spin>
     </div>
   );
 

--- a/packages/base/src/cascader/node.tsx
+++ b/packages/base/src/cascader/node.tsx
@@ -105,7 +105,7 @@ const CascaderNode = <DataItem, Value extends KeygenResult[]>(
     if (loading && children === undefined) {
       return (
         <span className={classNames(styles.optionIcon)} style={{ paddingTop: 2 }}>
-          <Spin jssStyle={jssStyle} size={10} />
+          <Spin jssStyle={jssStyle} size={10} name='ring' ignoreConfig />
         </span>
       );
     }

--- a/packages/base/src/image/image.tsx
+++ b/packages/base/src/image/image.tsx
@@ -128,7 +128,7 @@ const Image = (props: ImageProps) => {
   const renderDefaultPlaceholder = () => {
     return (
       <div className={defaultPlaceholderClass}>
-        <Spin jssStyle={jssStyle} color='#B3B7C1' size={16}></Spin>
+        <Spin jssStyle={jssStyle} color='#B3B7C1' size={16} name='ring' ignoreConfig></Spin>
       </div>
     );
   };

--- a/packages/base/src/spin/spin.tsx
+++ b/packages/base/src/spin/spin.tsx
@@ -15,11 +15,13 @@ const Spin = (props: SpinProps = {}) => {
     tipClassName,
     color: colorProps,
     mode: modeProps,
+    ignoreConfig = false,
   } = props;
 
   const config = useConfig();
 
   const getSpinName = () => {
+    if (ignoreConfig) return props.name;
     const { spin } = config;
     if (!spin) return;
 
@@ -36,6 +38,7 @@ const Spin = (props: SpinProps = {}) => {
   };
 
   const getSpinTip = () => {
+    if (ignoreConfig) return props.tip;
     const { spin } = config;
     if (!spin || typeof spin !== 'object') return;
     const { tip } = spin;
@@ -43,6 +46,7 @@ const Spin = (props: SpinProps = {}) => {
   };
 
   const getSpinColor = () => {
+    if (ignoreConfig) return props.color;
     const { spin } = config;
     if (!spin || typeof spin !== 'object') return;
     const { color } = spin;
@@ -50,6 +54,7 @@ const Spin = (props: SpinProps = {}) => {
   };
 
   const getSpinMode = () => {
+    if (ignoreConfig) return props.mode;
     const { spin } = config;
     if (!spin || typeof spin !== 'object') return;
     const { mode } = spin;
@@ -75,7 +80,9 @@ const Spin = (props: SpinProps = {}) => {
     const n = name as keyof typeof Spins;
     if (Spins[n]) {
       const Comp = Spins[n];
-      return <Comp {...props} color={color} style={style} className={!tip ? className : undefined} />;
+      return (
+        <Comp {...props} color={color} style={style} className={!tip ? className : undefined} />
+      );
     }
 
     return null;

--- a/packages/base/src/spin/spin.type.ts
+++ b/packages/base/src/spin/spin.type.ts
@@ -73,7 +73,7 @@ export interface BaseSpinProps {
   itemClass?: string;
   itemSize?: number | string;
   className?: string;
-  uniqueClassName?: string
+  uniqueClassName?: string;
 }
 
 export interface SpinProps extends Pick<CommonType, 'className' | 'style'> {
@@ -121,4 +121,10 @@ export interface SpinProps extends Pick<CommonType, 'className' | 'style'> {
    * @default false
    */
   loading?: boolean;
+  /**
+   * @en
+   * @cn 内部属性，是否忽略全局配置
+   * @default false
+   */
+  ignoreConfig?: boolean;
 }

--- a/packages/base/src/transfer/transfer-list.tsx
+++ b/packages/base/src/transfer/transfer-list.tsx
@@ -202,7 +202,14 @@ const TransferList = <DataItem, Value extends KeygenResult[]>(
   return (
     <div className={rootClass}>
       {renderHeader()}
-      <Spin className={styles.spinContainer} jssStyle={jssStyle} loading={loading} size={24}>
+      <Spin
+        className={styles.spinContainer}
+        jssStyle={jssStyle}
+        loading={loading}
+        size={24}
+        name='ring'
+        ignoreConfig
+      >
         {onFilter && renderFilter()}
         {renderList()}
         {renderFooter()}

--- a/packages/base/src/tree/tree-content.tsx
+++ b/packages/base/src/tree/tree-content.tsx
@@ -110,7 +110,7 @@ const NodeContent = <DataItem, Value extends KeygenResult[]>(
         data-icon={hasExpandIcons}
         dir={config.direction}
       >
-        <Spin size={12} jssStyle={jssStyle}></Spin>
+        <Spin size={12} jssStyle={jssStyle} ignoreConfig name='ring'></Spin>
       </span>
     );
   };

--- a/packages/base/src/upload/button.tsx
+++ b/packages/base/src/upload/button.tsx
@@ -59,7 +59,7 @@ const UploadButton = <T,>(props: UploadButtonProps<T>) => {
     ) : (
       <span>
         <span className={uploadClasses?.buttonBgSpin}>
-          <Spin jssStyle={props.jssStyle} size={10} color={color} />
+          <Spin jssStyle={props.jssStyle} size={10} color={color} ignoreConfig name='ring'/>
         </span>
         {typeof loading === 'string' ? loading : placeholder}
       </span>

--- a/packages/base/src/upload/result.tsx
+++ b/packages/base/src/upload/result.tsx
@@ -44,7 +44,7 @@ const Result = (props: ResultProps) => {
           </div>
           <div className={uploadClasses?.resultTextFooter}>
             <div className={classNames(uploadClasses?.icon, uploadClasses?.resultStatusIcon)}>
-              {status === 1 && <Spin jssStyle={props.jssStyle} size={10} name={'ring'} />}
+              {status === 1 && <Spin jssStyle={props.jssStyle} size={10} name={'ring'} ignoreConfig />}
               {status === 2 && icons.upload.Success}
               {status === 3 && icons.upload.Warning}
             </div>
@@ -130,6 +130,7 @@ const Result = (props: ResultProps) => {
                 size={'null'}
                 jssStyle={props.jssStyle}
                 name={'ring'}
+                ignoreConfig
                 className={uploadClasses?.imageResultLoading}
               />
             )}


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others


### Changelog

- 修复 setConfig 干涉部分组件内部 spin 固有样式的问题

### Other information
如果内部组件支持 loading 属性并且支持 RactNode 类型的，不作调整，因为有特殊需求可以自己传 Spin 进去来顶替全局配置，其余情况忽略 setConfig 配置