### PR TITLE
feat: `Select` 组件 placeholder 属性同步老版本表现

### DIFF
--- a/docs/theme/layout/desktop/menu/index.tsx
+++ b/docs/theme/layout/desktop/menu/index.tsx
@@ -88,6 +88,7 @@ const MenuComponent = () => {
       locale: 'en-US',
       spin: {
         name: 'ring',
+        tip:'啊哈哈哈'
       },
       popupContainer: () => document.getElementById('layout'),
     });

--- a/docs/theme/layout/desktop/menu/index.tsx
+++ b/docs/theme/layout/desktop/menu/index.tsx
@@ -88,7 +88,6 @@ const MenuComponent = () => {
       locale: 'en-US',
       spin: {
         name: 'ring',
-        tip:'啊哈哈哈'
       },
       popupContainer: () => document.getElementById('layout'),
     });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.4.7-beta.3",
+  "version": "3.4.7-beta.4",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.4.7-beta.2",
+  "version": "3.4.7-beta.3",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.4.7-beta.1",
+  "version": "3.4.7-beta.2",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/button/button.tsx
+++ b/packages/base/src/button/button.tsx
@@ -92,7 +92,7 @@ const Button = (props: ButtonProps) => {
 
   let loadingEl: React.ReactNode = (
     <div className={buttonStyle.spin}>
-      <Spin size={getSpinSize()} jssStyle={jssStyle} name='ring'></Spin>
+      <Spin size={getSpinSize()} jssStyle={jssStyle} name='ring' ignoreConfig></Spin>
     </div>
   );
 

--- a/packages/base/src/cascader/node.tsx
+++ b/packages/base/src/cascader/node.tsx
@@ -105,7 +105,7 @@ const CascaderNode = <DataItem, Value extends KeygenResult[]>(
     if (loading && children === undefined) {
       return (
         <span className={classNames(styles.optionIcon)} style={{ paddingTop: 2 }}>
-          <Spin jssStyle={jssStyle} size={10} />
+          <Spin jssStyle={jssStyle} size={10} name='ring' ignoreConfig />
         </span>
       );
     }

--- a/packages/base/src/image/image.tsx
+++ b/packages/base/src/image/image.tsx
@@ -128,7 +128,7 @@ const Image = (props: ImageProps) => {
   const renderDefaultPlaceholder = () => {
     return (
       <div className={defaultPlaceholderClass}>
-        <Spin jssStyle={jssStyle} color='#B3B7C1' size={16}></Spin>
+        <Spin jssStyle={jssStyle} color='#B3B7C1' size={16} name='ring' ignoreConfig></Spin>
       </div>
     );
   };

--- a/packages/base/src/select/result.tsx
+++ b/packages/base/src/select/result.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useLayoutEffect } from 'react';
+import React, { useState, useRef, useEffect, useLayoutEffect, useMemo } from 'react';
 import classNames from 'classnames';
 import { util, addResizeObserver, UnMatchedData, useRender } from '@sheinx/hooks';
 import { ResultProps } from './result.type';
@@ -122,13 +122,24 @@ const Result = <DataItem, Value>(props: ResultProps<DataItem, Value>) => {
     onResultItemClick?.(e, item);
   };
 
+  const renderPlaceholderBase = useMemo(() => {
+    return (
+      <span className={classNames(styles.placeholder, styles.ellipsis)}>
+        <span>{placeholder}</span>
+      </span>
+    );
+  }, [placeholder]);
+
   const renderInput = () => {
     let _placeholder = empty ? placeholder : '';
     if (!multiple && valueProp && valueProp !== 0) {
       const result = getDataByValues(value);
       _placeholder = renderResultContent(result[0]);
-      if (_placeholder === undefined) _placeholder = placeholder;
+      if (_placeholder === undefined) {
+        return renderPlaceholderBase;
+      }
     }
+
     return (
       <React.Fragment key='input'>
         <ResultInput
@@ -228,11 +239,7 @@ const Result = <DataItem, Value>(props: ResultProps<DataItem, Value>) => {
     }
     if (!placeholder) return renderNbsp();
 
-    return (
-      <span className={classNames(styles.placeholder, styles.ellipsis)}>
-        <span>{placeholder}</span>
-      </span>
-    );
+    return renderPlaceholderBase;
   };
 
   const renderSingleResult = () => {

--- a/packages/base/src/select/result.tsx
+++ b/packages/base/src/select/result.tsx
@@ -339,7 +339,26 @@ const Result = <DataItem, Value>(props: ResultProps<DataItem, Value>) => {
       const result = getDataByValues(value);
       if (result.length > 0) {
         const inputTmpText = renderResultContent(result[0]);
-        inputTmpText && props.setInputText(inputTmpText);
+        if (inputTmpText) {
+          // 提取result文本
+          const getTextFromReactElement = (element: React.ReactElement): string => {
+            if (!element) return '';
+            // 如果是字符串或数字，直接返回
+            if (typeof element === 'string' || typeof element === 'number') return String(element);
+            // 如果是 React Element，处理的是renderResult返回的是React Element的场景
+            if (React.isValidElement(element)) {
+              const children = (element.props as { children?: React.ReactNode })?.children;
+              if (Array.isArray(children)) {
+                return children.map((child) => getTextFromReactElement(child)).join('');
+              }
+              return React.isValidElement(children) ? getTextFromReactElement(children) : String(children || '');
+            }
+            return '';
+          };
+
+          const textContent = getTextFromReactElement(inputTmpText);
+          props.setInputText(textContent);
+        }
       }
 
       setTimeout(() => {

--- a/packages/base/src/spin/spin.tsx
+++ b/packages/base/src/spin/spin.tsx
@@ -15,11 +15,13 @@ const Spin = (props: SpinProps = {}) => {
     tipClassName,
     color: colorProps,
     mode: modeProps,
+    ignoreConfig = false,
   } = props;
 
   const config = useConfig();
 
   const getSpinName = () => {
+    if (ignoreConfig) return props.name;
     const { spin } = config;
     if (!spin) return;
 
@@ -36,6 +38,7 @@ const Spin = (props: SpinProps = {}) => {
   };
 
   const getSpinTip = () => {
+    if (ignoreConfig) return props.tip;
     const { spin } = config;
     if (!spin || typeof spin !== 'object') return;
     const { tip } = spin;
@@ -43,6 +46,7 @@ const Spin = (props: SpinProps = {}) => {
   };
 
   const getSpinColor = () => {
+    if (ignoreConfig) return props.color;
     const { spin } = config;
     if (!spin || typeof spin !== 'object') return;
     const { color } = spin;
@@ -50,6 +54,7 @@ const Spin = (props: SpinProps = {}) => {
   };
 
   const getSpinMode = () => {
+    if (ignoreConfig) return props.mode;
     const { spin } = config;
     if (!spin || typeof spin !== 'object') return;
     const { mode } = spin;
@@ -75,7 +80,9 @@ const Spin = (props: SpinProps = {}) => {
     const n = name as keyof typeof Spins;
     if (Spins[n]) {
       const Comp = Spins[n];
-      return <Comp {...props} color={color} style={style} className={!tip ? className : undefined} />;
+      return (
+        <Comp {...props} color={color} style={style} className={!tip ? className : undefined} />
+      );
     }
 
     return null;

--- a/packages/base/src/spin/spin.type.ts
+++ b/packages/base/src/spin/spin.type.ts
@@ -73,7 +73,7 @@ export interface BaseSpinProps {
   itemClass?: string;
   itemSize?: number | string;
   className?: string;
-  uniqueClassName?: string
+  uniqueClassName?: string;
 }
 
 export interface SpinProps extends Pick<CommonType, 'className' | 'style'> {
@@ -121,4 +121,10 @@ export interface SpinProps extends Pick<CommonType, 'className' | 'style'> {
    * @default false
    */
   loading?: boolean;
+  /**
+   * @en
+   * @cn 内部属性，是否忽略全局配置
+   * @default false
+   */
+  ignoreConfig?: boolean;
 }

--- a/packages/base/src/transfer/transfer-list.tsx
+++ b/packages/base/src/transfer/transfer-list.tsx
@@ -202,7 +202,14 @@ const TransferList = <DataItem, Value extends KeygenResult[]>(
   return (
     <div className={rootClass}>
       {renderHeader()}
-      <Spin className={styles.spinContainer} jssStyle={jssStyle} loading={loading} size={24}>
+      <Spin
+        className={styles.spinContainer}
+        jssStyle={jssStyle}
+        loading={loading}
+        size={24}
+        name='ring'
+        ignoreConfig
+      >
         {onFilter && renderFilter()}
         {renderList()}
         {renderFooter()}

--- a/packages/base/src/tree/tree-content.tsx
+++ b/packages/base/src/tree/tree-content.tsx
@@ -110,7 +110,7 @@ const NodeContent = <DataItem, Value extends KeygenResult[]>(
         data-icon={hasExpandIcons}
         dir={config.direction}
       >
-        <Spin size={12} jssStyle={jssStyle}></Spin>
+        <Spin size={12} jssStyle={jssStyle} ignoreConfig name='ring'></Spin>
       </span>
     );
   };

--- a/packages/base/src/upload/button.tsx
+++ b/packages/base/src/upload/button.tsx
@@ -59,7 +59,7 @@ const UploadButton = <T,>(props: UploadButtonProps<T>) => {
     ) : (
       <span>
         <span className={uploadClasses?.buttonBgSpin}>
-          <Spin jssStyle={props.jssStyle} size={10} color={color} />
+          <Spin jssStyle={props.jssStyle} size={10} color={color} ignoreConfig name='ring'/>
         </span>
         {typeof loading === 'string' ? loading : placeholder}
       </span>

--- a/packages/base/src/upload/result.tsx
+++ b/packages/base/src/upload/result.tsx
@@ -44,7 +44,7 @@ const Result = (props: ResultProps) => {
           </div>
           <div className={uploadClasses?.resultTextFooter}>
             <div className={classNames(uploadClasses?.icon, uploadClasses?.resultStatusIcon)}>
-              {status === 1 && <Spin jssStyle={props.jssStyle} size={10} name={'ring'} />}
+              {status === 1 && <Spin jssStyle={props.jssStyle} size={10} name={'ring'} ignoreConfig />}
               {status === 2 && icons.upload.Success}
               {status === 3 && icons.upload.Warning}
             </div>
@@ -130,6 +130,7 @@ const Result = (props: ResultProps) => {
                 size={'null'}
                 jssStyle={props.jssStyle}
                 name={'ring'}
+                ignoreConfig
                 className={uploadClasses?.imageResultLoading}
               />
             )}

--- a/packages/shineout/src/select/__doc__/changelog.cn.md
+++ b/packages/shineout/src/select/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.4.7-beta.4
+2024-11-08
+
+### 🐞 BugFix
+
+- `Select` 组件 `placeholder` 属性同步老版本表现 ([#787](https://github.com/sheinsight/shineout-next/pull/787))
+
 ## 3.4.7-beta.1
 2024-11-06
 

--- a/packages/shineout/src/spin/__doc__/changelog.cn.md
+++ b/packages/shineout/src/spin/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.4.7-beta.3
+2024-11-07
+### 🐞 BugFix
+
+- 修复 `setConfig` 干涉部分组件内部 spin 固有样式的问题 ([#786](https://github.com/sheinsight/shineout-next/pull/786))
+
 ## 3.3.0
 2024-07-23
 ### 🐞 BugFix


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others


### Changelog

- `Select` 组件 placeholder 属性同步老版本表现

### Other information
老版本在最终渲染 result 内容为空的时候，会以 span 方式渲染 placeholder，当前 3.x 是以 input 占位，调整为基础 placeholder 渲染

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新特性**
  - `Spin` 组件增加了 `ignoreConfig` 属性，允许在加载状态下更灵活地处理配置。
  - `TransferList`、`UploadButton`、`Result` 等组件的加载指示器现在使用了新的 `Spin` 属性。
  - `Select` 组件的 `placeholder` 属性行为已与旧版本同步。

- **修复**
  - 更新了版本号至 `3.4.7-beta.4`，修复了与 `setConfig` 函数相关的样式问题。
  - 修复了 `Select` 组件中与 `placeholder` 相关的多个问题。

- **文档**
  - 在变更日志中添加了新条目，记录了与 `Spin` 组件相关的修复。
  - 更新了 `Select` 组件的变更日志，记录了新版本的修复。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->