### PR TITLE
fix: 修复 `Cascader`非虚拟列表情况下搜索内容溢出列表的问题，搜索结果列表支持虚拟列表

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.5.1-beta.3",
+  "version": "3.5.1-beta.4",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/cascader/cascader.tsx
+++ b/packages/base/src/cascader/cascader.tsx
@@ -201,6 +201,7 @@ const Cascader = <DataItem, Value extends KeygenResult[]>(
     disabled === true && styles?.wrapperDisabled,
     focused && disabled !== true && styles?.wrapperFocus,
     innerTitle && styles?.wrapperInnerTitle,
+    virtual && styles.virtual,
     size === 'small' && styles?.wrapperSmall,
     size === 'large' && styles?.wrapperLarge,
     (!!props.error || props.status === 'error') && styles?.wrapperError,
@@ -605,6 +606,10 @@ const Cascader = <DataItem, Value extends KeygenResult[]>(
           jssStyle={jssStyle}
           data={filterData!}
           datum={datum}
+          keygen={keygen}
+          height={height}
+          size={size}
+          virtual={virtual}
           wideMatch={wideMatch}
           filterFunc={filterFunc}
           renderItem={renderItem}

--- a/packages/base/src/cascader/cascader.type.ts
+++ b/packages/base/src/cascader/cascader.type.ts
@@ -63,6 +63,7 @@ export interface CascaderClasses {
   inputMirror: string;
   inputPlaceholder: string;
   moreWrapper: string;
+  virtual: string;
   virtualList: string;
   option: string;
   filterOption: string;

--- a/packages/base/src/cascader/filter-list.type.ts
+++ b/packages/base/src/cascader/filter-list.type.ts
@@ -5,11 +5,12 @@ import { JssStyleType, CascaderProps } from './cascader.type';
 export interface FilterListProps<DataItem, Value extends KeygenResult[]>
   extends Pick<
     CascaderProps<DataItem, Value>,
-    'renderOptionList' | 'loading' | 'wideMatch' | 'childrenKey'
+    'renderOptionList' | 'loading' | 'wideMatch' | 'childrenKey' | 'virtual' | 'keygen' | 'size'
   > {
   jssStyle?: JssStyleType;
   data: DataItem[];
   datum: DatumType<DataItem>['datum'];
+  height: number;
   filterFunc?: (data: DataItem) => boolean;
   shouldFinal: boolean;
   renderItem: (data: DataItem, active?: boolean, id?: Value[0] | undefined) => React.ReactNode;

--- a/packages/shineout-style/src/cascader/cascader.ts
+++ b/packages/shineout-style/src/cascader/cascader.ts
@@ -150,6 +150,11 @@ const cascaderStyle: JsStyles<CascaderClassType> = {
       },
     },
   },
+  virtual: {
+    '& $filterList': {
+      overflow: 'hidden',
+    },
+  },
   wrapperDisabled: {
     ...wrapperDisabled,
     '& $icon': {
@@ -388,6 +393,7 @@ const cascaderStyle: JsStyles<CascaderClassType> = {
   },
   filterList: {
     display: 'block',
+    overflow: 'auto',
     '& $list': {
       width: '100%',
     },

--- a/packages/shineout/src/cascader/__doc__/changelog.cn.md
+++ b/packages/shineout/src/cascader/__doc__/changelog.cn.md
@@ -1,3 +1,12 @@
+## 3.5.1-beta.4
+2024-11-13
+
+### 🐞 BugFix
+- 修复 `Cascader` 非虚拟列表情况下搜索内容溢出列表的问题 ([#798](https://github.com/sheinsight/shineout-next/pull/798))
+
+### 🆕 Feature
+- `Cascader` 单选模式下搜索结果列表支持虚拟列表 ([#798](https://github.com/sheinsight/shineout-next/pull/798))
+
 ## 3.5.0
 2024-11-11
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [x] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Changelog

- 修复 `Cascader` 非虚拟列表情况下搜索内容溢出列表的问题
- `Cascader` 单选模式下搜索结果列表支持虚拟列表

### Other information