### PR TITLE
fix: 修复 `Cascader` 在开启 `unmatch` 情况下指定 renderItem 为 string 类型时渲染异常的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.5.1-beta.5",
+  "version": "3.5.1-beta.6",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/select/result.tsx
+++ b/packages/base/src/select/result.tsx
@@ -74,7 +74,7 @@ const Result = <DataItem, Value>(props: ResultProps<DataItem, Value>) => {
   );
 
   const renderResultContent = (
-    data: DataItem | UnMatchedData,
+    data: DataItem | UnMatchedData | null,
     index?: number,
     nodes?: (DataItem | UnMatchedData)[],
   ) => {
@@ -98,13 +98,12 @@ const Result = <DataItem, Value>(props: ResultProps<DataItem, Value>) => {
         const cur = renderResultContent(item, index, datas);
         return !isEmpty(cur);
       }) >= 0;
-
     return !hasValue;
   };
 
   const empty = useMemo(() => {
     return isEmptyResult();
-  }, [props.value]);
+  }, [props.value, props.data, getDataByValues]);
 
   const basePlaceholder = useMemo(() => {
     return (
@@ -263,7 +262,6 @@ const Result = <DataItem, Value>(props: ResultProps<DataItem, Value>) => {
       nextValue = valueProp.split(separator);
     }
     const datas = getDataByValues(nextValue as Value);
-
     const result = datas.map((d, i) => {
       const v = nextValue[i];
       if (renderResultContentProp && i !== datas.length - 1) {
@@ -278,14 +276,14 @@ const Result = <DataItem, Value>(props: ResultProps<DataItem, Value>) => {
     });
     return { results: result, datas };
   }, [
-    props.value,             // 必需：控制选中的值
-    props.data,        // 必需：数据源
-    separator,         // 必需：影响值的分割
-    valueProp,         // 必需：影响值的处理
-    renderResultContentProp,  // 必需：影响渲染方式
-    renderResultItem,  // 必需：渲染每个选项的方法
-    getDataByValues   // 必需：根据值获取数据的方法
-]);
+    props.value, // 必需：控制选中的值
+    props.data, // 必需：数据源
+    separator, // 必需：影响值的分割
+    valueProp, // 必需：影响值的处理
+    renderResultContentProp, // 必需：影响渲染方式
+    renderResultItem, // 必需：渲染每个选项的方法
+    getDataByValues, // 必需：根据值获取数据的方法
+  ]);
 
   const result = renderMultipleResult.results as React.ReactNode[];
   const moreNumber = getCompressedBound();
@@ -387,7 +385,7 @@ const Result = <DataItem, Value>(props: ResultProps<DataItem, Value>) => {
     handleResetMore();
   }, [valueProp, data]);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     // datum.getDataByValues(value); 需要等待 useTree useEffect  执行完毕 才能获取到
     render();
   }, [data]);

--- a/packages/base/src/select/result.type.ts
+++ b/packages/base/src/select/result.type.ts
@@ -48,7 +48,7 @@ export interface ResultProps<DataItem, Value>
   // crud
   onClearCreatedData?: () => void;
   getDataByValues: (values: Value) => (DataItem | UnMatchedData)[];
-  checkUnMatched: (item: DataItem | UnMatchedData) => boolean;
+  checkUnMatched: (item: DataItem | UnMatchedData | null) => boolean;
   onRemove?: (item: DataItem | UnMatchedData, key?: KeygenResult, index?: number) => void;
   onResultItemClick?: (
     e: React.MouseEvent<HTMLDivElement, MouseEvent>,

--- a/packages/base/src/select/select.tsx
+++ b/packages/base/src/select/select.tsx
@@ -466,7 +466,7 @@ function Select<DataItem, Value>(props0: SelectPropsBase<DataItem, Value>) {
     return datum.getDataByValues(values as Value[], { childrenKey });
   };
 
-  const checkUnMatched = (item: DataItem | UnMatchedData): item is UnMatchedData => {
+  const checkUnMatched = (item: DataItem | UnMatchedData | null): item is UnMatchedData => {
     return datum.isUnMatchedData(item);
   };
   const handleRemove = (item: DataItem | UnMatchedData) => {

--- a/packages/hooks/src/components/use-tree/use-tree.ts
+++ b/packages/hooks/src/components/use-tree/use-tree.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import useLatestObj from '../../common/use-latest-obj';
 import { useInputAble } from '../../common/use-input-able';
 import {
@@ -64,6 +64,8 @@ const useTree = <DataItem>(props: BaseTreeProps<DataItem>) => {
     isControlled,
     onExpand: onExpandProp,
   } = props;
+
+  const [inited, setInited] = useState(false);
 
   const { value: expanded, onChange: onExpand } = useInputAble({
     value: expandedProp,
@@ -192,13 +194,17 @@ const useTree = <DataItem>(props: BaseTreeProps<DataItem>) => {
     if (oroginData) {
       return oroginData;
     }
-    if (!unmatch) return null;
-    return { IS_NOT_MATCHED_VALUE: true, value: id };
+    // if (!unmatch) return null;
+    // if (!unmatch) return { IS_NOT_MATCHED_VALUE: true, value: null};
+    // return { IS_NOT_MATCHED_VALUE: true, value: !unmatch ? null : id };
+    return { IS_NOT_MATCHED_VALUE: true, value: !unmatch ? null : id };
   };
 
-  const getDataByValues = (values: KeygenResult[] | KeygenResult): DataItem | DataItem[] | null => {
+  const getDataByValues = (
+    values: KeygenResult[] | KeygenResult,
+  ): DataItem | (DataItem | null)[] | null => {
     if (isArray(values)) {
-      return values.map(getDataById) as DataItem[] | null;
+      return values.map(getDataById) as (DataItem | null)[];
     }
 
     return getDataById(values) as DataItem | null;
@@ -240,7 +246,6 @@ const useTree = <DataItem>(props: BaseTreeProps<DataItem>) => {
         console.error(`There is already a key "${id}" exists. The key must be unique.`);
         continue;
       }
-
       // 制作 data mapping
       context.dataMap.set(id, item);
 
@@ -451,6 +456,10 @@ const useTree = <DataItem>(props: BaseTreeProps<DataItem>) => {
     setValue(value);
   }, [value]);
 
+  useEffect(() => {
+    setInited(true);
+  }, []);
+
   const datum: TreeDatum<DataItem> = useLatestObj({
     get,
     set,
@@ -476,6 +485,7 @@ const useTree = <DataItem>(props: BaseTreeProps<DataItem>) => {
   });
 
   return {
+    inited,
     datum: props.datum || datum,
     expanded,
     onExpand,

--- a/packages/hooks/src/components/use-tree/use-tree.type.ts
+++ b/packages/hooks/src/components/use-tree/use-tree.type.ts
@@ -125,7 +125,7 @@ export interface TreeDatum<DataItem> {
   getValue: () => KeygenResult[];
   getChecked: (id: KeygenResult) => boolean | 'indeterminate';
   getKey: (item: DataItem, id?: KeygenResult, index?: number) => KeygenResult;
-  getDataByValues: (values: KeygenResult[] | KeygenResult) => DataItem | DataItem[] | null;
+  getDataByValues: (values: KeygenResult[] | KeygenResult) => DataItem | (DataItem | null)[] | null;
   setValue: (value?: KeygenResult[]) => void;
   setData: (data?: DataItem[]) => void;
   isDisabled: (id: KeygenResult) => boolean;
@@ -136,7 +136,7 @@ export interface TreeDatum<DataItem> {
   ) => { active: boolean; expanded: boolean };
   getDataById: (
     id: KeygenResult,
-  ) => DataItem | { IS_NOT_MATCHED_VALUE: boolean; value: KeygenResult } | null;
+  ) => DataItem | { IS_NOT_MATCHED_VALUE: boolean; value: KeygenResult | null } | null;
   bindUpdate: (id: KeygenResult, update: () => void) => void;
   unBindUpdate: (id: KeygenResult) => void;
   isUnMatched: (data: any) => boolean;

--- a/packages/shineout/src/cascader/__doc__/changelog.cn.md
+++ b/packages/shineout/src/cascader/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.5.1-beta.6
+2024-11-14
+
+### 🐞 BugFix
+- 修复 `Cascader` 在开启 `unmatch` 情况下指定 renderItem 为 string 类型时渲染异常的问题 ([#800](https://github.com/sheinsight/shineout-next/pull/800))
+
 ## 3.5.1-beta.4
 2024-11-13
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Changelog

- 修复 `Cascader` 在开启 `unmatch` 情况下指定 renderItem 为 string 类型时渲染异常的问题

### Other information