### PR TITLE
fix: repair remove all bug when set separator

### DIFF
--- a/packages/hooks/src/common/use-list-select/use-list-select-multiple.ts
+++ b/packages/hooks/src/common/use-list-select/use-list-select-multiple.ts
@@ -138,7 +138,7 @@ const useListSelectMultiple = <DataItem, Value extends string | any[]>(
   );
 
   const removeAll = usePersistFn(() => {
-    props.onChange([] as unknown as Value, undefined as DataItem, false);
+    props.onChange((props.separator ? '' : []) as unknown as Value, undefined as DataItem, false);
   });
 
   // 删除数据


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Changelog

- 修复设置separator时，点击清除按钮后value为[]的问题


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能更新**
	- 修改了`removeAll`函数的行为，以便根据`props.separator`的存在条件地传递空字符串或空数组，从而影响状态重置时返回给调用者的值类型。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->