### PR TITLE
fix: 修复 `Select` 开启创建选项后无法选中创建内容的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.5.2-beta.1",
+  "version": "3.5.2-beta.2",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/select/select.tsx
+++ b/packages/base/src/select/select.tsx
@@ -192,6 +192,13 @@ function Select<DataItem, Value>(props0: SelectPropsBase<DataItem, Value>) {
     position: positionProp,
   });
 
+  const preventDefault = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    if (!createdData) return;
+    if (focused && e.target !== inputRef.current) {
+      e.preventDefault();
+    }
+  };
+
   const handleSelectChange = usePersistFn((value: Value, dataItem: any, checked?: boolean) => {
     if (createdData || props.emptyAfterSelect) {
       onFilter?.('');
@@ -206,7 +213,7 @@ function Select<DataItem, Value>(props0: SelectPropsBase<DataItem, Value>) {
     onChange?.(value, dataItem, checked);
 
     if (props.absolute === undefined) return;
-    
+
     setAbsoluteListUpdateKey(value as string);
   });
 
@@ -735,6 +742,7 @@ function Select<DataItem, Value>(props0: SelectPropsBase<DataItem, Value>) {
       onFocus={handleFocus}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
+      onMouseDown={preventDefault}
     >
       {tipNode}
       {renderResult()}

--- a/packages/shineout/src/select/__doc__/changelog.cn.md
+++ b/packages/shineout/src/select/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.5.2-beta.2
+2024-11-19
+
+### 🐞 BugFix
+
+- 修复 `Select` 开启创建选项后无法选中创建内容的问题(Regression: since v3.4.4) ([#807](https://github.com/sheinsight/shineout-next/pull/807))
+
 ## 3.5.2-beta.1
 2024-11-19
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Changelog

- 修复 `Select` 开启创建选项后无法选中创建内容的问题

### Other information

回归 3.4.4 

- 修复 Select 组件无法拖拽选中 dom 内容的问题

https://github.com/sheinsight/shineout-next/pull/729

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 在 `Select` 组件中添加了 `preventDefault` 方法，以改善鼠标事件的处理。
- **修复**
	- 修复了 `Select` 组件在启用创建选项时无法选择创建内容的问题。
	- 修复了在启用 `absolute` 属性时，多个选择时面板位置未更新的问题。
- **版本更新**
	- 项目版本已更新至 `3.5.2-beta.2`。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->