### PR TITLE
fix: 修复 `Form.FieldSet` 初始化默认值后更新内部值异常的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.5.2-beta.6",
+  "version": "3.5.2-beta.7",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-form/use-form.ts
+++ b/packages/hooks/src/components/use-form/use-form.ts
@@ -365,9 +365,9 @@ const useForm = <T extends ObjectType>(props: UseFormProps<T>) => {
           onChange((v) => {
             deepSet(v, n, df, deepSetOptions);
           });
+          update(n);
         });
       }
-      update(n);
     },
     unbind: (n: string, reserveAble?: boolean, validateFiled?: ValidateFn, update?: UpdateFn) => {
       const validateFieldSet = context.validateMap[n];

--- a/packages/shineout/src/form/__doc__/changelog.cn.md
+++ b/packages/shineout/src/form/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.5.2-beta.7
+2024-11-25
+### 🐞 BugFix
+
+- 修复 `Form.FieldSet` 初始化默认值后更新内部值异常的问题 ([#816](https://github.com/sheinsight/shineout-next/pull/816))
+
 ## 3.5.2-beta.3
 2024-11-21
 ### 🐞 BugFix


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Changelog

- 修复 `Form.FieldSet` 初始化默认值后更新内部值异常的问题

### Other information

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 改进了 `useForm` 钩子的 `bind` 方法，确保在绑定新字段时即时更新表单状态。
- **错误修复**
	- 修复了 `Form.FieldSet` 组件中初始化默认值后更新内部值的问题。
- **文档**
	- 更新了版本号至 `3.5.2-beta.7`，并在变更日志中添加了相关条目。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->