### PR TITLE
 fix: 修复 Form 初始化表单后 value 异步更新导致 defaultValue 无法再次同步的问题

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,4 +37,6 @@
 
 <!-- - Fix `Component` ... -->
 
+### Playground id
+
 ### Other information

--- a/packages/hooks/src/components/use-form/use-form-control/use-form-control.ts
+++ b/packages/hooks/src/components/use-form/use-form-control/use-form-control.ts
@@ -96,6 +96,7 @@ export default function useFormControl<T>(props: BaseFormControlProps<T>) {
           }
         });
         setValueState(nextValue as T);
+        formFunc?.setValue({ [name]: nextValue }, { validate: false });
       } else {
         const value = getValue(name, formValue) as T;
         const error = getError(name, errors, severErrors);
@@ -105,6 +106,7 @@ export default function useFormControl<T>(props: BaseFormControlProps<T>) {
         if (!shallowEqual(value, latestInfo.valueState)) {
           if (value === undefined && defaultValue !== undefined) {
             setValueState(defaultValue);
+            formFunc?.setValue({ [name]: defaultValue }, { validate: false });
           } else {
             setValueState(value);
           }

--- a/packages/shineout/src/form/__doc__/changelog.cn.md
+++ b/packages/shineout/src/form/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.5.2-beta.8
+2024-11-26
+### 🐞 BugFix
+
+- 修复 · 初始化表单后 value 异步更新导致 defaultValue 无法再次同步的问题 ([#817](https://github.com/sheinsight/shineout-next/pull/817))
+
 ## 3.5.2-beta.7
 2024-11-25
 ### 🐞 BugFix


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Changelog

- 修复 `Form` 初始化表单后 value 异步更新导致 defaultValue 无法再次同步的问题

### Playground id

aa84b721-a5b4-4ef9-89f4-00c6a5419437

### Other information

Form 表单中 Form.FieldSet 给一个 defaultValue ，初始化的时候 defaultValue 会触发 onChange 并同步修改外部的 value。如果用户调用接口，或者异步地将带有 defaultValue 的字段设置为 undefined 或者直接去除了（等同 undefined）并设置给了 Form，此时 defaultValue 不会再次补位。该现象和 1.x 2.x 不一致，老版本组件 defalutValue 在 value 变了后且 defaultValue 对应的字段取值为 undefined 的话，会重新补位

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 在拉取请求模板中新增“Playground id”部分，以便贡献者填写。
	- 改进了表单控制逻辑，增强了表单值和错误的处理能力，特别是在处理数组和默认值的情况下。

- **错误修复**
	- 修复了表单初始化后异步更新值的问题，确保默认值能够正确同步。
	- 改进了错误处理，确保表单上下文中的错误状态正确更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->