### PR TITLE
fix: 修复 `Tree` 组件开启 `doubleClickExpand` 后，双击节点（非根节点）无法展开的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.5.2-beta.7",
+  "version": "3.5.2-beta.8",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/tree/tree-node.tsx
+++ b/packages/base/src/tree/tree-node.tsx
@@ -236,6 +236,7 @@ const Node = <DataItem, Value extends KeygenResult[]>(props: TreeNodeProps<DataI
       isControlled,
       contentClass,
       parentClickExpand,
+      doubleClickExpand,
       expanded,
       line,
       data: children,

--- a/packages/shineout/src/tree/__doc__/changelog.cn.md
+++ b/packages/shineout/src/tree/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.5.2-beta.8
+2024-11-26
+
+### 🐞 BugFix
+
+- 修复 `Tree` 组件开启 `doubleClickExpand` 后，双击节点（非根节点）无法展开的问题 ([#818](https://github.com/sheinsight/shineout-next/pull/818))
 ## 3.4.3
 2024-10-14
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog
- 修复 `Tree` 组件开启 `doubleClickExpand` 后，双击节点（非根节点）无法展开的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
  - 在树节点组件中添加了双击展开功能，提升了用户交互体验。
  
- **错误修复**
  - 修复了在启用双击展开功能时，非根节点双击未展开的问题。

- **文档**
  - 更新了版本日志，记录了新版本 `3.5.2-beta.8` 的相关变更和修复。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->