### PR TITLE
fix: 修复 `Select` 开启 `filterSameChange` 后单选模式下选择重复项无法关闭面板的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.5.2-beta.8",
+  "version": "3.5.2-beta.9",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/select/select.tsx
+++ b/packages/base/src/select/select.tsx
@@ -216,6 +216,13 @@ function Select<DataItem, Value>(props0: SelectPropsBase<DataItem, Value>) {
     setAbsoluteListUpdateKey(value as string);
   });
 
+  const handleSameChange = () => {
+    const shouldFocus = showInput && props.reFocus;
+    if (!multiple && !shouldFocus) {
+      closePop();
+    }
+  };
+
   const { datum, value } = useSelect<DataItem, Value>({
     value: valueProp,
     data,
@@ -231,6 +238,7 @@ function Select<DataItem, Value>(props0: SelectPropsBase<DataItem, Value>) {
     prediction,
     beforeChange,
     onChange: handleSelectChange,
+    onSameChange: handleSameChange,
     filterSameChange,
     noCache,
   });

--- a/packages/hooks/src/common/use-input-able/use-Input-able.ts
+++ b/packages/hooks/src/common/use-input-able/use-Input-able.ts
@@ -8,7 +8,7 @@ import { useRender } from '../use-render';
 import { ChangeType, InputAbleProps } from './use-Input-able.type';
 
 export default function useInputAble<T, V extends ChangeType<T>>(props: InputAbleProps<T, V>) {
-  const { value: valuePo, onChange, control, beforeChange, delay } = props;
+  const { value: valuePo, onChange, onSameChange, control, beforeChange, delay } = props;
 
   const [stateValue, changeStateValue] = useState<T | undefined>(props.value ?? props.defaultValue);
 
@@ -52,7 +52,10 @@ export default function useInputAble<T, V extends ChangeType<T>>(props: InputAbl
   const handleChange = usePersistFn((v: T, ...other: any[]) => {
     let vv = v;
     if (other.length === 0 || props.filterSameChange) {
-      if (shallowEqual(v, value)) return;
+      if (shallowEqual(v, value)) {
+        if (onSameChange) onSameChange(v);
+        return;
+      }
     }
     if (isFunc(beforeChange)) {
       const temp = beforeChange(v);

--- a/packages/hooks/src/common/use-input-able/use-Input-able.type.ts
+++ b/packages/hooks/src/common/use-input-able/use-Input-able.type.ts
@@ -4,6 +4,7 @@ export interface InputAbleProps<T, V extends ChangeType<T>> {
   defaultValue: T | undefined;
   beforeChange: ((value: T) => T | void) | undefined;
   onChange: V | undefined;
+  onSameChange?: V;
   control: boolean;
   // 延迟时间
   delay?: number;

--- a/packages/hooks/src/components/use-select/use-select.ts
+++ b/packages/hooks/src/components/use-select/use-select.ts
@@ -1,9 +1,11 @@
 import { useInputAble } from '../../common/use-input-able';
 import { useListSelect } from '../../common/use-list-select';
-import { BaseSelectProps } from './use-select.type';
+import { BaseSelectProps, UseSelectProps } from './use-select.type';
 
 const emptyArray: any[] = [];
-const useSelect = <DataItem, Value>(props: BaseSelectProps<DataItem, Value>) => {
+const useSelect = <DataItem, Value>(
+  props: BaseSelectProps<DataItem, Value> & UseSelectProps<Value>,
+) => {
   const {
     data,
     treeData,
@@ -18,8 +20,9 @@ const useSelect = <DataItem, Value>(props: BaseSelectProps<DataItem, Value>) => 
     prediction,
     value: valueProp,
     onChange: onChangeProp,
+    onSameChange,
     filterSameChange,
-    noCache
+    noCache,
   } = props;
 
   const { value, onChange } = useInputAble({
@@ -28,6 +31,7 @@ const useSelect = <DataItem, Value>(props: BaseSelectProps<DataItem, Value>) => 
     defaultValue,
     beforeChange,
     onChange: onChangeProp,
+    onSameChange,
     filterSameChange,
   });
 

--- a/packages/hooks/src/components/use-select/use-select.type.ts
+++ b/packages/hooks/src/components/use-select/use-select.type.ts
@@ -67,3 +67,7 @@ export interface BaseSelectProps<DataItem, Value> {
   groupBy?: (item: DataItem, index?: number, data?: DataItem[]) => string;
   filterSameChange?: boolean;
 }
+
+export interface UseSelectProps<Value> {
+  onSameChange: (value: Value) => void;
+}

--- a/packages/shineout/src/select/__doc__/changelog.cn.md
+++ b/packages/shineout/src/select/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.5.2-beta.9
+2024-11-27
+
+### 🐞 BugFix
+
+- 修复 `Select` 开启 `filterSameChange` 后单选模式下选择重复项无法关闭面板的问题 ([#819](https://github.com/sheinsight/shineout-next/pull/819))
+
 ## 3.5.2-beta.4
 2024-11-19
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Changelog

- 修复 `Select` 开启 `filterSameChange` 后单选模式下选择重复项无法关闭面板的问题

### Playground id

d3750fdd-9e50-444a-bcf7-bc38921dff92

### Other information

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在选择组件中添加了`onSameChange`回调，以处理重复选择相同值的情况。
- **错误修复**
	- 修复了在单选模式下选择重复项时无法关闭面板的问题。
- **版本更新**
	- 更新版本号至`3.5.2-beta.9`，反映了小幅更新和错误修复。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->