### PR TITLE
fix: 修复 `Form` 的 `formRef` 上的set方法，为某个字段手动设置相同长度的数组值时，无法更新值的问题

### DIFF
--- a/packages/base/src/form/form-fieldset.tsx
+++ b/packages/base/src/form/form-fieldset.tsx
@@ -5,7 +5,7 @@ const { produce } = util;
 
 const FormFieldSet = <T,>(props: FormFieldSetProps<T>) => {
   const { children, empty } = props;
-  const { current: context } = React.useRef<{ ids: string[] }>({ ids: [] });
+  const { current: context } = React.useRef<{ ids: string[], lastValues: any }>({ ids: [], lastValues: [] });
 
   const formFunc = useFormFunc();
 
@@ -48,10 +48,13 @@ const FormFieldSet = <T,>(props: FormFieldSetProps<T>) => {
   if (context.ids.length !== valueArr.length) {
     context.ids = valueArr.map(() => util.generateUUID());
   }
-  const ids = context.ids || [];
+
   valueArr.forEach((v: any, i: number) => {
+    if(context.lastValues[i] !== v) {
+      context.ids[i] = util.generateUUID()
+    }
     result.push(
-      <Provider key={ids[i]} value={{ path: `${ProviderValue.path}[${i}]`, validateFieldSet }}>
+      <Provider key={context.ids[i] ?? i} value={{ path: `${ProviderValue.path}[${i}]`, validateFieldSet }}>
         {children({
           list: valueArr,
           value: v,
@@ -96,7 +99,11 @@ const FormFieldSet = <T,>(props: FormFieldSetProps<T>) => {
       </Provider>,
     );
   });
-  return <>{result}</>;
+
+  // 更新 lastValues
+  context.lastValues = valueArr
+
+  return result;
 };
 
 export default FormFieldSet;

--- a/packages/shineout/src/date-picker/__test__/datePicker.spec.tsx
+++ b/packages/shineout/src/date-picker/__test__/datePicker.spec.tsx
@@ -286,7 +286,7 @@ describe('Alert[Base]', () => {
     fireEvent.click(rightHeaderIcons[0]);
     await waitFor(async () => {
       await delay(300);
-      textContentTest(headerInfos[1], `${Number(month) + 1}`);
+      textContentTest(headerInfos[1], `${Number(month === '12' ? 0 : month) + 1}`);
     });
     fireEvent.click(leftHeaderIcons[1]);
     await waitFor(async () => {
@@ -1260,7 +1260,7 @@ describe('DatePicker[QuickSelect]', () => {
       await delay(300);
       textContentTest(
         datePickerPickers[1].querySelectorAll(pickerHeaderInfo)[1],
-        `${Number(month) + 1}`,
+        `${Number(month === '12' ? 0 : month) + 1}`,
       );
     });
   });

--- a/packages/shineout/src/form/__doc__/changelog.cn.md
+++ b/packages/shineout/src/form/__doc__/changelog.cn.md
@@ -3,7 +3,7 @@
 ### 🐞 BugFix
 
 - 修复 `Form` 的 `reserveAble` 属性在处理嵌套字段时，无法保留值的问题 ([#834](https://github.com/sheinsight/shineout-next/pull/834))
-
+- 修复 `Form` 的 `formRef` 上的set方法，为某个字段手动设置相同长度的数组值时，无法更新值的问题 ([#835](https://github.com/sheinsight/shineout-next/pull/835))
 
 ## 3.5.3-beta.2
 2024-11-28


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Changelog
-  修复 `Form` 的 `formRef` 上的set方法，为某个字段手动设置相同长度的数组值时，无法更新值的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - `FormFieldSet` 组件更新，增加了对表单字段上一个值的跟踪。
  - `formRef` 新增方法：`validateFieldsWithValue` 和 `scrollToField`，提升了表单验证和滚动功能。

- **错误修复**
  - 修复了嵌套字段的 `reserveAble` 属性值未保留的问题。
  - 修复了 `formRef` 的 `set` 方法在手动设置数组时未能更新值的问题。
  - 解决了表单初始化后默认值的异步更新问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->