### PR TITLE
fix: Tabs动态设置disabled时的禁用不生效问题(Regression since 3.5.3)

### DIFF
--- a/packages/base/src/tabs/tabs-panel.tsx
+++ b/packages/base/src/tabs/tabs-panel.tsx
@@ -7,6 +7,7 @@ import { TabData } from './tab.type';
 
 const TabsPanel = (props: TabsPanelProps) => {
   const { children, id, tab, className, style, jssStyle } = props;
+
   const panelStyle = jssStyle?.tabs?.() || ({} as TabsClasses);
 
   const { active, lazy, setTabs, color } = useTabsContext<TabData>();
@@ -14,12 +15,23 @@ const TabsPanel = (props: TabsPanelProps) => {
   const keekAlive = useRef(false);
 
   useLayoutEffect(() => {
+    const tabData = {
+      id,
+      tab,
+      disabled: props.disabled,
+      jssStyle,
+      color: props.color || (active === id ? color : undefined),
+    } as TabData;
+
     setTabs(prev => {
       const prevTab = prev.find(item => item.id === id)
       if(prevTab){
-        return prev.map(item => item.id === id ? { ...item, tab } : item)
+        return prev.map(item => {
+          if(item.id !== id) return item
+          return { ...item, ...tabData }
+        })
       }
-      return [...prev, { id, tab, disabled: props.disabled, jssStyle, color: props.color || (active === id ? color : undefined) } as TabData]
+      return [...prev, tabData]
     })
   }, [id, tab, color, ...(color ? [active] : []), props.disabled, props.jssStyle])
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others


### Changelog
- Tabs动态设置disabled时的禁用不生效问题(Regression since 3.5.3)