### PR TITLE
fix: 修复 `DatePicker` 从 setLocale获取到的 `startOfWeek` 是字符串时，得到星期顺序不正确的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.5.3-beta.5",
+  "version": "3.5.3-beta.7",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/date-picker/day.tsx
+++ b/packages/base/src/date-picker/day.tsx
@@ -113,6 +113,7 @@ const Day = (props: DayProps) => {
   };
   const weeks = getLocale(locale, 'weekdayValues.narrow');
   const weekDays = Array.from({ length: 7 }).map((_, index) => {
+    // weekStartsOn可能是字符串，需要转换为数字，否则得到星期顺序不正确
     const num = (props.options.weekStartsOn + index) % 7;
     return weeks[num];
   });
@@ -214,6 +215,7 @@ const Day = (props: DayProps) => {
       </div>
     );
   };
+
   return (
     <div
       className={classNames(
@@ -274,6 +276,9 @@ const Day = (props: DayProps) => {
           <tbody>
             {Array.from({ length: len }).map((_, index) => {
               const start = index * 7;
+              // console.log('======================')
+              // console.log('days, start, days[start + 3]: >>', days, start, days[start + 3])
+              // console.log('======================')
               return (
                 <tr
                   key={index}

--- a/packages/shineout/src/date-picker/__doc__/changelog.cn.md
+++ b/packages/shineout/src/date-picker/__doc__/changelog.cn.md
@@ -1,9 +1,19 @@
+## 3.5.3-beta.7
+2024-11-28
+
+### 🐞 BugFix
+
+- 修复 `DatePicker` 从 setLocale获取到的 `startOfWeek` 是字符串时，得到星期顺序不正确的问题 ([#826](https://github.com/sheinsight/shineout-next/pull/826))
+
+
+
 ## 3.5.3-beta.1
 2024-11-28
 
 ### 🐞 BugFix
 
 - 修复 `DatePicker` 在设置 `inputable` 和 `range` 后开始时间可以输入非法值的问题 ([#826](https://github.com/sheinsight/shineout-next/pull/826))
+
 
 ## 3.5.1
 2024-11-14


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background
从远程获取的国际化资源包内的startOfWeek配置不是number类型时，星期顺序会错乱的问题

### Changelog
- 修复 `DatePicker` 从 setLocale获取到的 `startOfWeek` 是字符串时，得到星期顺序不正确的问题