### PR TITLE
fix: 修复 `DatePicker` 从 setLocale获取到的 `startOfWeek` 是字符串时，得到星期顺序不正确的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.5.3-beta.7",
+  "version": "3.5.3-beta.8",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/date-picker/day.tsx
+++ b/packages/base/src/date-picker/day.tsx
@@ -114,7 +114,7 @@ const Day = (props: DayProps) => {
   const weeks = getLocale(locale, 'weekdayValues.narrow');
   const weekDays = Array.from({ length: 7 }).map((_, index) => {
     // weekStartsOn可能是字符串，需要转换为数字，否则得到星期顺序不正确
-    const num = (props.options.weekStartsOn + index) % 7;
+    const num = (Number(props.options.weekStartsOn) + index) % 7;
     return weeks[num];
   });
 

--- a/packages/shineout/src/date-picker/__example__/test-006-bbl.tsx
+++ b/packages/shineout/src/date-picker/__example__/test-006-bbl.tsx
@@ -1,8 +1,8 @@
 /**
- * cn - 基本用法
- *    -- 最基本的用法
- * en - Base
- *    -- The basic usage
+ * cn - 远程多语言
+ *    -- 测试从远程获取多语言数据
+ * en - Remote Multi-language
+ *    -- Test getting multi-language data from remote
  */
 import React, { useEffect } from 'react';
 import { DatePicker, setLocale } from 'shineout';


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog
- 修复 `DatePicker` 从 setLocale获取到的 `startOfWeek` 是字符串时，得到星期顺序不正确的问题