### PR TITLE
fix: 修复 `Image` 在 `fit` 属性为 fill 或 fit 时，图片可能无法加载的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.5.3",
+  "version": "3.5.4-beta.1",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/image/image.tsx
+++ b/packages/base/src/image/image.tsx
@@ -115,7 +115,7 @@ const Image = (props: ImageProps) => {
   };
 
   const renderDivInnerEl = (src?: string) => {
-    const imageDivProps = getImageDivProps({ style: { backgroundImage: `url(${src})` } });
+    const imageDivProps = getImageDivProps({ style: { backgroundImage: `url("${src}")` } });
     return <div className={imgInnerClass} {...imageDivProps}></div>;
   };
 

--- a/packages/shineout/src/image/__doc__/changelog.cn.md
+++ b/packages/shineout/src/image/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.5.4-beta.1
+2024-12-04
+
+### 🐞 BugFix
+
+- 修复 `Image` 在 `fit` 属性为 fill 或 fit 时，图片可能无法加载的问题 ([#847](https://github.com/sheinsight/shineout-next/pull/847))
+
 ## 3.5.2
 2024-10-28
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

- 修复 `Image` 在 `fit` 属性为 fill 或 fit 时，图片可能无法加载的问题

### Playground id

81c604f5-672b-4b0f-a18f-479704a5a26d

### Other information

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 更新了 `Image` 组件的版本至 `3.5.4-beta.1`，并在变更日志中记录了相关信息。
- **错误修复**
	- 修复了当 `fit` 属性设置为 `fill` 或 `fit` 时，图像可能无法加载的问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->