### PR TITLE
fix: 修复 `Sticky` 组件设置负值 `top` 或 `bottom` 值时组件报错的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.5.4-beta.1",
+  "version": "3.5.4-beta.2",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/sticky/sticky.tsx
+++ b/packages/base/src/sticky/sticky.tsx
@@ -219,7 +219,7 @@ const Sticky = (props: StickyProps) => {
     cancelFixedObserver();
     context.fixedObserver = new IntersectionObserver(handleFixedInter, {
       root: null,
-      rootMargin: `-${top || 0}px 0px -${bottom || 0}px 0px`,
+      rootMargin: `${-(top || 0)}px 0px ${-(bottom || 0)}px 0px`,
       threshold: 1.0,
     });
   };
@@ -257,7 +257,7 @@ const Sticky = (props: StickyProps) => {
       if (window.IntersectionObserver) {
         const observer = new IntersectionObserver(handleTargetPosition, {
           root: context.target,
-          rootMargin: `-${top || 0}px 0px -${bottom || 0}px 0px`,
+          rootMargin: `${-(top || 0)}px 0px ${-(bottom || 0)}px 0px`,
           threshold: 1.0,
         });
         context.targetObserver = observer;
@@ -277,7 +277,7 @@ const Sticky = (props: StickyProps) => {
     cancelParentObserver();
     context.parentObserver = new IntersectionObserver(handleParentVisible, {
       root: context.target,
-      rootMargin: `-${top || 0}px 0px -${bottom || 0}px 0px`,
+      rootMargin: `${-(top || 0)}px 0px ${-(bottom || 0)}px 0px`,
       threshold: 0,
     });
     context.parentObserver.observe(props.parent);

--- a/packages/shineout/src/sticky/__doc__/changelog.cn.md
+++ b/packages/shineout/src/sticky/__doc__/changelog.cn.md
@@ -1,3 +1,11 @@
+## 3.5.4-beta.2
+2024-12-04
+
+### 🐞 BugFix
+
+- 修复 `Sticky` 组件设置负值 `top` 或 `bottom` 值时组件报错的问题 ([#848](https://github.com/sheinsight/
+shineout-next/pull/848))
+
 ## 3.1.16
 2024-05-24
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

- 修复 `Sticky` 组件设置负值 `top` 或 `bottom` 值时组件报错的问题

### Playground id

dfab1632-a2fc-453b-8404-b0efc164ae5b

### Other information

设置负数组件直接崩了

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了 `Sticky` 组件的版本至 `3.5.4-beta.2`。
- **错误修复**
	- 修复了 `Sticky` 组件在设置 `top` 或 `bottom` 属性为负值时出现的错误。
- **文档**
	- 在变更日志中添加了新版本条目，记录了相关的错误修复和版本更新信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->