### PR TITLE
fix: 修复 `Table` 同时设置了`defaultTreeExpandKeys`, `treeExpandKeys`, `onTr…

### DIFF
--- a/packages/hooks/src/components/use-table/use-table-tree.tsx
+++ b/packages/hooks/src/components/use-table/use-table-tree.tsx
@@ -5,6 +5,7 @@ import type { BaseTableProps } from './use-table.type';
 import { isObject } from '../../utils/is';
 import { OptionalToRequired } from '../../common/type';
 import { useLatestObj } from '../../common/use-latest-obj';
+import { util } from '@sheinx/hooks'
 
 interface GetExpandDataResult {
   treeData: any[];
@@ -115,6 +116,11 @@ export const useTableTree = (props: UseTableTreeProps) => {
 
     // 检查treeData中的每一项，对比expandKeysState，如果expandKeysState有但是children是空的，则需要修正expandKeysState
     const newExpandKeys = expandKeysState.filter((key) => !unmatchExpandKeys.includes(key));
+
+    if(util.shallowEqual(newExpandKeys, expandKeysState)) {
+      return;
+    }
+
     setExpandKeysState(newExpandKeys);
   }, [unmatchExpandKeys, expandKeysState]);
 

--- a/packages/shineout/src/table/__doc__/changelog.cn.md
+++ b/packages/shineout/src/table/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.5.4-beta.5
+2024-12-06
+
+### 🐞 BugFix
+- 修复 `Table` 同时设置了`defaultTreeExpandKeys`, `treeExpandKeys`, `onTreeExpand`后导致的组件渲染卡死问题 ([#852](https://github.com/sheinsight/shineout-next/pull/852))
+
 ## 3.5.4-beta.4
 2024-12-05
 


### PR DESCRIPTION
…eeExpand`后导致的组件渲染卡死问题

<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Changelog
- 修复 `Table` 同时设置了`defaultTreeExpandKeys`, `treeExpandKeys`, `onTreeExpand`后导致的组件渲染卡死问题