### PR TITLE
fix: 修复 `DatePicker` 开启 `quickSelect` 模式下选择快速选项后清空值的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.5.4-beta.7",
+  "version": "3.5.4-beta.8",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/date-picker/date-picker.tsx
+++ b/packages/base/src/date-picker/date-picker.tsx
@@ -43,8 +43,10 @@ const DatePicker = <Value extends DatePickerValueType>(props0: DatePickerProps<V
   const [oldDateArr, setOldDateArr] = React.useState<(Date | undefined)[]>([]);
   const inputRef = useRef<{
     inputRef: HTMLInputElement | null;
+    inputRefs: (HTMLInputElement | null)[];
   }>({
     inputRef: null,
+    inputRefs: [],
   });
 
   const styles = jssStyle?.datePicker?.();
@@ -171,7 +173,9 @@ const DatePicker = <Value extends DatePickerValueType>(props0: DatePickerProps<V
     if (isFromConfirm) {
       func.finishEdit();
     }
-    inputRef.current.inputRef?.blur();
+    inputRef.current.inputRefs.forEach((el) => {
+      el?.blur();
+    });
   };
 
   const handleResultClick = usePersistFn(() => {

--- a/packages/base/src/date-picker/picker.tsx
+++ b/packages/base/src/date-picker/picker.tsx
@@ -151,6 +151,7 @@ const Picker = (props: PickerProps) => {
           jssStyle={jssStyle}
           dateArr={dateArr}
           type={type}
+          onClearInputArr={props.onClearInputArr}
           setDateArr={props.setDateArr}
           setCurrentArr={props.setCurrentArr}
           format={props.format}

--- a/packages/base/src/date-picker/quick.tsx
+++ b/packages/base/src/date-picker/quick.tsx
@@ -5,7 +5,8 @@ import { dateUtil, util } from '@sheinx/hooks';
 import classNames from 'classnames';
 
 const Quick = (props: QuickProps) => {
-  const { jssStyle, quickSelect, format, options, children, type, closePop } = props;
+  const { jssStyle, quickSelect, format, onClearInputArr, options, children, type, closePop } =
+    props;
   const styles = jssStyle?.datePicker?.();
   const quickDateCache = useRef<DatePickerValueType>();
   const quickActiveKey = useRef<number>();
@@ -26,7 +27,7 @@ const Quick = (props: QuickProps) => {
     });
     props.setDateArr(dateArr);
     props.setCurrentArr(dateArr, 'quick', item);
-
+    onClearInputArr()
     if (immediate && closePop) {
       closePop();
     }

--- a/packages/base/src/date-picker/quick.type.ts
+++ b/packages/base/src/date-picker/quick.type.ts
@@ -11,5 +11,6 @@ export interface QuickProps {
   range: PickerProps['range'];
   options: PickerProps['options'];
   children?: PickerProps['children'];
+  onClearInputArr: (index?: number | undefined) => void;
   closePop?: (isFromConfirm?: boolean | undefined) => void;
 }

--- a/packages/base/src/date-picker/result.tsx
+++ b/packages/base/src/date-picker/result.tsx
@@ -83,6 +83,7 @@ interface ResultProps
   activeIndex?: number;
   onRef: React.MutableRefObject<{
     inputRef: HTMLInputElement | null;
+    inputRefs: (HTMLInputElement | null)[];
   }>;
   onFocus?: (e: React.FocusEvent) => void;
   onBlur?: (e: React.FocusEvent) => void;
@@ -183,39 +184,40 @@ const Result = (props: ResultProps) => {
     return (
       <div className={className} id={formFieldId[info.index]}>
         <span className={styles?.resultTextPadding}>
-            <Input
-              key={info.index}
-              onRef={(el) => {
-                onRef.current.inputRef = el;
-                context.inputRefs[info.index] = el;
-              }}
-              disabled={dis && info.inputable}
-              readOnly={!info.inputable}
-              open={!!open}
-              inputRef={inputRef}
-              value={info.target || info.value || ''}
-              placeholder={info.place}
-              onChange={(s) => {
-                onChange(s, info.index);
-              }}
-              onMouseDown={() => {
-                context.clickIndex = info.index;
-              }}
-              onBlur={(e) => {
-                e.stopPropagation();
-                if (e.relatedTarget === context.inputRefs[1 - info.index]) return;
-                props.onBlur?.(e);
-                if (inputRef.current) inputRef.current.updateValue?.();
-                context.clickIndex = 0;
-              }}
-              onFocus={(e) => {
-                context.clickIndex = info.index;
-                e.stopPropagation();
-                if (focused) return;
-                props.onFocus?.(e);
-              }}
-              onClick={onClickProps}
-            />
+          <Input
+            key={info.index}
+            onRef={(el) => {
+              onRef.current.inputRef = el;
+              onRef.current.inputRefs[info.index] = el;
+              context.inputRefs[info.index] = el;
+            }}
+            disabled={dis && info.inputable}
+            readOnly={!info.inputable}
+            open={!!open}
+            inputRef={inputRef}
+            value={info.target || info.value || ''}
+            placeholder={info.place}
+            onChange={(s) => {
+              onChange(s, info.index);
+            }}
+            onMouseDown={() => {
+              context.clickIndex = info.index;
+            }}
+            onBlur={(e) => {
+              e.stopPropagation();
+              if (e.relatedTarget === context.inputRefs[1 - info.index]) return;
+              props.onBlur?.(e);
+              if (inputRef.current) inputRef.current.updateValue?.();
+              context.clickIndex = 0;
+            }}
+            onFocus={(e) => {
+              context.clickIndex = info.index;
+              e.stopPropagation();
+              if (focused) return;
+              props.onFocus?.(e);
+            }}
+            onClick={onClickProps}
+          />
         </span>
         <div className={styles?.resultTextBg}></div>
       </div>

--- a/packages/hooks/src/components/use-datepicker/use-datepicker-format.ts
+++ b/packages/hooks/src/components/use-datepicker/use-datepicker-format.ts
@@ -158,7 +158,6 @@ const useDatePickerFormat = <Value extends DatePickerValueType>(
         return isDis;
       }
     }
-
     if (range && typeof range === 'number') {
       if (start) {
         if (!end) return isDis;
@@ -245,11 +244,13 @@ const useDatePickerFormat = <Value extends DatePickerValueType>(
   const finishEdit = () => {
     setEdit(false);
     let formatValue = getFormatValueArr(stateDate);
+
     if (inputArr.length && inputArr.some((i) => i)) {
-      const inputValue = inputArr.map((item, index) => {
-        if (item) return item;
-        return stateDate[index];
+      const inputValue = stateDate.map((item, index) => {
+        if (inputArr[index]) return inputArr[index];
+        return item;
       });
+
       const isDis = isDisabledInputDate(inputValue);
       if (!isDis) {
         formatValue = getFormatValueArr(inputValue);

--- a/packages/shineout/src/date-picker/__doc__/changelog.cn.md
+++ b/packages/shineout/src/date-picker/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.5.4-beta.8
+2024-12-06
+
+### 🐞 BugFix
+
+- 修复 `DatePicker` 开启 `quickSelect` 模式下选择快速选项后清空值的问题 ([#855](https://github.com/sheinsight/shineout-next/pull/855))
+
 ## 3.5.4-beta.6
 2024-12-06
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

- 修复 `DatePicker` 开启 `quickSelect` 模式下选择快速选项后清空值的问题

### Playground id

aad8a821-5aec-44dc-a014-78acef0c98a2

### Other information

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
  - 更新了 `DatePicker` 组件，增强了对多个输入引用的管理。
  - 新增 `onClearInputArr` 属性，提升了 `Quick` 组件的交互性。
  
- **错误修复**
  - 修复了在启用 `quickSelect` 模式时选择快速选项会清除已选值的问题。
  
- **文档**
  - 更新了版本日志，记录了新版本 `3.5.4-beta.8` 的变更和修复。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->