### PR TITLE
fix: add scopeNormalizeStyle method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.5.4-beta.8",
+  "version": "3.5.4-beta.9",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout/src/index.ts
+++ b/packages/shineout/src/index.ts
@@ -55,7 +55,7 @@ export { default as Upload } from './upload';
 export { setConfig, config, setLocale, setIcons } from '@sheinx/base';
 export type { ConfigOption } from '@sheinx/base';
 export { setToken, useToken } from '@sheinx/theme';
-export { JssProvider, SheetsRegistry, setJssConfig } from '@sheinx/shineout-style';
+export { JssProvider, SheetsRegistry, setJssConfig, scopeNormalizeStyle } from '@sheinx/shineout-style';
 export * as utls from './utils';
 export * from './deprecated';
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog
- 增加scopeNormalizeStyle方法，供用户控制normalize css作用域

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 更新了版本号至 `3.5.4-beta.9`。
	- 引入了 `scopeNormalizeStyle` 函数，增强了CSS样式管理和跨浏览器兼容性。
	- 添加了 `appendNormalizeStyle` 函数，用于创建和附加样式元素。

- **样式**
	- 修改了CSS规范化，确保更一致的样式表现。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->