### PR TITLE
fix: 修复 `Form.FieldSet` 在非结尾位置插入数据时，数组的渲染显示异常的问题(Regression: v3.5.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.5.5",
+  "version": "3.5.6-beta.1",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/form/form-fieldset.tsx
+++ b/packages/base/src/form/form-fieldset.tsx
@@ -5,7 +5,7 @@ const { produce } = util;
 
 const FormFieldSet = <T,>(props: FormFieldSetProps<T>) => {
   const { children, empty } = props;
-  const { current: context } = React.useRef<{ ids: string[] }>({ ids: [] });
+  // const { current: context } = React.useRef<{ ids: string[] }>({ ids: [] });
 
   const formFunc = useFormFunc();
 
@@ -36,7 +36,7 @@ const FormFieldSet = <T,>(props: FormFieldSetProps<T>) => {
             draft.push(val);
           }) as T;
           onChange(newValue);
-          context.ids.push(util.generateUUID());
+          // context.ids.push(util.generateUUID());
           formFunc?.insertError(name, 0);
         })}
       </React.Fragment>
@@ -44,13 +44,13 @@ const FormFieldSet = <T,>(props: FormFieldSetProps<T>) => {
   }
 
   const errorList = (Array.isArray(error) ? error : [error]).filter(Boolean);
-  if (context.ids.length !== valueArr.length) {
-    context.ids = valueArr.map(() => util.generateUUID());
-  }
+  // if (context.ids.length !== valueArr.length) {
+  //   context.ids = valueArr.map(() => util.generateUUID());
+  // }
 
   return valueArr.map((v: any, i: number) => (
     <Provider
-      key={context.ids[i] ?? i}
+      key={i}
       value={{ path: `${ProviderValue.path}[${i}]`, validateFieldSet }}
     >
       {children({
@@ -72,7 +72,7 @@ const FormFieldSet = <T,>(props: FormFieldSetProps<T>) => {
             draft.splice(i, 0, val);
           }) as T;
           onChange(newValue);
-          context.ids.splice(i, 0, util.generateUUID());
+          // context.ids.splice(i, 0, util.generateUUID());
           formFunc?.insertError(name, i);
         },
         onAppend: (val: T extends (infer U)[] ? U : never) => {
@@ -81,7 +81,7 @@ const FormFieldSet = <T,>(props: FormFieldSetProps<T>) => {
             draft.splice(i + 1, 0, val);
           }) as T;
           onChange(newValue);
-          context.ids.splice(i + 1, 0, util.generateUUID());
+          // context.ids.splice(i + 1, 0, util.generateUUID());
           formFunc?.insertError(name, i + 1);
         },
         onRemove: () => {
@@ -90,7 +90,7 @@ const FormFieldSet = <T,>(props: FormFieldSetProps<T>) => {
             draft.splice(i, 1);
           }) as T;
           onChange(newValue);
-          context.ids.splice(i, 1);
+          // context.ids.splice(i, 1);
           formFunc?.spliceError(name, i);
         },
       })}

--- a/packages/shineout/src/form/__doc__/changelog.cn.md
+++ b/packages/shineout/src/form/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.5.6-beta.1
+2024-12-25
+
+### 🐞 BugFix
+- 修复 `Form.FieldSet` 在非结尾位置插入数据时，数组的渲染显示异常的问题(Regression: since v3.5.4) ([#889](https://github.com/sheinsight/shineout-next/pull/889))
+
+
 ## 3.5.5
 2024-12-24
 


### PR DESCRIPTION

<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

### Other information