### PR TITLE
fix: 修复`Radio.Group` 传data属性用法下，设置 `size` 属性不生效的问题

### DIFF
--- a/packages/base/src/radio/radio-group.tsx
+++ b/packages/base/src/radio/radio-group.tsx
@@ -1,6 +1,6 @@
 import { RadioGroupProps } from './radio-group.type';
 import { useInputAble, useListSelectSingle, usePersistFn, util } from '@sheinx/hooks';
-import groupContext from './group-context';
+import GroupContext from './group-context';
 import Radio from './radio';
 import React, { useContext } from 'react';
 import classNames from 'classnames';
@@ -106,7 +106,7 @@ const Group = <DataItem, Value>(props0: RadioGroupProps<DataItem, Value>) => {
 
   const Radios =
     props.data === undefined ? (
-      <groupContext.Provider value={providerValue}>{children}</groupContext.Provider>
+      <GroupContext.Provider value={providerValue}>{children}</GroupContext.Provider>
     ) : (
       <>
         {props.data.map((d, i) => (
@@ -116,6 +116,7 @@ const Group = <DataItem, Value>(props0: RadioGroupProps<DataItem, Value>) => {
             disabled={datum.disabledCheck(d)}
             key={util.getKey(keygen, d, i)}
             htmlValue={i}
+            size={size}
             onChange={handleIndexChange}
             renderRadio={renderRadio}
           >

--- a/packages/shineout/src/radio/__doc__/changelog.cn.md
+++ b/packages/shineout/src/radio/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.5.6-beta.2
+2024-12-26
+### 🐞 BugFix
+
+- 修复`Radio.Group` 传data属性用法下，设置 `size` 属性不生效的问题 ([#893](https://github.com/sheinsight/shineout-next/pull/893))
+
 ## 3.4.4
 2024-10-28
 ### 🐞 BugFix


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id
eaa4aef5-19b2-4a9b-9dce-8e97cebbb36a

### Other information