### PR TITLE
fix: 修复 `Form.Field` 下的Input使用onChange设置对象格式的值时，光标跳到末尾的问题(Regression:3.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.5.6-beta.7",
+  "version": "3.5.6-beta.8",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-form/use-form.ts
+++ b/packages/hooks/src/components/use-form/use-form.ts
@@ -103,9 +103,18 @@ const useForm = <T extends ObjectType>(props: UseFormProps<T>) => {
     } else {
       const names = isArray(name) ? name : [name];
       names.forEach((key) => {
-        context.updateMap[key]?.forEach((update) => {
-          update(context.value, context.errors, context.serverErrors);
-        });
+        // 外部直接设置user.name这种格式的，但是又没有显性的声明user.name绑定的表单元素；
+        // 这里需要手动触发，否则会导致Input输入过程中光标跳到末尾的异常
+        if (!context.updateMap[key]) {
+          const parentKey = key.split('.')[0];
+          context.updateMap[parentKey]?.forEach((update) => {
+            update(context.value, context.errors, context.serverErrors);
+          });
+        } else {
+          context.updateMap[key]?.forEach((update) => {
+            update(context.value, context.errors, context.serverErrors);
+          });
+        }
         context.flowMap[key]?.forEach((update) => {
           update();
         });

--- a/packages/shineout/src/form/__doc__/changelog.cn.md
+++ b/packages/shineout/src/form/__doc__/changelog.cn.md
@@ -1,3 +1,11 @@
+## 3.5.6-beta.8
+2024-12-31
+
+### 🐞 BugFix
+- 修复 `Form.Field` 下的Input使用onChange设置对象格式的值时，光标跳到末尾的问题(Regression: since v3.4.4) ([#901](https://github.com/sheinsight/shineout-next/pull/901))
+
+
+
 ## 3.5.6-beta.1
 2024-12-25
 

--- a/packages/shineout/src/form/__example__/test-004-deley-0.tsx
+++ b/packages/shineout/src/form/__example__/test-004-deley-0.tsx
@@ -1,0 +1,77 @@
+/**
+ * cn - deley 0
+ *    -- 调试用的，在这个例子基础上随便改吧
+ * en - Test Form
+ *    -- Test Form
+ */
+import React, { useEffect, useState } from 'react';
+import { Form, DatePicker, Input, Modal, Rule, TYPE, setConfig } from 'shineout';
+
+type Value = string[];
+type FormProps = TYPE.Form.Props<Value>;
+
+setConfig({
+  delay: 0,
+});
+
+const NameInput = (props: FormProps) => {
+  const { value, onChange } = props;
+  // console.log("%c Line:37 🥒", "color:#7f2b82",{value});
+
+  const {name} = value || {}
+
+  const handleLastName = (v: string | undefined) => {
+    console.log('outer onChange')
+    onChange!({
+      name: v
+    });
+  };
+
+  useEffect(() => {
+    return () => {
+      console.log('💀💀NameInput Unmount')
+    }
+  }, [])
+
+
+  // console.log("%c Line:37 🥒", "color:#7f2b82",{name});
+
+
+  return (
+    <div>
+        <Input
+         value={name} width={120} onChange={handleLastName} clearable onFocus={() => {
+          console.log('focus')
+        }}
+        onBlur={() => {
+          console.log('blur')
+        }}/>
+    </div>
+  );
+};
+
+
+const App: React.FC = () => {
+  const [initValue, setInitValue] = useState({
+    user:{
+      name: 'Harry',
+    }
+  });
+
+  return (
+    <Form
+      value={initValue}
+      onChange={v => {
+        setInitValue(v)
+      }}
+    >
+      <Form.Item label='Name'>
+        <Form.Field name={'user'}>
+          {({value, onChange}) => <NameInput value={value} onChange={onChange} />}
+        </Form.Field>
+      </Form.Item>
+    </Form>
+  );
+};
+
+export default App;


### PR DESCRIPTION
… since v3.4.4)

<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id
3c66ee32-1e20-485b-b088-dd057e8d0c43

### Other information