### PR TITLE
fix: 修复 `Cascader` 在输入搜索过程中点击选项后 `onChange` 第二参数未返回的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.5.6-beta.9",
+  "version": "3.5.6-beta.10",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/cascader/filter-node.tsx
+++ b/packages/base/src/cascader/filter-node.tsx
@@ -20,7 +20,7 @@ const FilterNode = <DataItem, Value extends KeygenResult[]>(
 
   const styles = jssStyle?.cascader?.() as CascaderClasses;
 
-  const handleSelectItem = (index: number, e?: any) => {
+  const handleSelectItem = (index: number, d: DataItem, e?: any) => {
     const isFinal = data && index === data.length - 1;
     if (shouldFinal && !isFinal) return;
     if (e) e.stopPropagation();
@@ -28,14 +28,14 @@ const FilterNode = <DataItem, Value extends KeygenResult[]>(
     const isDisabled = datum.isDisabled(datum.getKey(item));
     if (isDisabled) return;
     const keys = data.slice(0, index + 1).map((i: DataItem) => datum.getKey(i)) as Value;
-    if (onChange) onChange(keys);
+    if (onChange) onChange(keys, d);
     onPathChange(datum.getKey(item), item, keys.slice(0, keys.length - 1) as Value, true);
     setInputText('');
     setFilterText('');
   };
 
   const handleSelect = () => {
-    handleSelectItem(data.length - 1);
+    handleSelectItem(data.length - 1, data?.[data.length - 1]);
   };
 
   return (
@@ -43,7 +43,7 @@ const FilterNode = <DataItem, Value extends KeygenResult[]>(
       <div className={classNames(styles.optionInner)}>
         {data.map((item, index) => {
           const handleClick = (e: any) => {
-            handleSelectItem(index, e);
+            handleSelectItem(index, item, e);
           };
           const isDisabled = datum.isDisabled(datum.getKey(item));
           const content = (

--- a/packages/base/src/cascader/filter-node.type.ts
+++ b/packages/base/src/cascader/filter-node.type.ts
@@ -10,7 +10,7 @@ export interface FilterNodeProps<DataItem, Value extends KeygenResult[]> {
   renderItem: (data: DataItem, active?: boolean, id?: Value[0] | undefined) => React.ReactNode;
   setInputText: (text: string) => void;
   setFilterText: (text: string) => void;
-  onChange: (item: Value) => void;
+  onChange: (item: Value, selected?: DataItem) => void;
   onPathChange: (
     id: KeygenResult,
     item: DataItem | null,

--- a/packages/shineout/src/cascader/__doc__/changelog.cn.md
+++ b/packages/shineout/src/cascader/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.5.6-beta.10
+2025-01-02
+
+### 🐞 BugFix
+- 修复 `Cascader` 在输入搜索过程中点击选项后 `onChange` 第二参数未返回的问题 ([#904](https://github.com/sheinsight/shineout-next/pull/904))
+
 ## 3.5.6-beta.9
 2025-01-02
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

- 修复 `Cascader` 在输入搜索过程中点击选项后 `onChange` 第二参数未返回的问题

### Playground id

aae6952c-d6a2-40b9-9717-e021b7de34de

### Other information