### PR TITLE
fix: 修复 `Popover` 组件在 `position='left'` 模式下三角箭头和 trigger 元素之间的垫片元素不生效的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.5.6-beta.10",
+  "version": "3.5.6-beta.11",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/popover/popover.ts
+++ b/packages/shineout-style/src/popover/popover.ts
@@ -92,7 +92,7 @@ const popoverStyle: JsStyles<PopoverClassType> = {
       },
       '&::after': {
         // left: arrowGap * -1,
-        left: `calc(${hideArrowGap} * -1)`,
+        right: `calc(${hideArrowGap} * -1)`,
         top: '0',
         bottom: '0',
         content: '" "',

--- a/packages/shineout/src/popover/__doc__/changelog.cn.md
+++ b/packages/shineout/src/popover/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.5.6-beta.11
+2025-01-02
+
+### 🐞 BugFix
+- 修复 `Popover` 组件在 `position='left'` 模式下三角箭头和 trigger 元素之间的垫片元素不生效的问题 ([#906](https://github.com/sheinsight/shineout-next/pull/906))
+
 ## 3.5.5
 2024-12-24
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

- 修复 `Popover` 组件在 `position='left'` 模式下三角箭头和 trigger 元素之间的垫片元素不生效的问题

### Playground id

65d9ed78-1686-4eef-bceb-af687c5b5e88

### Other information