### PR TITLE
fix: `Form` 在 `Modal` 组件中嵌套使用时，子Form卸载后父Form无法提交的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.5.7-beta.2",
+  "version": "3.5.7-beta.3",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/form/form-footer-context.tsx
+++ b/packages/base/src/form/form-footer-context.tsx
@@ -4,7 +4,7 @@ import React, { createContext, useMemo, useRef, useState, useContext } from 'rea
 
 export interface FormFooterContextValue {
   setFormStats: (disabled?: 'disabled' | 'pending') => void;
-  setFormInfo: (info: { submit: () => void }) => void;
+  setFormInfo: (info: { submit: () => void }) => boolean;
   deleteFormInfo: () => void;
   formStats: 'disabled' | 'pending' | undefined;
   func: {
@@ -22,7 +22,9 @@ export const FormFooterProvider = (props: { children: React.ReactNode }) => {
     if(!context.hasSubmit){
       context.submit = info.submit;
       context.hasSubmit = true;
+      return true
     }
+    return false
   });
 
   const deleteFormInfo = usePersistFn(() => {

--- a/packages/base/src/form/form.tsx
+++ b/packages/base/src/form/form.tsx
@@ -1,7 +1,7 @@
 import { FormContext, useForm, useInputAble, useLatestObj, usePersistFn, util } from '@sheinx/hooks';
 import classNames from 'classnames';
 import { useFormFooter } from './form-footer-context';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import type { FormProps } from './form.type';
 import type { ObjectType } from '@sheinx/hooks';
@@ -63,6 +63,10 @@ const Form = <V extends ObjectType>(props: FormProps<V>) => {
     }
   }, [formRefObj]);
 
+  const {current: context} = React.useRef({
+    bindindModalFormContextSuccess: false
+  })
+
   const handleFormModalInfo = () => {
     let status: 'disabled' | 'pending' | undefined = undefined;
     if (props.disabled) {
@@ -75,13 +79,16 @@ const Form = <V extends ObjectType>(props: FormProps<V>) => {
       modalFormContext?.setFormStats(status);
     }
     if (props.onSubmit) {
-      modalFormContext?.setFormInfo(formRefObj);
+      const ok = modalFormContext?.setFormInfo(formRefObj);
+      context.bindindModalFormContextSuccess = !!ok
     }
   };
   useEffect(() => {
     handleFormModalInfo();
     return () => {
-      modalFormContext?.deleteFormInfo();
+      if(context.bindindModalFormContextSuccess){
+        modalFormContext?.deleteFormInfo();
+      }
     }
   }, [props.disabled, props.pending]);
 

--- a/packages/shineout/src/form/__doc__/changelog.cn.md
+++ b/packages/shineout/src/form/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.5.7-beta.3
+2025-01-08
+
+### 🐞 BugFix
+- `Form` 在 `Modal` 组件中嵌套使用时，子Form卸载后父Form无法提交的问题 ([#914](https://github.com/sheinsight/shineout-next/pull/914))
+
+
 ## 3.5.7-beta.2
 2025-01-08
 

--- a/packages/shineout/src/form/__example__/test-005-base-form.tsx
+++ b/packages/shineout/src/form/__example__/test-005-base-form.tsx
@@ -1,0 +1,67 @@
+/**
+ * cn - Form嵌套提交
+ *    -- 调试用的，在这个例子基础上随便改吧
+ * en - Test Form
+ *    -- Test Form
+ */
+import React from 'react';
+import { Form, Input, Switch, Button, Modal } from 'shineout';
+
+export default () => {
+  const [parentForm, setParentForm] = React.useState({
+    parent1: '1',
+    parent2: '2',
+    showChild: true,
+  });
+  const [childForm, setChildForm] = React.useState({ child1: '1' });
+
+  const [modalVisible, setModalVisible] = React.useState(false);
+
+  return (
+    <div>
+      <Button
+        onClick={() => {
+          setModalVisible(true);
+        }}
+      >
+        打开Modal
+      </Button>
+      <Modal
+        title='嵌套Form提交'
+        visible={modalVisible}
+        footer={
+          <>
+            <Modal.Submit type='primary' data-apmclick='mindmap-用例列表的用例抽屉提交'>
+              保存
+            </Modal.Submit>
+            <Button
+              onClick={() => {
+                setModalVisible(false);
+              }}
+            >
+              取消
+            </Button>
+          </>
+        }
+      >
+        <Form
+          value={parentForm}
+          onChange={setParentForm}
+          onSubmit={(v) => console.log('parent form submit:>>', v)}
+        >
+          <h4>parent form:</h4>
+          <Input name='parent1' />
+          <Input name='parent2' />
+          <Switch name='showChild' />
+
+          {parentForm.showChild && (
+            <Form value={childForm} onChange={setChildForm}>
+              <h4>child form:</h4>
+              <Input name='child1' trim />
+            </Form>
+          )}
+        </Form>
+      </Modal>
+    </div>
+  );
+};


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

### Other information