### PR TITLE
fix: 修复 `Form` 的 `FormRef.validateFields("friends[1]")` 这种用法不生效和`Form…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.5.8-beta.1",
+  "version": "3.5.8-beta.2",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-form/use-form.ts
+++ b/packages/hooks/src/components/use-form/use-form.ts
@@ -196,6 +196,7 @@ const useForm = <T extends ObjectType>(props: UseFormProps<T>) => {
 
         const validates = finalFields.map((key) => {
           const validateField = context.validateMap[key];
+          if(!validateField) return []
           return Array.from(validateField).map((validate) =>
             validate(key, deepGet(context.value, key), context.value, config),
           );

--- a/packages/hooks/src/utils/object.ts
+++ b/packages/hooks/src/utils/object.ts
@@ -296,5 +296,6 @@ export const getCompleteFieldKeys = (fields: string | string[], allFields: strin
     }
   });
 
-  return completeFields;
+  // 返回之前去重
+  return Array.from(new Set(completeFields));
 }

--- a/packages/shineout/src/form/__doc__/changelog.cn.md
+++ b/packages/shineout/src/form/__doc__/changelog.cn.md
@@ -1,8 +1,15 @@
+## 3.5.8-beta.2
+2025-01-14
+
+### 🐞 BugFix
+- 修复 `Form` 的 `FormRef.validateFields("friends[1]")` 这种用法不生效和`FormRef.clearValidate(["friends[1]"])`报错的问题 ([#928](https://github.com/sheinsight/shineout-next/pull/928))
+
+
 ## 3.5.7
 2025-01-14
 
 ### 🐞 BugFix
-- 修复 `Form` 的 `FormRef.validateFields("friends[1]")` 这种用法不生效的问题 ([#920](https://github.com/sheinsight/shineout-next/pull/920))
+
 - 修复 `Form` 在 `Modal` 组件中嵌套使用时，子Form卸载后父Form无法提交的问题 ([#914](https://github.com/sheinsight/shineout-next/pull/914))
 - 修复 `Form` 的FormRef.validateFields方法校验数组类型字段不生效的问题 ([#909](https://github.com/sheinsight/shineout-next/pull/909))
 


### PR DESCRIPTION
…Ref.clearValidate(["friends[1]"])`报错的问题

<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog
- 修复 `Form` 的 `FormRef.validateFields("friends[1]")` 这种用法不生效和`FormRef.clearValidate(["friends[1]"])`报错的问题
<!-- - Fix `Component` ... -->

### Playground id
6af4b861-a626-43c3-aabf-686cfbc8e717

### Other information