### PR TITLE
fix: 修复 `Checkbox` 触发两次 `onChange` 和 `List` 设置尺寸后 Checkbox 尺寸不跟随的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.5.8-beta.2",
+  "version": "3.5.8-beta.3",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/checkbox/checkbox.tsx
+++ b/packages/base/src/checkbox/checkbox.tsx
@@ -115,7 +115,7 @@ const CheckboxWithContext = <T,>(props: CheckboxProps<T>) => {
         <Checkbox
           {...props}
           {...value}
-          onRawChange={props.onChange}
+          onRawChange={value.onChange && props.onChange ? props.onChange : undefined}
           checked={'checked' in props ? props.checked : value.checked}
         />
       )}

--- a/packages/base/src/list/list.tsx
+++ b/packages/base/src/list/list.tsx
@@ -85,6 +85,7 @@ const List = <DataItem, Value extends any[]>(props: ListProps<DataItem, Value>) 
             <Checkbox
               jssStyle={props.jssStyle}
               checked={datum.check(item)}
+              size={props.size}
               disabled={datum.disabledCheck(item)}
               onChange={(_value, checked) => {
                 if (checked) {

--- a/packages/shineout/src/checkbox/__doc__/changelog.cn.md
+++ b/packages/shineout/src/checkbox/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.5.8-beta.3
+2025-01-15
+### 🐞 BugFix
+
+- 修复 `Checkbox` 触发两次 `onChange` 的问题（Regression: since v3.5.6） ([#929](https://github.com/sheinsight/shineout-next/pull/929))
+
 ## 3.5.6
 2025-01-06
 ### 🐞 BugFix

--- a/packages/shineout/src/list/__doc__/changelog.cn.md
+++ b/packages/shineout/src/list/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.5.8-beta.3
+2025-01-15
+
+### 🐞 BugFix
+
+-  修复 `List` 组件设置 `size` 属性后选择行的 Checkbox 组件不跟随尺寸的问题 ([#929](https://github.com/sheinsight/shineout-next/pull/929))
+
 ## 3.4.4
 2024-10-28
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

- 修复 `Checkbox` 触发两次 `onChange` 的问题
- 修复 `List` 组件设置 `size` 属性后选择行的 Checkbox 组件不跟随尺寸的问题

### Playground id

2708265f-20f2-4535-88ad-fd3d04ae3941

### Other information