### PR TITLE
fix: 修复 `Input` 开启 `digits` 是值为 0 的情况下依然可以输入小数的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.5.8-beta.4",
+  "version": "3.5.8-beta.5",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-input/use-input-format.ts
+++ b/packages/hooks/src/components/use-input/use-input-format.ts
@@ -57,7 +57,7 @@ const useInputFormat = (props: InputFormatProps) => {
       // 修正小数位数
       const _value = v.split('.');
       const __value = value.split('.');
-      if (_value[1] !== undefined && __value[1] === undefined) {
+      if (_value[1] !== undefined && __value[1] === undefined && digits !== 0) {
         value = `${value}.${_value[1]}`;
       }
     }

--- a/packages/shineout/src/input/__doc__/changelog.cn.md
+++ b/packages/shineout/src/input/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.5.8-beta.5
+2025-01-20
+
+### 🐞 BugFix
+
+- 修复 `Input` 开启 `digits` 是值为 0 的情况下依然可以输入小数的问题（Regression: since v3.5.7） ([#935](https://github.com/sheinsight/shineout-next/pull/935))
+
 ## 3.5.7
 2025-01-14
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

948553d3-178b-45df-b663-a46d53c6e7b6

### Other information