### PR TITLE
fix: 修复 `Transfer` 设置了 `renderFilter` 之后可能导致左右面板高度不一致的问题

### DIFF
--- a/packages/base/src/progress/circle.tsx
+++ b/packages/base/src/progress/circle.tsx
@@ -42,11 +42,6 @@ const Circle = (props: ProgressProps) => {
     type === 'danger' && progressClasses?.wrapperDanger,
   );
 
-  console.log('======================')
-  console.log('dasharray: >>', dasharray)
-  console.log('strokeLinecap: >>', strokeLinecap)
-  console.log('width: >>', width)
-  console.log('======================')
   return (
     <div className={mc} style={style}>
       <svg viewBox={`0 0 ${size} ${size}`}>

--- a/packages/base/src/transfer/transfer-list.tsx
+++ b/packages/base/src/transfer/transfer-list.tsx
@@ -1,3 +1,4 @@
+import { useLayoutEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
 import { util, KeygenResult } from '@sheinx/hooks';
 import { getLocale, useConfig } from '../config';
@@ -26,7 +27,7 @@ const TransferList = <DataItem, Value extends KeygenResult[]>(
     loading,
     listStyle,
     listClassName,
-    listHeight = 180,
+    listHeight: listHeightProp = 180,
     lineHeight: lineHeightProp,
     listType,
     rowsInView = 20,
@@ -53,6 +54,20 @@ const TransferList = <DataItem, Value extends KeygenResult[]>(
     [styles.target]: listType === 'target',
   });
   const listClass = classNames(styles.list, listClassName);
+
+  const [addonHeight, setAddonHeight] = useState(0);
+  const listContainerRef = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    if(!listContainerRef.current) return;
+
+    const $list = listContainerRef.current.querySelector(`.${styles.list}`);
+    const containerBottom = listContainerRef.current.getBoundingClientRect().bottom;
+    const listBottom = $list?.getBoundingClientRect().bottom || containerBottom;
+    if(containerBottom - listBottom > 1) {
+      setAddonHeight(containerBottom - listBottom);
+    }
+  },[]);
+  const listHeight = listHeightProp + addonHeight;
 
   const getLineHeight = () => {
     if (lineHeightProp) {
@@ -201,7 +216,7 @@ const TransferList = <DataItem, Value extends KeygenResult[]>(
   };
 
   return (
-    <div className={rootClass}>
+    <div className={rootClass} ref={listContainerRef}>
       {renderHeader()}
       <Spin
         className={styles.spinContainer}

--- a/packages/base/src/transfer/transfer-list.tsx
+++ b/packages/base/src/transfer/transfer-list.tsx
@@ -71,7 +71,6 @@ const TransferList = <DataItem, Value extends KeygenResult[]>(
 
   const getLineHeight = () => {
     if (lineHeightProp) {
-      // console.log('lineHeightProp', lineHeightProp);
       return lineHeightProp;
     }
     if (size === 'small') {

--- a/packages/shineout/src/transfer/__doc__/changelog.cn.md
+++ b/packages/shineout/src/transfer/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.6.0-beta.8
+2025-02-20
+
+### 🐞 BugFix
+
+- 修复 `Transfer` 设置了 `renderFilter` 之后可能导致左右面板高度不一致的问题 ([#967](https://github.com/sheinsight/shineout-next/pull/967))
+
 ## 3.5.8
 2025-02-13
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id
d321839d-6d07-4023-adc3-540ff4f1be0d

### Other information