### PR TITLE
feat: Popover类弹出层的父元素滚动超出视口时, 自动隐藏Popover

### DIFF
--- a/packages/hooks/src/common/use-position-style/check-position.ts
+++ b/packages/hooks/src/common/use-position-style/check-position.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 
-interface Position {
+export interface Position {
   top: number;
   left: number;
 }

--- a/packages/shineout/src/pagination/__doc__/changelog.cn.md
+++ b/packages/shineout/src/pagination/__doc__/changelog.cn.md
@@ -2,7 +2,7 @@
 2025-03-25
 
 ### 🐞 BugFix
-- 修复 `Pagination` 的 `simple` 模式输入框不展示当前页的问题（Regression： since v3.6.0） ([#1009](https://github.com/sheinsight/shineout-next/pull/1009))
+- 修复 `Pagination` 的 `simple` 模式输入框不展示当前页的问题（Regression： since v3.6.0） ([#1010](https://github.com/sheinsight/shineout-next/pull/1010))
 
 ## 3.4.4
 2024-10-28


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

### Other information