### PR TITLE
fix: 修复 `Pagination` 的 `simple` 模式输入框不展示当前页的问题（Regression： since v3.6.0）

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.6.1-beta.1",
+  "version": "3.6.1-beta.2",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/pagination/pagination-jumper.tsx
+++ b/packages/base/src/pagination/pagination-jumper.tsx
@@ -1,21 +1,22 @@
 import classNames from 'classnames';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Input from '../input';
 import { PaginationJumperProps } from './pagination-jumper.type';
 
 const PaginationJumper = (props: PaginationJumperProps) => {
-  const { jssStyle, simple, size, total, pageSize, disabled, text, onChange } = props;
+  const { jssStyle, simple, size, total, pageSize, disabled, text, current, onChange } = props;
   const paginationStyle = jssStyle?.pagination?.();
   const rootClasses = classNames(paginationStyle?.section, paginationStyle?.jumper);
 
   let txt: string[] | React.ReactNode[] = text.jumper ? text.jumper.split('{input}') : [];
-  const [value, setValue] = useState('');
+  const [value, setValue] = useState(String(current));
 
   const getMax = () => {
     return Math.ceil(total / pageSize) || 1;
   };
 
   const cleatInternalState = () => {
+    if(simple) return;
     setValue('');
   };
 
@@ -35,6 +36,11 @@ const PaginationJumper = (props: PaginationJumperProps) => {
   const handleChange = (v?: string) => {
     setValue(v || '');
   };
+
+  useEffect(() => {
+    if(!simple) return;
+    setValue(String(current));
+  }, [current, simple]);
 
   const renderInput = () => {
     return (

--- a/packages/base/src/pagination/pagination-jumper.type.ts
+++ b/packages/base/src/pagination/pagination-jumper.type.ts
@@ -10,6 +10,7 @@ export interface PaginationJumperProps extends Pick<CommonType, 'size'> {
     pagination?: () => PaginationClasses;
   };
   total: number;
+  current?: number;
   simple?: boolean;
   pageSize: number;
   text: TextParams;

--- a/packages/base/src/pagination/pagination-simple.tsx
+++ b/packages/base/src/pagination/pagination-simple.tsx
@@ -44,6 +44,7 @@ const PaginationSimple = (props: PaginationSimpleProps) => {
         total={total}
         text={text}
         size={size}
+        current={current}
         pageSize={pageSize}
         onChange={onChange}
       ></Jumper>

--- a/packages/base/src/pagination/pagination.tsx
+++ b/packages/base/src/pagination/pagination.tsx
@@ -100,6 +100,7 @@ const Pagination = (props: PaginationProps) => {
                 {...props}
                 text={text}
                 total={total}
+                current={current}
                 pageSize={pageSize}
                 onChange={onChange}
               />

--- a/packages/shineout/src/pagination/__doc__/changelog.cn.md
+++ b/packages/shineout/src/pagination/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.6.1-beta.2
+2025-03-25
+
+### 🐞 BugFix
+- 修复 `Pagination` 的 `simple` 模式输入框不展示当前页的问题（Regression： since v3.6.0） ([#1009](https://github.com/sheinsight/shineout-next/pull/1009))
+
 ## 3.4.4
 2024-10-28
 

--- a/packages/shineout/src/pagination/__test__/__snapshots__/pagination.spec.tsx.snap
+++ b/packages/shineout/src/pagination/__test__/__snapshots__/pagination.spec.tsx.snap
@@ -842,7 +842,7 @@ exports[`Pagination[Base] should render correctly about disabled 1`] = `
           class="soui-input-input"
           disabled=""
           type="text"
-          value=""
+          value="1"
         />
       </div>
     </div>
@@ -989,7 +989,7 @@ exports[`Pagination[Base] should render correctly about jumper 1`] = `
         <input
           class="soui-input-input"
           type="text"
-          value=""
+          value="1"
         />
       </div>
     </div>
@@ -1279,7 +1279,7 @@ exports[`Pagination[Base] should render correctly about simple 1`] = `
         <input
           class="soui-input-input"
           type="text"
-          value=""
+          value="1"
         />
       </div>
     </div>


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog
- 修复 `Pagination` 的 `simple` 模式输入框不展示当前页的问题（Regression： since v3.6.0）
<!-- - Fix `Component` ... -->

### Playground id
d3601609-7b6a-4e36-aa3d-0bb766b52eca

### Other information