### PR TITLE
fix: 修复 `Form` 在表单组件的 key 变更后 `defaultValue` 无法设置成功的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.6.1-beta.5",
+  "version": "3.6.1-beta.6",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.6.1-beta.2",
+  "version": "3.6.1-beta.3",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.6.1-beta.3",
+  "version": "3.6.1-beta.4",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.6.1-beta.4",
+  "version": "3.6.1-beta.5",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.6.1-beta.6",
+  "version": "3.6.1-beta.7",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/card-group/item.tsx
+++ b/packages/base/src/card-group/item.tsx
@@ -23,7 +23,6 @@ const Item = <V,>(props: CardGroupItemProps<V>) => {
 
   const renderChildren = (content: React.ReactNode) => {
     if (!props.placeholder) return content;
-    if (!container) return content;
     return (
       <Lazyload container={container} placeholder={props.placeholder} isInView={isInView}>
         {content}

--- a/packages/base/src/card-group/lazyload.tsx
+++ b/packages/base/src/card-group/lazyload.tsx
@@ -6,7 +6,7 @@ const { addStack, removeStack } = util;
 export interface LazyloadProps {
   children?: React.ReactNode;
   placeholder?: React.ReactNode;
-  container?: HTMLElement;
+  container?: HTMLElement | null;
   offset?: number;
   isInView?: boolean;
 }

--- a/packages/base/src/input/input-group.tsx
+++ b/packages/base/src/input/input-group.tsx
@@ -35,11 +35,11 @@ export default (props: InputGroupProps) => {
       ref.current.eventMap.set(child, {
         onFocus: (...args: any) => {
           setFocus(true);
-          ref.current.propsMap.get(child)?.onFocus?.(args);
+          ref.current.propsMap.get(child)?.onFocus?.(...args);
         },
         onBlur: (...args: any) => {
           setFocus(false);
-          ref.current.propsMap.get(child)?.onBlur?.(args);
+          ref.current.propsMap.get(child)?.onBlur?.(...args);
         },
       });
     }

--- a/packages/hooks/src/common/use-in-view/use-in-view.ts
+++ b/packages/hooks/src/common/use-in-view/use-in-view.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { isScrollable } from '../../utils/dom';
 
 type ElementType = HTMLElement;
 
@@ -38,7 +39,7 @@ const useInView = <T extends ElementType>(options: UseInViewOptions = {}) => {
         }
       },
       {
-        root: options.root || null,
+        root: options.root && isScrollable(options.root) ? options.root : null,
         rootMargin: options.rootMargin || '0px',
         threshold: options.threshold || 0,
       }

--- a/packages/hooks/src/common/use-position-style/check-position.ts
+++ b/packages/hooks/src/common/use-position-style/check-position.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 
-interface Position {
+export interface Position {
   top: number;
   left: number;
 }

--- a/packages/hooks/src/components/use-form/use-form.ts
+++ b/packages/hooks/src/components/use-form/use-form.ts
@@ -624,8 +624,6 @@ const useForm = <T extends ObjectType>(props: UseFormProps<T>) => {
     context.lastValue = props.value;
   };
 
-  updateValue();
-
   React.useEffect(() => {
     // 服务端错误更新
     if (!props.error) context.serverErrors = {};
@@ -645,6 +643,7 @@ const useForm = <T extends ObjectType>(props: UseFormProps<T>) => {
 
   // 默认值更新
   React.useEffect(() => {
+    updateValue();
     context.removeLock = false;
     // 内部 onChange 改的 value, 不需要更新
     if (props.value === context.value) return;

--- a/packages/hooks/src/components/use-form/use-form.ts
+++ b/packages/hooks/src/components/use-form/use-form.ts
@@ -282,13 +282,19 @@ const useForm = <T extends ObjectType>(props: UseFormProps<T>) => {
             if (offsetTop < 0) {
               parentEl.scrollTop = Math.max(parentEl.scrollTop + offsetTop, 0);
             } else {
-              parentEl.scrollTop = Math.min(parentEl.scrollTop + offsetTop, parentEl.scrollHeight - parentEl.clientHeight);
+              parentEl.scrollTop = Math.min(
+                parentEl.scrollTop + offsetTop,
+                parentEl.scrollHeight - parentEl.clientHeight,
+              );
             }
             // 如果是往左滚动，那么只有当元素的偏移量小于0时才需要滚动
             if (offsetLeft < 0) {
               parentEl.scrollLeft = Math.max(parentEl.scrollLeft + offsetLeft, 0);
             } else {
-              parentEl.scrollLeft = Math.min(parentEl.scrollLeft + offsetLeft, parentEl.scrollWidth - parentEl.clientWidth);
+              parentEl.scrollLeft = Math.min(
+                parentEl.scrollLeft + offsetLeft,
+                parentEl.scrollWidth - parentEl.clientWidth,
+              );
             }
           }
         } else {
@@ -501,8 +507,11 @@ const useForm = <T extends ObjectType>(props: UseFormProps<T>) => {
         context.updateMap[n] = new Set();
       }
       context.updateMap[n].add(updateFn);
+      const shouldTriggerResetChange = context.removeArr.has(n);
       context.removeArr.delete(n);
-      if (df !== undefined && deepGet(context.value, n) === undefined) {
+      const shouldTriggerDefaultChange =
+        df !== undefined && deepGet(context.value, n) === undefined;
+      if (shouldTriggerDefaultChange || shouldTriggerResetChange) {
         if (!context.mounted) context.defaultValues[n] = df;
         setTimeout(() => {
           onChange((v) => {

--- a/packages/hooks/src/components/use-table/use-table-filter.ts
+++ b/packages/hooks/src/components/use-table/use-table-filter.ts
@@ -72,19 +72,24 @@ const useTableFilter = <Item = any>(props: UseTableFilterProps<Item>) => {
 
   // 根据columns生成filterInfo
   useEffect(() => {
-    const _filterInfo = props?.columns?.reduce((acc, column, index) => {
-      if(!column.filter) return acc;
-      const columnKey = typeof column.render === 'string' ? column.render : String(index);
+    setFilterInfo((prev) => {
+      const _filterInfo = props?.columns?.reduce((acc, column, index) => {
+        if(!column.filter) return acc;
+        const columnKey = typeof column.render === 'string' ? column.render : String(index);
 
-      acc.set(columnKey, {
-        value: undefined,
-        onFilter: column.filter?.onFilter,
-      } as FilterInfo<Item>);
+        const prevValue = prev.get(columnKey)?.value;
 
-      return acc
-    }, new Map() as FilterMap<Item>);
+        acc.set(columnKey, {
+          value: prevValue,
+          onFilter: column.filter?.onFilter,
+        } as FilterInfo<Item>);
 
-    if(_filterInfo) setFilterInfo(_filterInfo);
+        return acc
+      }, new Map());
+
+      return _filterInfo || new Map()
+    })
+
 
 }, [props.columns])
 

--- a/packages/hooks/src/utils/dom/element.tsx
+++ b/packages/hooks/src/utils/dom/element.tsx
@@ -103,6 +103,19 @@ export function getParent(el: HTMLElement | null | Element, target?: string | HT
   return null;
 }
 
+export function isScrollable(el: HTMLElement) {
+  const style = window.getComputedStyle(el);
+  const overflowX = style.overflowX;
+  const overflowY = style.overflowY;
+  return (
+    (overflowX === 'auto' ||
+      overflowX === 'scroll' ||
+      overflowY === 'auto' ||
+      overflowY === 'scroll') &&
+    (el.scrollHeight > el.clientHeight || el.scrollWidth > el.clientWidth)
+  );
+}
+
 export function getClosestScrollContainer(element: HTMLElement | null): HTMLElement | null {
   if (!element) {
     return null;

--- a/packages/hooks/src/utils/dom/element.tsx
+++ b/packages/hooks/src/utils/dom/element.tsx
@@ -121,20 +121,6 @@ export function getClosestScrollContainer(element: HTMLElement | null): HTMLElem
     return null;
   }
 
-  // 检查元素是否可滚动
-  const isScrollable = (el: HTMLElement) => {
-    const style = window.getComputedStyle(el);
-    const overflowX = style.overflowX;
-    const overflowY = style.overflowY;
-    return (
-      (overflowX === 'auto' ||
-        overflowX === 'scroll' ||
-        overflowY === 'auto' ||
-        overflowY === 'scroll') &&
-      (el.scrollHeight > el.clientHeight || el.scrollWidth > el.clientWidth)
-    );
-  };
-
   // 如果元素本身是可滚动的，直接返回
   if (isScrollable(element)) {
     return element;

--- a/packages/shineout-style/src/input/input-border.ts
+++ b/packages/shineout-style/src/input/input-border.ts
@@ -62,7 +62,6 @@ export default <T extends string>(name: T, token: Token = {} as any) => {
       verticalAlign: 'top',
       transition: `border-color .15s ease-in-out,box-shadow .15s ease-in-out;`,
       '&:hover': {
-        zIndex: 1,
         borderColor: token.hoverBorderColor,
         [`&:not($${name}Disabled):not($${name}Error)`]: {
           backgroundColor: token.hoverBackgroundColor,
@@ -84,6 +83,10 @@ export default <T extends string>(name: T, token: Token = {} as any) => {
         flexShrink: 0,
         width: 'auto',
         'margin-left': `-1px`,
+
+        '&:hover': {
+          zIndex: 1050,
+        },
 
         '&:first-child': {
           marginLeft: 0,

--- a/packages/shineout/src/card-group/__doc__/changelog.cn.md
+++ b/packages/shineout/src/card-group/__doc__/changelog.cn.md
@@ -1,9 +1,9 @@
-## 3.6.1-beta.5
+## 3.6.1-beta.7
 2025-03-26
 
 ### 💎 Enhancement
 
-- 优化 `CardGroup` 在非滚动容器下也能支持懒加载 ([#1016](https://github.com/sheinsight/shineout-next/pull/1016))
+- 优化 `CardGroup.Item` 在非滚动容器下也能支持懒加载 ([#1016](https://github.com/sheinsight/shineout-next/pull/1016), [#1017](https://github.com/sheinsight/shineout-next/pull/1017))
 
 
 ## 3.4.5

--- a/packages/shineout/src/card-group/__doc__/changelog.cn.md
+++ b/packages/shineout/src/card-group/__doc__/changelog.cn.md
@@ -1,3 +1,11 @@
+## 3.6.1-beta.5
+2025-03-26
+
+### 💎 Enhancement
+
+- 优化 `CardGroup` 在非滚动容器下也能支持懒加载 ([#1016](https://github.com/sheinsight/shineout-next/pull/1016))
+
+
 ## 3.4.5
 2024-10-31
 

--- a/packages/shineout/src/date-picker/__doc__/changelog.cn.md
+++ b/packages/shineout/src/date-picker/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.6.1-beta.5
+2025-03-26
+
+### 🐞 BugFix
+
+- 修复 `DatePicker` 弹出层的层级低于其他absolute元素的问题（Regression： since v3.6.0） ([#1015](https://github.com/sheinsight/shineout-next/pull/1015))
+
 ## 3.6.0
 2025-03-20
 

--- a/packages/shineout/src/form/__doc__/changelog.cn.md
+++ b/packages/shineout/src/form/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.6.1-beta.4
+2025-03-25
+
+### 🐞 BugFix
+- 修复 `Form` 同时设置 value 和 names为数组的DatePicker并发渲染时，value未按照预期设置进去的问题  ([#1013](https://github.com/sheinsight/shineout-next/pull/1013))
+
+
 ## 3.6.0
 2025-03-20
 

--- a/packages/shineout/src/form/__example__/test-004-deley-0.tsx
+++ b/packages/shineout/src/form/__example__/test-004-deley-0.tsx
@@ -1,77 +1,72 @@
 /**
- * cn - deley 0
+ * cn - form onchange
  *    -- 调试用的，在这个例子基础上随便改吧
  * en - Test Form
  *    -- Test Form
  */
-import React, { useEffect, useState } from 'react';
-import { Form, DatePicker, Input, Modal, Rule, TYPE, setConfig } from 'shineout';
+import { Form, Input, DatePicker, Select } from 'shineout';
+import { useState } from 'react';
 
-type Value = string[];
-type FormProps = TYPE.Form.Props<Value>;
-
-setConfig({
-  delay: 0,
-});
-
-const NameInput = (props: FormProps) => {
-  const { value, onChange } = props;
-  // console.log("%c Line:37 🥒", "color:#7f2b82",{value});
-
-  const {name} = value || {}
-
-  const handleLastName = (v: string | undefined) => {
-    console.log('outer onChange')
-    onChange!({
-      name: v
-    });
-  };
-
-  useEffect(() => {
-    return () => {
-      console.log('💀💀NameInput Unmount')
-    }
-  }, [])
-
-
-  // console.log("%c Line:37 🥒", "color:#7f2b82",{name});
-
+export default () => {
+  const data = [1, 2];
+  const [formValue, setFormValue] = useState<Record<string, any>>({});
 
   return (
     <div>
-        <Input
-         value={name} width={120} onChange={handleLastName} clearable onFocus={() => {
-          console.log('focus')
+      <Form
+        value={formValue}
+        onChange={(vv) => {
+          console.log(111, vv);
+          setFormValue(vv);
         }}
-        onBlur={() => {
-          console.log('blur')
-        }}/>
+      >
+        <Form.Item label='时间类型'>
+          <Select
+            name='timeType'
+            clearable
+            data={data}
+            keygen
+            onChange={(v) => {
+              const tempValue = {
+                ...formValue,
+                effectiveTimeEnd: '',
+                timeType: v,
+              };
+              // 为红色则name赋值
+              if (v === 1) {
+                console.log(222);
+                tempValue.effectiveTimeEnd = '2099-12-31 23:59:00';
+              }
+              console.log(333, tempValue);
+              setFormValue(tempValue);
+            }}
+          />
+        </Form.Item>
+        <Form.Item label='生效时间'>
+          {formValue.timeType === 1 ? (
+            <Input.Group style={{ width: '100%' }}>
+              <DatePicker
+                type='datetime'
+                format='YYYY-MM-DD HH:mm'
+                defaultTime='00:00:00'
+                name='effectiveTimeBegin'
+                placeholder={'开始时间'}
+              />
+              <div style={{ display: 'flex', alignItems: 'center', padding: '0 8px' }}>~</div>
+              <div style={{ padding: '5px 8px' }}>{formValue.effectiveTimeEnd?.slice(0, 16)}</div>
+            </Input.Group>
+          ) : (
+            <DatePicker
+              type='datetime'
+              range
+              name={['effectiveTimeBegin', 'effectiveTimeEnd']}
+              defaultTime={['00:00:00', '23:59:00']}
+              placeholder={['开始时间', '结束时间']}
+              format='YYYY-MM-DD HH:mm'
+            />
+          )}
+        </Form.Item>
+      </Form>
     </div>
   );
 };
-
-
-const App: React.FC = () => {
-  const [initValue, setInitValue] = useState({
-    user:{
-      name: 'Harry',
-    }
-  });
-
-  return (
-    <Form
-      value={initValue}
-      onChange={v => {
-        setInitValue(v)
-      }}
-    >
-      <Form.Item label='Name'>
-        <Form.Field name={'user'}>
-          {({value, onChange}) => <NameInput value={value} onChange={onChange} />}
-        </Form.Field>
-      </Form.Item>
-    </Form>
-  );
-};
-
-export default App;

--- a/packages/shineout/src/input/__doc__/changelog.cn.md
+++ b/packages/shineout/src/input/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.6.1-beta.4
+2025-03-25
+
+### 🐞 BugFix
+
+- 修复 `Input.Group` 下面的 `Input` 的 `onBlur` 和 `onFocus` 回调函数的参数格式不正确的问题 ([#1014](https://github.com/sheinsight/shineout-next/pull/1014))
+
 ## 3.6.0
 2025-03-13
 

--- a/packages/shineout/src/pagination/__doc__/changelog.cn.md
+++ b/packages/shineout/src/pagination/__doc__/changelog.cn.md
@@ -2,7 +2,7 @@
 2025-03-25
 
 ### 🐞 BugFix
-- 修复 `Pagination` 的 `simple` 模式输入框不展示当前页的问题（Regression： since v3.6.0） ([#1009](https://github.com/sheinsight/shineout-next/pull/1009))
+- 修复 `Pagination` 的 `simple` 模式输入框不展示当前页的问题（Regression： since v3.6.0） ([#1010](https://github.com/sheinsight/shineout-next/pull/1010))
 
 ## 3.4.4
 2024-10-28

--- a/packages/shineout/src/table/__doc__/changelog.cn.md
+++ b/packages/shineout/src/table/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.6.1-beta.3
+2025-03-25
+
+### 🐞 BugFix
+- 修复 `Table` 的columns是动态值时，column.filter的过滤功能意外的被重置的问题 ([#1012](https://github.com/sheinsight/shineout-next/pull/1012))
+
 ## 3.6.0
 2025-03-06
 

--- a/packages/shineout/src/table/__test__/table.spec.tsx
+++ b/packages/shineout/src/table/__test__/table.spec.tsx
@@ -29,6 +29,7 @@ import TableGroup from '../__example__/04-group';
 // import TableSorter from '../__example__/09-01-sorter'
 // import TableSorterRender from '../__example__/09-02-sorter-render'
 import TableSorterWeight from '../__example__/09-03-sorter-weight';
+import TableColumnFilter from '../__example__/09-001-filter-column';
 // import TablePaginationCopy from '../__example__/10-01-pagination copy'
 // import TablePagination from '../__example__/10-02-pagination'
 // import TableScroll from '../__example__/11-scroll'
@@ -55,6 +56,8 @@ const originClasses = [
   'sorterDesc',
   'resizeSpanner',
   'expandIcon',
+  'filterIconContainer',
+  'filterIcon',
 ];
 const originItemClasses = [
   'default',
@@ -85,7 +88,7 @@ const {
   rowStriped,
   small: tableSmall,
   cellHover,
-  rowHover,
+  // rowHover,
   verticalAlignMiddle,
   iconWrapper,
   rowExpand,
@@ -101,6 +104,7 @@ const {
   cellFixedLast,
   cellFixedRight,
   expandIcon,
+  filterIconContainer,
 } = createClassName(SO_PREFIX, originClasses, originItemClasses);
 
 const {
@@ -1093,6 +1097,16 @@ describe('Table[Checked]', () => {
     trs.forEach((item) => {
       classTest(item, rowChecked);
     });
+  });
+});
+describe('Table[Filter]', () => {
+  test('should render filter icons', () => {
+    const { container } = render(<TableColumnFilter />);
+    const thead = container.querySelector('thead')!;
+    const iconContainer = thead.querySelectorAll(filterIconContainer);
+
+    // 断言iconContainer的数量为5
+    expect(iconContainer.length).toBe(5);
   });
 });
 describe('Table[Sort]', () => {


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

f88e0d6d-c5db-4a36-af4f-2bfd008a4f4d

### Other information

现象是：key 变了，组件卸载再挂载，value 没有变。理论上没给 reserveAble 的话，应该 value 会被删掉，然后用 defaultValue 替代

预期是：key 变了，组件先卸载，由于没给 reserveAble 会导致 value 被删了。但是马上又挂载了，由于没有 value ，所以 defaultValue 会上位，然后触发一次 onChange