### PR TITLE
fix: 修复 `Input.Group` 下面的 `Input` 的 `onBlur` 和 `onFocus` 回调函数的参数格式不正确的问题

### DIFF
--- a/packages/base/src/input/input-group.tsx
+++ b/packages/base/src/input/input-group.tsx
@@ -35,11 +35,11 @@ export default (props: InputGroupProps) => {
       ref.current.eventMap.set(child, {
         onFocus: (...args: any) => {
           setFocus(true);
-          ref.current.propsMap.get(child)?.onFocus?.(args);
+          ref.current.propsMap.get(child)?.onFocus?.(...args);
         },
         onBlur: (...args: any) => {
           setFocus(false);
-          ref.current.propsMap.get(child)?.onBlur?.(args);
+          ref.current.propsMap.get(child)?.onBlur?.(...args);
         },
       });
     }

--- a/packages/shineout/src/input/__doc__/changelog.cn.md
+++ b/packages/shineout/src/input/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.6.1-beta.4
+2025-03-25
+
+### 🐞 BugFix
+
+- 修复 `Input.Group` 下面的 `Input` 的 `onBlur` 和 `onFocus` 回调函数的参数格式不正确的问题 ([#1014](https://github.com/sheinsight/shineout-next/pull/1014))
+
 ## 3.6.0
 2025-03-13
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

### Other information