### PR TITLE
fix: 修复 `Card.Header` 和 `Card.Footer` 在未开启 `moveable` 属性时不可选中文本的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.6.1-beta.7",
+  "version": "3.6.1-beta.8",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/card/card.tsx
+++ b/packages/base/src/card/card.tsx
@@ -61,7 +61,7 @@ const Card = (props: CardProps) => {
       collapsed: realCollapsed,
       collapsible: collapsible,
       onCollapse: handleCollapsed,
-      handleDragMouseDown: moveInfo.handleMouseDown,
+      handleDragMouseDown: props.moveable ? moveInfo.handleMouseDown : undefined,
     };
   }, [realCollapsed, collapsible]);
 

--- a/packages/shineout/src/card/__doc__/changelog.cn.md
+++ b/packages/shineout/src/card/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.6.1-beta.8
+2025-03-28
+### 🐞 BugFix
+
+- 修复 `Card.Header` 和 `Card.Footer` 在未开启 `moveable` 属性时不可选中文本的问题 ([#1022](https://github.com/sheinsight/shineout-next/pull/1022))
+
+
 ## 3.1.23
 2024-06-01
 ### 🐞 BugFix


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

### Other information