### PR TITLE
fix: 修复 `Form.Field` 在 `name` 为数组情况下组件卸载时错误信息无法清空的问题

### DIFF
--- a/packages/hooks/src/components/use-form/use-form-control/use-form-control.ts
+++ b/packages/hooks/src/components/use-form/use-form-control/use-form-control.ts
@@ -78,11 +78,7 @@ export default function useFormControl<T>(props: BaseFormControlProps<T>) {
   }
 
   const update = usePersistFn(
-    (
-      formValue: ObjectType = {},
-      errors: ObjectType,
-      severErrors: ObjectType,
-    ) => {
+    (formValue: ObjectType = {}, errors: ObjectType, severErrors: ObjectType) => {
       if (!name) return;
       if (isArray(name)) {
         const value = getValue(name, formValue) as T[];
@@ -215,8 +211,8 @@ export default function useFormControl<T>(props: BaseFormControlProps<T>) {
         if (isArray(name)) {
           name.forEach((n) => {
             controlFunc.unbind(n, reserveAble, validateField, update);
-            updateError(n, undefined);
           });
+          updateError(isArray(name) ? name.join('|') : name, undefined);
         } else {
           controlFunc.unbind(name, reserveAble, validateField, update);
           updateError(name, undefined);


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

6f86a38d-fabc-4e85-80e1-25c4326017fe

### Other information