### PR TITLE
fix: 修复 `Modal` 多层嵌套使用时，关闭子Modal但未关闭父Modal时body的滚动条出现的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.6.3-beta.3",
+  "version": "3.6.3-beta.4",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/modal/modal-content.tsx
+++ b/packages/base/src/modal/modal-content.tsx
@@ -156,6 +156,7 @@ const Modal = (props: ModalContentProps) => {
           doc.style.paddingRight = `${window.innerWidth - util.docSize.width}px`;
         }
       } else {
+        if(!context.isMask) return;
         doc.style.paddingRight = '';
         doc.style.overflow = '';
       }
@@ -180,6 +181,7 @@ const Modal = (props: ModalContentProps) => {
         hasMask = false;
       }
       {
+        if(!context.isMask) return;
         const doc = document.body.parentNode! as HTMLElement;
         doc.style.paddingRight = '';
         doc.style.overflow = '';

--- a/packages/shineout/src/modal/__doc__/changelog.cn.md
+++ b/packages/shineout/src/modal/__doc__/changelog.cn.md
@@ -1,9 +1,9 @@
-## 3.5.5
-2024-12-24
+## 3.6.3-beta.4
+2025-04-14
 
 ### 🐞 BugFix
 
-- 修复 `Modal.Submit` 在存在多个 `Form` 切换时，点击触发的onSubmit的value不正确的问题 ([#885](https://github.com/sheinsight/shineout-next/pull/885))
+- 修复 `Modal` 多层嵌套使用时，关闭子Modal但未关闭父Modal时body的滚动条出现的问题 ([#1054](https://github.com/sheinsight/shineout-next/pull/1054))
 
 
 ## 3.5.0


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id
f4c81797-ff66-471c-ac01-2fc2e6fb8d40

### Other information