### PR TITLE
fix: 修复 `Form` 在表单组件的 key 变更后 `defaultValue` 无法设置成功的问题

### DIFF
--- a/packages/hooks/src/components/use-form/use-form-control/use-form-control.type.ts
+++ b/packages/hooks/src/components/use-form/use-form-control/use-form-control.type.ts
@@ -34,3 +34,7 @@ export interface BaseFormControlProps<T> {
    */
   getValidateProps: (() => ObjectType) | undefined;
 }
+
+export interface FormControlContext {
+  mounted: boolean;
+}

--- a/packages/hooks/src/components/use-form/use-form.ts
+++ b/packages/hooks/src/components/use-form/use-form.ts
@@ -507,8 +507,11 @@ const useForm = <T extends ObjectType>(props: UseFormProps<T>) => {
         context.updateMap[n] = new Set();
       }
       context.updateMap[n].add(updateFn);
+      const shouldTriggerResetChange = context.removeArr.has(n);
       context.removeArr.delete(n);
-      if (df !== undefined && deepGet(context.value, n) === undefined) {
+      const shouldTriggerDefaultChange =
+        df !== undefined && deepGet(context.value, n) === undefined;
+      if (shouldTriggerDefaultChange || shouldTriggerResetChange) {
         if (!context.mounted) context.defaultValues[n] = df;
         onChange((v) => {
           deepSet(v, n, df, deepSetOptions);

--- a/packages/shineout/src/form/__doc__/changelog.cn.md
+++ b/packages/shineout/src/form/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.6.4-beta.5
+2025-04-17
+
+### 🐞 BugFix
+- 修复 `Form` 在表单组件的 key 变更后 `defaultValue` 无法设置成功的问题 ([#1068](https://github.com/sheinsight/shineout-next/pull/1068))
+
 ## 3.6.4-beta.4
 2025-04-16
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

f88e0d6d-c5db-4a36-af4f-2bfd008a4f4d

### Other information

现象是：key 变了，组件卸载再挂载，value 没有变。理论上没给 reserveAble 的话，应该 value 会被删掉，然后用 defaultValue 替代

预期是：key 变了，组件先卸载，由于没给 reserveAble 会导致 value 被删了。但是马上又挂载了，由于没有 value ，所以 defaultValue 会上位，然后触发一次 onChange

组件 key 变化后触发了 unbind 和 bind，在 unbind 过程中会删除原字段，这个删除行为是在宏任务中完成的，这样执行顺序就变成了 unbind -> bind -> remove。由于组件带 defaultValue，在 bind 过程中会触发 onChange 以同步外部 value，因此总执行顺序为：unbind -> bind -> onChange -> remove 

然而，bind 过程中会去检查当前 value 中字段是否存在值，由于此时此刻还没有走到 remove 阶段，值依然存在于 value 中，所以并未走到是否让 defaultValue 上位替代的逻辑，从而引发了上述现象