### PR TITLE
fix: 优化 Popover 和 Tooltip 在窗口resize和父容器滚动后依然能跟随目标

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.6.4-beta.4",
+  "version": "3.6.4-beta.5",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/popover/popover.tsx
+++ b/packages/base/src/popover/popover.tsx
@@ -1,4 +1,4 @@
-import { usePersistFn, usePopup, useRender, util } from '@sheinx/hooks';
+import { getClosestScrollContainer, usePersistFn, usePopup, useRender, util } from '@sheinx/hooks';
 import AbsoluteList from '../absolute-list';
 import React, { useEffect } from 'react';
 import { PopoverProps } from './popover.type';
@@ -53,6 +53,10 @@ const Popover = (props: PopoverProps) => {
 
   const events = getTargetProps();
 
+  const [updateKey, setUpdateKey] = React.useState(0);
+  const handleUpdateKey = () => {
+    setUpdateKey(prev => (prev + 1) % 2);
+  }
   const bindEvents = () => {
     const targetEl = targetRef.current;
     if (!targetEl) return;
@@ -63,8 +67,13 @@ const Popover = (props: PopoverProps) => {
     if (trigger === 'hover' && props.clickToCancelDelay && props.mouseEnterDelay) {
       targetEl.addEventListener('click', closePop);
     }
-  };
 
+    window?.addEventListener('resize', handleUpdateKey);
+    const scrollContainer = getClosestScrollContainer(targetEl);
+    if (scrollContainer) {
+      scrollContainer.addEventListener('scroll', handleUpdateKey);
+    }
+  };
   const unbindEvents = () => {
     const targetEl = targetRef.current;
     if (!targetEl) return;
@@ -73,6 +82,12 @@ const Popover = (props: PopoverProps) => {
     if (events.onMouseLeave) targetEl.removeEventListener('mouseleave', events.onMouseLeave);
     if (events.onClick) targetEl.removeEventListener('click', events.onClick);
     targetEl.removeEventListener('click', closePop);
+
+    window?.removeEventListener('resize', handleUpdateKey);
+    const scrollContainer = getClosestScrollContainer(targetEl);
+    if (scrollContainer) {
+      scrollContainer.addEventListener('scroll', handleUpdateKey);
+    }
   };
 
   useEffect(() => {
@@ -142,6 +157,7 @@ const Popover = (props: PopoverProps) => {
       adjust={props.adjust}
       lazy={props.lazy}
       offset={props.offset}
+      updateKey={updateKey}
     >
       <div
         className={classNames(

--- a/packages/base/src/tooltip/tooltip.tsx
+++ b/packages/base/src/tooltip/tooltip.tsx
@@ -1,4 +1,4 @@
-import { usePopup, util } from '@sheinx/hooks';
+import { getClosestScrollContainer, usePopup, util } from '@sheinx/hooks';
 import classNames from 'classnames';
 import React, { cloneElement, isValidElement, useEffect } from 'react';
 import { TooltipProps } from './tooltip.type';
@@ -47,12 +47,22 @@ const Tooltip = (props: TooltipProps) => {
 
   const events = getTargetProps();
 
+  const [updateKey, setUpdateKey] = React.useState(0);
+  const handleUpdateKey = () => {
+    setUpdateKey((prev) => (prev + 1) % 2);
+  };
   const bindEvents = () => {
     const targetEl = targetRef.current;
     if (!targetEl) return;
     if (events.onMouseEnter) targetEl.addEventListener('mouseenter', events.onMouseEnter);
     if (events.onMouseLeave) targetEl.addEventListener('mouseleave', events.onMouseLeave);
     if (events.onClick) targetEl.addEventListener('click', events.onClick);
+
+    window?.addEventListener('resize', handleUpdateKey);
+    const scrollContainer = getClosestScrollContainer(targetEl);
+    if (scrollContainer) {
+      scrollContainer.addEventListener('scroll', handleUpdateKey);
+    }
   };
 
   const unbindEvents = () => {
@@ -63,6 +73,12 @@ const Tooltip = (props: TooltipProps) => {
     if (events.onMouseLeave) targetEl.removeEventListener('mouseleave', events.onMouseLeave);
     if (events.onClick) targetEl.removeEventListener('click', events.onClick);
     targetEl.removeEventListener('click', closePop);
+
+    window?.removeEventListener('resize', handleUpdateKey);
+    const scrollContainer = getClosestScrollContainer(targetEl);
+    if (scrollContainer) {
+      scrollContainer.addEventListener('scroll', handleUpdateKey);
+    }
   };
 
   useEffect(() => {
@@ -113,6 +129,7 @@ const Tooltip = (props: TooltipProps) => {
         popupGap={0}
         zIndex={zIndex}
         adjust={popsitionProps === 'auto'}
+        updateKey={updateKey}
       >
         <div
           className={classNames(

--- a/packages/hooks/src/common/use-position-style/index.ts
+++ b/packages/hooks/src/common/use-position-style/index.ts
@@ -190,13 +190,6 @@ export const usePositionStyle = (config: PositionStyleConfig) => {
 
         style.left = 'auto';
         style.transform = '';
-        if (adjust) {
-          overLeft = bodyRect.left - (rect.right - context.popUpWidth);
-          if (style.right < 0 && targetRect) {
-            style.left = bodyRect.width - targetRect.width;
-            style.right = 'auto';
-          }
-        }
       } else {
         // 居中对齐
         style.left = rect.left + rect.width / 2 - containerRect.left + containerScroll.left;

--- a/packages/shineout/src/popover/__doc__/changelog.cn.md
+++ b/packages/shineout/src/popover/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.6.4-beta.5
+2025-04-17
+
+### 💎 Enhancement
+- 优化 `Popover` 在窗口resize和父容器滚动后依然能跟随目标 ([#1069](https://github.com/sheinsight/shineout-next/pull/1069))
+
+
 ## 3.6.1-beta.7
 2025-03-26
 

--- a/packages/shineout/src/tooltip/__doc__/changelog.cn.md
+++ b/packages/shineout/src/tooltip/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.6.4-beta.5
+2025-04-17
+
+### 💎 Enhancement
+- 优化 `Tooltip` 在窗口resize和父容器滚动后依然能跟随目标 ([#1069](https://github.com/sheinsight/shineout-next/pull/1069))
+
+
 ## 3.6.1-beta.7
 2025-03-27
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

### Other information