### PR TITLE
fix: 修复 `TreeSelect` 在页面边界搜索时，下拉弹出层的位置未实时更新导致偏离父元素的问题

### DIFF
--- a/packages/base/src/popover/popover.tsx
+++ b/packages/base/src/popover/popover.tsx
@@ -54,9 +54,10 @@ const Popover = (props: PopoverProps) => {
   const events = getTargetProps();
 
   const [updateKey, setUpdateKey] = React.useState(0);
-  const handleUpdateKey = () => {
+  const handleUpdateKey = usePersistFn(() => {
     setUpdateKey(prev => (prev + 1) % 2);
-  }
+  });
+
   const bindEvents = () => {
     const targetEl = targetRef.current;
     if (!targetEl) return;
@@ -69,9 +70,9 @@ const Popover = (props: PopoverProps) => {
     }
 
     window?.addEventListener('resize', handleUpdateKey);
-    const scrollContainer = getClosestScrollContainer(targetEl);
-    if (scrollContainer) {
-      scrollContainer.addEventListener('scroll', handleUpdateKey);
+    if (props.adjust) {
+      const scrollContainer = getClosestScrollContainer(targetEl);
+      if(scrollContainer) scrollContainer.addEventListener('scroll', handleUpdateKey);
     }
   };
   const unbindEvents = () => {
@@ -84,9 +85,9 @@ const Popover = (props: PopoverProps) => {
     targetEl.removeEventListener('click', closePop);
 
     window?.removeEventListener('resize', handleUpdateKey);
-    const scrollContainer = getClosestScrollContainer(targetEl);
-    if (scrollContainer) {
-      scrollContainer.addEventListener('scroll', handleUpdateKey);
+    if (props.adjust) {
+      const scrollContainer = getClosestScrollContainer(targetEl);
+      if(scrollContainer) scrollContainer.removeEventListener('scroll', handleUpdateKey);
     }
   };
 

--- a/packages/base/src/tooltip/tooltip.tsx
+++ b/packages/base/src/tooltip/tooltip.tsx
@@ -1,4 +1,4 @@
-import { getClosestScrollContainer, usePopup, util } from '@sheinx/hooks';
+import { usePersistFn, usePopup, util } from '@sheinx/hooks';
 import classNames from 'classnames';
 import React, { cloneElement, isValidElement, useEffect } from 'react';
 import { TooltipProps } from './tooltip.type';
@@ -48,9 +48,10 @@ const Tooltip = (props: TooltipProps) => {
   const events = getTargetProps();
 
   const [updateKey, setUpdateKey] = React.useState(0);
-  const handleUpdateKey = () => {
+  const handleUpdateKey = usePersistFn(() => {
     setUpdateKey((prev) => (prev + 1) % 2);
-  };
+  });
+
   const bindEvents = () => {
     const targetEl = targetRef.current;
     if (!targetEl) return;
@@ -59,10 +60,6 @@ const Tooltip = (props: TooltipProps) => {
     if (events.onClick) targetEl.addEventListener('click', events.onClick);
 
     window?.addEventListener('resize', handleUpdateKey);
-    const scrollContainer = getClosestScrollContainer(targetEl);
-    if (scrollContainer) {
-      scrollContainer.addEventListener('scroll', handleUpdateKey);
-    }
   };
 
   const unbindEvents = () => {
@@ -75,10 +72,6 @@ const Tooltip = (props: TooltipProps) => {
     targetEl.removeEventListener('click', closePop);
 
     window?.removeEventListener('resize', handleUpdateKey);
-    const scrollContainer = getClosestScrollContainer(targetEl);
-    if (scrollContainer) {
-      scrollContainer.addEventListener('scroll', handleUpdateKey);
-    }
   };
 
   useEffect(() => {

--- a/packages/hooks/src/common/use-position-style/check-element-size.ts
+++ b/packages/hooks/src/common/use-position-style/check-element-size.ts
@@ -1,0 +1,67 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+export interface Size {
+  width?: number;
+  height?: number;
+}
+
+interface UseCheckElementSizeOptions {
+  // 是否需要检查元素尺寸
+  enable?: boolean;
+}
+
+export const useCheckElementSize = (
+  targetElementRef: React.RefObject<HTMLElement>,
+  options: UseCheckElementSizeOptions = {},
+): Size | null => {
+  const { enable } = options;
+
+  const [size, setSize] = useState<Size>({ width: 0, height: 0 });
+  const lastSize = useRef<Size>({ width: 0, height: 0 });
+
+  const checkSize = useCallback(() => {
+    if (targetElementRef.current) {
+      const rect = targetElementRef.current.getBoundingClientRect();
+
+      const newSize: Size = {
+        width: rect.width,
+        height: rect.height,
+      };
+
+      if (
+        newSize.width !== lastSize.current.width ||
+        newSize.height !== lastSize.current.height
+      ) {
+        setSize(newSize);
+        lastSize.current = newSize;
+      }
+    }
+  }, [targetElementRef]);
+
+  useEffect(() => {
+    if (!enable) return;
+    const element = targetElementRef.current;
+
+    if (!element) return;
+
+    // 初始检查
+    checkSize();
+
+    let resizeObserver: ResizeObserver | null = null;
+    if (window?.ResizeObserver) {
+      resizeObserver = new ResizeObserver(checkSize);
+      resizeObserver.observe(element);
+    }
+
+    // 清理函数
+    return () => {
+      resizeObserver?.disconnect();
+    };
+  }, [enable, targetElementRef, checkSize]);
+
+  if (!enable || !targetElementRef) {
+    return null;
+  }
+
+  return size;
+};

--- a/packages/hooks/src/common/use-position-style/index.ts
+++ b/packages/hooks/src/common/use-position-style/index.ts
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { getPositionStyle } from './get-position-style';
 import { useCheckElementPosition, type Position } from './check-position'
 import { useCheckElementBorderWidth } from './check-border';
+import { useCheckElementSize } from './check-element-size'
 import shallowEqual from '../../utils/shallow-equal';
 import usePersistFn from '../use-persist-fn';
 import { getCurrentCSSZoom } from '../../utils';
@@ -88,6 +89,8 @@ export const usePositionStyle = (config: PositionStyleConfig) => {
   const parentElNewPosition = useCheckElementPosition(parentElRef, {scrollContainer: scrollElRef?.current, enable: show && adjust});
 
   const parentElBorderWidth = useCheckElementBorderWidth(parentElRef, {direction: 'horizontal'});
+
+  const popupElSize = useCheckElementSize(popupElRef, { enable: show });
 
   const adjustPosition = (position: PositionType) => {
     const winHeight = docSize.height;
@@ -331,6 +334,7 @@ export const usePositionStyle = (config: PositionStyleConfig) => {
     updateKey,
     fixedWidth,
     parentElNewPosition,
+    popupElSize,
   ]);
 
   return { style };

--- a/packages/shineout/src/tree-select/__doc__/changelog.cn.md
+++ b/packages/shineout/src/tree-select/__doc__/changelog.cn.md
@@ -1,7 +1,13 @@
+## 3.6.4-beta.8
+2025-04-22
+
+### 🐞 BugFix
+- 修复 `TreeSelect` 在页面边界搜索时，下拉弹出层的位置未实时更新导致偏离父元素的问题 ([#1076](https://github.com/sheinsight/shineout-next/pull/1076))
+
 ## 3.6.4-beta.7
 2025-04-18
 
-### 🆕 Feature
+### 🐞 BugFix
 - 修复 `TreeSelect` 的 `onFilter` ts 类型和第二参数丢失的问题 ([#1073](https://github.com/sheinsight/shineout-next/pull/1073))
 
 ## 3.6.3-beta.6


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id
0eaba21f-425c-432f-bca4-21c1c22ff267

### Other information