### PR TITLE
fix: 调整 Form.Flow `strict` 属性 默认值

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.6.5-beta.4",
+  "version": "3.6.5-beta.5",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/form/form-flow.tsx
+++ b/packages/base/src/form/form-flow.tsx
@@ -3,11 +3,10 @@ import { useFormFlow, util } from '@sheinx/hooks';
 import type { FormFlowProps } from './form-flow.type';
 
 const FormFlow: React.FC<FormFlowProps> = (props) => {
-  const { strict = true } = props;
   const datum = useFormFlow({ names: props.names });
   const valueOfNames = props.names?.map((name) => datum?.get(name));
   const memoizedResult = useMemo(() => {
-    if (!strict) return null;
+    if (!props.strict) return null;
     if (util.isFunc(props.children)) {
       return props.children(datum) as JSX.Element;
     }
@@ -15,7 +14,7 @@ const FormFlow: React.FC<FormFlowProps> = (props) => {
     return props.children as JSX.Element;
   }, [valueOfNames?.toString()]);
 
-  if (strict) {
+  if (props.strict) {
     return memoizedResult;
   }
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [x] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

### Other information

还是保持 strict 默认值，作为一个新特性存在。目前已经有用户依赖不开 strict 的行为