### PR TITLE
fix: 修复 `Transfer` 自定义children时左右勾选互斥的问题，并修正children的 `onSelect` ts类型

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.6.5-beta.10",
+  "version": "3.6.5-beta.11",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/transfer/transfer-list.type.ts
+++ b/packages/base/src/transfer/transfer-list.type.ts
@@ -40,7 +40,5 @@ export interface TransferListProps<DataItem, Value extends KeygenResult[]>
   renderFilter?: (filterProps: FilterProps) => React.ReactNode;
   customRender?: (props: CustomRenderProps<Value>) => React.ReactNode;
   onFilter?: (text: string, listType: TransferListType) => void;
-  onSelectChange:
-    | ((value: KeygenResult[], sourceKeys: KeygenResult[], targetKeys: KeygenResult[]) => void)
-    | ((selectKeys: KeygenResult[]) => void);
+  onSelectChange: ((selectKeys: KeygenResult[]) => void);
 }

--- a/packages/base/src/transfer/transfer.tsx
+++ b/packages/base/src/transfer/transfer.tsx
@@ -174,7 +174,15 @@ const Transfer = <DataItem, Value extends KeygenResult[]>(
         searchPlaceholder={placeholder}
         renderFilter={renderFilter}
         onFilter={onFilterProp ? onFilter : undefined}
-        onSelectChange={onSelectChange}
+        onSelectChange={(keys) => {
+          if (isSource) {
+            const newAllKeys = Array.from(new Set([...keys, ...(targetSelectedKeys || [])]));
+            onSelectChange(newAllKeys, keys, targetSelectedKeys);
+          } else {
+            const newAllKeys = Array.from(new Set([...keys, ...(sourceSelectedKeys || [])]));
+            onSelectChange(newAllKeys, sourceSelectedKeys, keys);
+          }
+        }}
       />
     );
   };

--- a/packages/base/src/transfer/transfer.type.ts
+++ b/packages/base/src/transfer/transfer.type.ts
@@ -61,7 +61,7 @@ export interface FilterProps {
 }
 
 export interface CustomRenderProps<Value extends KeygenResult[]> {
-  onSelected: (value: KeygenResult[], source: KeygenResult[], target: KeygenResult[]) => void;
+  onSelected: (selectedKeys: KeygenResult[]) => void;
   /**
    * @deprecated 请使用 listType 属性判断是否为源或目标列表
    */

--- a/packages/shineout/src/transfer/__doc__/changelog.cn.md
+++ b/packages/shineout/src/transfer/__doc__/changelog.cn.md
@@ -1,3 +1,11 @@
+## 3.6.5-beta.11
+2025-04-29
+
+### 🐞 BugFix
+
+- 修复 `Transfer` 自定义children时左右勾选互斥的问题，并修正children的 `onSelect` ts类型 ([#1089](https://github.com/sheinsight/shineout-next/pull/1089))
+
+
 ## 3.6.2-beta.6
 2025-04-02
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id
7d8a6132-2f3d-4fb3-af7f-e21e30644168

### Other information