### PR TITLE
fix: 修复 `Select`、`TreeSelect`、`Cascader` 结果框高度不继承的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.6.6-beta.3",
+  "version": "3.6.6-beta.4",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/cascader/cascader.ts
+++ b/packages/shineout-style/src/cascader/cascader.ts
@@ -183,6 +183,7 @@ const cascaderStyle: JsStyles<CascaderClassType> = {
     display: 'flex',
     flex: '1',
     minWidth: 0,
+    height: '100%',
     alignItems: 'center',
     lineHeight: token.lineHeightDynamic,
   },

--- a/packages/shineout-style/src/select/select.ts
+++ b/packages/shineout-style/src/select/select.ts
@@ -165,6 +165,7 @@ const selectStyle: JsStyles<SelectClassType> = {
   result: {
     display: 'flex',
     flex: '1',
+    height: '100%',
     minWidth: 0,
     alignItems: 'center',
     lineHeight: token.lineHeightDynamic,

--- a/packages/shineout-style/src/tree-select/tree-select.ts
+++ b/packages/shineout-style/src/tree-select/tree-select.ts
@@ -179,6 +179,7 @@ const treeSelectStyle: JsStyles<TreeSelectClassType> = {
     display: 'flex',
     flex: '1',
     minWidth: 0,
+    height: '100%',
     alignItems: 'center',
     lineHeight: token.lineHeightDynamic,
   },

--- a/packages/shineout/src/cascader/__doc__/changelog.cn.md
+++ b/packages/shineout/src/cascader/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.6.6-beta.4
+2025-05-09
+
+### 🐞 BugFix
+- 修复 `Cascader`结果框高度不继承的问题  ([#1105](https://github.com/sheinsight/shineout-next/pull/1105))
+
 ## 3.6.6-beta.3
 2025-05-07
 

--- a/packages/shineout/src/select/__doc__/changelog.cn.md
+++ b/packages/shineout/src/select/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.6.6-beta.4
+2025-05-09
+
+### 🐞 BugFix
+- 修复 `Select`结果框高度不继承的问题  ([#1105](https://github.com/sheinsight/shineout-next/pull/1105))
+
 ## 3.6.6-beta.3
 2025-05-07
 

--- a/packages/shineout/src/tree-select/__doc__/changelog.cn.md
+++ b/packages/shineout/src/tree-select/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.6.6-beta.4
+2025-05-09
+
+### 🐞 BugFix
+- 修复 `TreeSelect`结果框高度不继承的问题  ([#1105](https://github.com/sheinsight/shineout-next/pull/1105))
+
 ## 3.6.6-beta.3
 2025-05-07
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

40ffa19f-379b-492f-902b-fff3aafe4a3d

### Other information

给 soui-result 这一层加了 100% 高度。场景是一个三层的 flex 嵌套，中间一层不给 height 100% 无法跟随子元素撑开的高度