### PR TITLE
fix: 修复 `Modal` 开启 `destory` 属性关闭后多次执行渲染函数的问题

### DIFF
--- a/packages/base/src/modal/modal-content.tsx
+++ b/packages/base/src/modal/modal-content.tsx
@@ -44,6 +44,7 @@ const Modal = (props: ModalContentProps) => {
     isMask: false,
     mouseDownTarget: null as HTMLElement | null,
     mouseUpTarget: null as HTMLElement | null,
+    content: null as React.ReactNode,
   });
 
   const [animation, setAnimation] = useState(props.visible || props.autoShow);
@@ -156,7 +157,7 @@ const Modal = (props: ModalContentProps) => {
           doc.style.paddingRight = `${window.innerWidth - util.docSize.width}px`;
         }
       } else {
-        if(!context.isMask) return;
+        if (!context.isMask) return;
         doc.style.paddingRight = '';
         doc.style.overflow = '';
       }
@@ -181,7 +182,7 @@ const Modal = (props: ModalContentProps) => {
         hasMask = false;
       }
       {
-        if(!context.isMask) return;
+        if (!context.isMask) return;
         const doc = document.body.parentNode! as HTMLElement;
         doc.style.paddingRight = '';
         doc.style.overflow = '';
@@ -316,6 +317,23 @@ const Modal = (props: ModalContentProps) => {
     panelStyle.transform = `translate(${moveInfo.pos.x}px, ${moveInfo.pos.y}px)`;
   }
 
+  const renderContent = () => {
+    if (!props.visible) return context.content;
+
+    return (
+      <React.Fragment>
+        {renderHeader()}
+        {renderBody()}
+        {renderFooter()}
+        {renderResize()}
+      </React.Fragment>
+    );
+  };
+
+  const content = renderContent();
+
+  context.content = content;
+
   return (
     <FormFooterProvider>
       <div
@@ -355,10 +373,7 @@ const Modal = (props: ModalContentProps) => {
             className={classNames(modalClasses?.panel, props.className)}
             style={panelStyle}
           >
-            {renderHeader()}
-            {renderBody()}
-            {renderFooter()}
-            {renderResize()}
+            {content}
           </div>
         </div>
       </div>


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

14e3e48f-2141-4107-9555-6a399ccf0f72

### Other information

这个 bug 其实是 hooks 的特性，当父组件状态发生改变时，子组件的渲染函数一般情况下都会触发执行，除非把它 memo 住。而 v1 v2 采用的 class 组件拥有特殊的卸载方式（直接 remove child），父组件状态发生改变后并不会触发子组件的重新执行，这让一些用户依赖了这种稳定的执行次数，用户认为 Modal 组件的 children 渲染函数，在打开、关闭的过程中只会执行 1 次

当前的 fix 方式是通过 useRef 来缓存上一次子组件的执行结果，在关闭的时候不再执行子组件函数，在子组件函数执行次数上对齐了 v1 v2 版本（因为用户依赖了这个特性，不然不会特地对齐，可以看下 playground 的例子）