### PR TITLE
fix: 修复 `Button` 在React 18以下初始化时有过渡动画的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.7.0-beta.23",
+  "version": "3.7.0-beta.24",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/button/button.ts
+++ b/packages/shineout-style/src/button/button.ts
@@ -197,7 +197,6 @@ const ButtonStyle: JsStyles<keyof ButtonClasses> = {
     borderRadius: Token.buttonBorderRadius,
     lineHeight: Token.lineHeightDynamic,
     padding: `${Token.buttonPaddingY} ${Token.buttonPaddingX}`,
-    transition: 'all .1s linear',
     fontFamily: 'inherit',
     // height: Token.buttonHeight,
 
@@ -207,6 +206,10 @@ const ButtonStyle: JsStyles<keyof ButtonClasses> = {
 
     '[class*="button-group"] > & + &': {
       margin: 0,
+    },
+
+    '&:hover': {
+      transition: 'all .1s linear',
     },
 
     '&:active': {

--- a/packages/shineout/src/button/__doc__/changelog.cn.md
+++ b/packages/shineout/src/button/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.7.0-beta.24
+2025-05-15
+### 🐞 BugFix
+
+- 修复 `Button` 在React 18以下初始化时有过渡动画的问题 ([#1114](https://github.com/sheinsight/shineout-next/pull/1114))
+
+
 ## 3.5.3
 2024-12-04
 ### 🐞 BugFix


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

### Other information