### PR TITLE
fix: 修复 `Tree` 在 data 发生变化后 `defaultExpanded` 不生效的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.6.7-beta.2",
+  "version": "3.6.7-beta.3",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/tree/tree.tsx
+++ b/packages/base/src/tree/tree.tsx
@@ -120,19 +120,6 @@ const Tree = <DataItem, Value extends KeygenResult[]>(props: TreeProps<DataItem,
     return props.height || styleHeight;
   };
 
-  const handleUpdateExpanded = (expanded?: KeygenResult[]) => {
-    const tempExpandMap = new Set(expanded);
-    if (!expanded) return;
-
-    if (virtual) {
-      datum.expandedFlat(expanded);
-    }
-
-    datum.updateMap.forEach((update, id) => {
-      update('expanded', tempExpandMap.has(id));
-    });
-  };
-
   const handleUpdateActive = (active?: KeygenResult, item?: DataItem) => {
     setActive(active);
 
@@ -183,7 +170,7 @@ const Tree = <DataItem, Value extends KeygenResult[]>(props: TreeProps<DataItem,
     const newData = produce(data, (draft) => {
       let node: any = draft;
       let temp: DataItem[];
-      let removeNode: () => void = () => {};
+      let removeNode: () => void = () => { };
       let offset = 0;
       current.indexPath.forEach((p, i) => {
         if (i < current.indexPath.length - 1) {
@@ -205,7 +192,7 @@ const Tree = <DataItem, Value extends KeygenResult[]>(props: TreeProps<DataItem,
           if (current.index <= target.index) {
             offset = -1;
           }
-          removeNode = () => {};
+          removeNode = () => { };
         }
       });
 
@@ -299,7 +286,7 @@ const Tree = <DataItem, Value extends KeygenResult[]>(props: TreeProps<DataItem,
       return;
     }
     if (!props.expanded) return;
-    handleUpdateExpanded(expanded);
+    datum.updateExpanded(expanded);
   }, [expanded]);
 
   useEffect(() => {

--- a/packages/hooks/src/components/use-tree/use-tree.type.ts
+++ b/packages/hooks/src/components/use-tree/use-tree.type.ts
@@ -184,4 +184,5 @@ export interface TreeDatum<DataItem> {
   dataMap: Map<KeygenResult, DataItem>;
   valueMap: Map<KeygenResult, CheckedStatusType>;
   dataFlatStatusMap: Map<KeygenResult, FlatMapType>;
+  updateExpanded: (expanded?: KeygenResult[]) => void;
 }

--- a/packages/shineout/src/tree/__doc__/changelog.cn.md
+++ b/packages/shineout/src/tree/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.6.7-beta.3
+2025-05-20
+
+### 🐞 BugFix
+
+- 修复 `Tree` 在 data 发生变化后 `defaultExpanded` 不生效的问题 ([#1118](https://github.com/sheinsight/shineout-next/pull/1118))
+
 ## 3.6.6-beta.2
 2025-05-06
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

783f3f69-7011-4b18-b4ac-c968c38bdf22

### Other information

老版本 data 变了后 node 节点挂载的时候是直接从 props.expanded || props.defaultExpanded 里取值去判断是不是要展开节点

v3 在 useTree 里把这个属性做成受控了，所以 defaultExpanded 一开始如果没有值，后续有值的话是不会生效的，例子里的场景虽然 data 变了，但是 defaultExpanded 是根据 data 来实时改变的，理论上来说不应该生效，但是为了对齐表现，还是在 data 变了后，做一下展开检查行为，把 expanded 同步更新给了内部的状态

按照这次的方案修改，带来的一个影响就是，会额外触发一次 onExpand ，在外部可以打 log 看到，符合目前组件里大部分 defaultValue 的现象