### PR TITLE
fix: 修复 `Tree` 在开启虚拟列表后 `data` 为 undefined 时可能存在死循环的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.6.7-beta.3",
+  "version": "3.6.7-beta.4",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-tree/use-tree.ts
+++ b/packages/hooks/src/components/use-tree/use-tree.ts
@@ -717,7 +717,7 @@ const useTree = <DataItem>(props: BaseTreeProps<DataItem>) => {
     }
 
     updateInnerCheckStatus();
-  }, [data]);
+  }, [props.data]);
 
   useEffect(() => {
     if (props.datum) return;

--- a/packages/shineout/src/tree/__doc__/changelog.cn.md
+++ b/packages/shineout/src/tree/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.6.7-beta.4
+2025-05-20
+
+### 🐞 BugFix
+
+- 修复 `Tree` 在 data 发生变化后 `defaultExpanded` 不生效的问题 ([#1119](https://github.com/sheinsight/shineout-next/pull/1119))
+
 ## 3.6.7-beta.3
 2025-05-20
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

60adac20-df43-477a-b9fa-304cb2e576c6

### Other information
useEffect 死循环了，监听了一个一直被新创建的空数组，改成 props.data