### PR TITLE
fix: 修复 `TreeSelect` 的 `beforeChange` 不生效的问题

### DIFF
--- a/packages/base/src/tree-select/tree-select.tsx
+++ b/packages/base/src/tree-select/tree-select.tsx
@@ -89,6 +89,7 @@ const TreeSelect = <DataItem, Value extends TreeSelectValueType>(
     onChangeAddition,
     onEnterExpand,
     onExpand,
+    beforeChange,
     filterSameChange,
   } = props;
   const styles = jssStyle?.treeSelect?.() as TreeSelectClasses;
@@ -110,6 +111,7 @@ const TreeSelect = <DataItem, Value extends TreeSelectValueType>(
     control: 'value' in props,
     filterSameChange: filterSameChange,
     multiple,
+    beforeChange,
   });
 
   const checkEmpty = () => {

--- a/packages/base/src/tree-select/tree-select.type.ts
+++ b/packages/base/src/tree-select/tree-select.type.ts
@@ -449,4 +449,9 @@ export interface TreeSelectProps<DataItem, Value>
    * @version 3.7.0
    */
   renderCompressed?: (options: RenderCompressedOption<DataItem>) => React.ReactNode;
+  /**
+   * @en The callback before the value is changed, when the return value is not empty, it will be used as the new value of the component
+   * @cn 值改变前的回调，当返回值不为空时将作为组件的新值
+   */
+  beforeChange?: (value: Value) => any;
 }


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

### Other information

属性没传给 useInputAble