### PR TITLE
fix: 修复 `Grid` 在多个shineout版本的同时使用时出现的样式覆盖问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.7.0-beta.39",
+  "version": "3.7.0-beta.40",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/grid/grid.tsx
+++ b/packages/base/src/grid/grid.tsx
@@ -4,7 +4,7 @@ import { getGrid } from './util';
 import { GridProps } from './grid.type';
 
 const Gird = (props: GridProps) => {
-  const { width = 1, offset, responsive, stretch, children, gutter, ...other } = props;
+  const { width = 1, offset, responsive, stretch, children, gutter, jssStyle, ...other } = props;
   let autoCount = 0;
   let settleWidth = 0;
   Children.toArray(children).forEach((c) => {
@@ -16,7 +16,15 @@ const Gird = (props: GridProps) => {
   });
   const autoWidth = autoCount > 0 ? (1 - settleWidth) / autoCount : 0;
 
-  const className = classNames(props.className, getGrid({ width, offset, responsive }));
+  const gridClasses = jssStyle?.grid?.();
+
+  const className = classNames(
+    props.className,
+    gridClasses?.rootClass,
+    gridClasses?.wrapper,
+    gridClasses?.full,
+    getGrid({ width, offset, responsive }),
+  );
   const style = Object.assign({}, props.style);
   if (gutter && gutter > 0) {
     style.width = 'auto';

--- a/packages/base/src/grid/grid.type.ts
+++ b/packages/base/src/grid/grid.type.ts
@@ -3,7 +3,16 @@ import { CommonType } from '../common/type';
 
 export type ResponsiveType = 'sm' | 'md' | 'lg' | 'xl';
 
+export interface GridClasses {
+  rootClass: string;
+  wrapper: string;
+  full: string;
+}
+
 export interface GridProps extends Pick<CommonType, 'className' | 'style'> {
+    jssStyle?: {
+      grid?: () => GridClasses;
+    };
   /**
    * @en Spacing between grids
    * @cn 栅格之间间距

--- a/packages/base/src/grid/index.ts
+++ b/packages/base/src/grid/index.ts
@@ -1,2 +1,2 @@
 export { default, default as Grid } from './grid';
-export type { GridProps } from './grid.type';
+export type { GridProps, GridClasses } from './grid.type';

--- a/packages/base/src/grid/util.ts
+++ b/packages/base/src/grid/util.ts
@@ -13,7 +13,6 @@ const RESPONSIVE = {
 type Responsive = keyof typeof RESPONSIVE;
 
 const GridClassName = `${config.prefix}-grid`;
-const GridFullClassName = `${config.prefix}-grid-full`;
 const defaultResponsive = 'md';
 
 function createStyle(text: string, id: string) {
@@ -86,26 +85,5 @@ export function getGrid(
   const gridClass = generate(width!, 'grid', responsive!);
   const offsetClass = generate(offset!, 'offset', responsive!);
 
-  return `${GridClassName} ${GridFullClassName} ${gridClass} ${offsetClass}`;
+  return `${gridClass} ${offsetClass}`;
 }
-
-function init() {
-  const text = [];
-
-  text.push(`
-.${GridClassName} {
-  position: relative;
-  display: inline-block;
-  zoom: 1;
-  letter-spacing: normal;
-  word-spacing: normal;
-  vertical-align: top;
-  text-rendering: auto;
-  box-sizing: border-box;
-}`);
-
-  text.push(`.${GridFullClassName}{width:100%}`);
-  createStyle(text.join(''), GridClassName);
-}
-
-init();

--- a/packages/shineout-style/src/grid/grid.ts
+++ b/packages/shineout-style/src/grid/grid.ts
@@ -1,0 +1,21 @@
+import { JsStyles } from '../jss-style';
+import { GridClasses } from '@sheinx/base';
+
+const gridStyle: JsStyles<keyof GridClasses> = {
+  rootClass: {},
+  wrapper: {
+    position: 'relative',
+    display: 'inline-block',
+    zoom: 1,
+    letterSpacing: 'normal',
+    wordSpacing: 'normal',
+    verticalAlign: 'top',
+    textRendering: 'auto',
+    boxSizing: 'border-box',
+  },
+  full: {
+    width: '100%',
+  },
+};
+
+export default gridStyle;

--- a/packages/shineout-style/src/grid/index.ts
+++ b/packages/shineout-style/src/grid/index.ts
@@ -1,0 +1,7 @@
+import { styled } from '../jss-style';
+import gridStyle from './grid';
+
+const useGridStyle = styled(gridStyle, 'grid');
+
+export { gridStyle, useGridStyle };
+export default gridStyle;

--- a/packages/shineout-style/src/index.ts
+++ b/packages/shineout-style/src/index.ts
@@ -18,6 +18,7 @@ export * from './editable-area';
 export * from './empty';
 export * from './form';
 export * from './gap';
+export * from './grid';
 export * from './icon';
 export * from './image';
 export * from './inner-title';

--- a/packages/shineout-style/src/version.ts
+++ b/packages/shineout-style/src/version.ts
@@ -1,1 +1,1 @@
-export default '3.7.0-beta.31';
+export default '3.7.0-beta.39';

--- a/packages/shineout/src/grid/__doc__/changelog.cn.md
+++ b/packages/shineout/src/grid/__doc__/changelog.cn.md
@@ -1,9 +1,9 @@
-## 3.7.0-beta.39
-2025-06-03
+## 3.7.0-beta.40
+2025-06-04
 
 ### 🐞 BugFix
 
-- 修复 `Grid` 多应用下加载出现样式覆盖的问题 ([#1141](https://github.com/sheinsight/shineout-next/pull/1141))
+- 修复 `Grid` 在多个shineout版本的同时使用时出现的样式覆盖问题 ([#1143](https://github.com/sheinsight/shineout-next/pull/1143))
 
 
 ## 3.1.22

--- a/packages/shineout/src/grid/grid.tsx
+++ b/packages/shineout/src/grid/grid.tsx
@@ -1,1 +1,11 @@
-export { Grid as default } from '@sheinx/base';
+import { Grid } from '@sheinx/base';
+import { useGridStyle } from '@sheinx/shineout-style';
+import { GridProps } from './grid.type';
+
+
+export default (props: GridProps) => {
+  const jssStyle = {
+    grid: useGridStyle,
+  };
+  return <Grid jssStyle={jssStyle} {...props} />;
+};

--- a/packages/shineout/src/grid/grid.type.ts
+++ b/packages/shineout/src/grid/grid.type.ts
@@ -2,4 +2,4 @@ import { GridProps as UnStyledGridProps } from '@sheinx/base';
 /**
  * @title Grid
  */
-export type GridProps = UnStyledGridProps
+export type GridProps = Omit<UnStyledGridProps, 'jssStyle'>;

--- a/packages/shineout/src/index.ts
+++ b/packages/shineout/src/index.ts
@@ -67,4 +67,4 @@ export * from './deprecated';
 
 export * as TYPE from './type';
 
-export default { version: '3.7.0-beta.31' };
+export default { version: '3.7.0-beta.39' };


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

### Other information