### PR TITLE
fix: 修复 `Select` 同时设置了 `absolute` 和 `optionWidth` 属性后，弹出层在右侧溢出时位置不自动调整的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.7.1-beta.4",
+  "version": "3.7.1-beta.5",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout/src/input/__example__/04-03-group-validate.tsx
+++ b/packages/shineout/src/input/__example__/04-03-group-validate.tsx
@@ -1,11 +1,11 @@
 /**
  * cn - Group的校验
  *    -- 配置 `status` 属性可以展示错误状态
- *    -- 配置 `seperate` 属性也有相应的校验效果
+ *    -- 配置 `separate` 属性也有相应的校验效果
  *    -- 配置 `keepErrorHeight` 属性可以保持错误提示的高度
  * en - Group validate
  *    -- The `status` property of Input.Group can be used to display error status
- *    -- The `seperate` property also has the corresponding verification effect
+ *    -- The `separate` property also has the corresponding verification effect
  *    -- The `keepErrorHeight` property can keep the height of the error prompt
  */
 
@@ -22,16 +22,16 @@ const App: React.FC = () => (
         {({ value, error, onChange }) => (
           <Input.Group style={{ width: 340 }} status={error ? 'error' : undefined}>
             <b>http://</b>
-            <Input value={value} onChange={onChange} placeholder='i am not seperate input group' />
+            <Input value={value} onChange={onChange} placeholder='i am not separate input group' />
           </Input.Group>
         )}
       </Form.Field>
     </Form.Item>
 
     <Form.Item label='Home2' required>
-      <Input.Group style={{ width: 340 }} seperate>
+      <Input.Group style={{ width: 340 }} separate>
         <Form.Field name='url2' rules={[rules.required]}>
-          <Input placeholder='i am seperate input group' />
+          <Input placeholder='i am separate input group' />
         </Form.Field>
         <b>.com</b>
       </Input.Group>

--- a/packages/shineout/src/select/__doc__/changelog.cn.md
+++ b/packages/shineout/src/select/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.7.1-beta.5
+2025-06-10
+
+### 🐞 BugFix
+- 修复 `Select` 同时设置了 `absolute` 和 `optionWidth` 属性后，弹出层在右侧溢出时位置不自动调整的问题 ([#1159](https://github.com/sheinsight/shineout-next/pull/1159))
+
 ## 3.7.1-beta.4
 2025-06-09
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog
- 修复 `Select` 同时设置了 `absolute` 和 `optionWidth` 属性后，弹出层在右侧溢出时位置不自动调整的问题

<!-- - Fix `Component` ... -->

### Playground id
d9779014-f092-4d2a-a41f-a7587820e636

### Other information