### PR TITLE
fix: 更新版本号至 3.7.1-beta.9，修复 `Select` 组件在 `Drawer` 中使用并开启 compressed 属…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.7.1-beta.7",
+  "version": "3.7.1-beta.9",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/select/result.tsx
+++ b/packages/base/src/select/result.tsx
@@ -167,9 +167,6 @@ const Result = <DataItem, Value>(props: ResultProps<DataItem, Value>) => {
 
   const handleCloseMouseDown = () => {
     removeLock.current = true;
-    setTimeout(() => {
-      removeLock.current = false;
-    }, 0);
   };
 
   const renderResultItem = (
@@ -342,7 +339,10 @@ const Result = <DataItem, Value>(props: ResultProps<DataItem, Value>) => {
   const handleResetMore = () => {
     if (!compressed) return;
     if (isCompressedBound()) return;
-    if (removeLock.current) return;
+    if (removeLock.current) {
+      removeLock.current = false;
+      return;
+    }
 
     setMore(-1);
     setShouldResetMore(true);

--- a/packages/shineout/src/select/__doc__/changelog.cn.md
+++ b/packages/shineout/src/select/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.7.1-beta.9
+2025-06-11
+
+### 🐞 BugFix
+- 修复 `Select` 在 `Drawer` 中使用并且开启了compressed属性后，点击compressed弹出层中的删除第二次无效的问题 ([#1164](https://github.com/sheinsight/shineout-next/pull/1164))
+
 ## 3.7.1-beta.5
 2025-06-10
 


### PR DESCRIPTION
…性时，点击弹出层中的删除第二次无效的问题

<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id
41999bea-f716-4d70-b43a-02db595f079f

### Other information