### PR TITLE
fix: 修复 `Modal` 组件在被外部卸载后无法重置 HTML 元素样式的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.7.2-beta.2",
+  "version": "3.7.2-beta.3",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/modal/modal-content.tsx
+++ b/packages/base/src/modal/modal-content.tsx
@@ -45,6 +45,10 @@ const Modal = (props: ModalContentProps) => {
     mouseDownTarget: null as HTMLElement | null,
     mouseUpTarget: null as HTMLElement | null,
     content: null as React.ReactNode,
+    originDocumentStyle: {
+      overflow: '',
+      paddingRight: '',
+    },
   });
 
   const [animation, setAnimation] = useState(props.visible || props.autoShow);
@@ -148,18 +152,31 @@ const Modal = (props: ModalContentProps) => {
     }
   }, [props.visible]);
 
+  // 设置 document.body.style.overflow 和 document.body.style.paddingRight，并记录原始值到 context 中
+  const setDocumentOverflow = usePersistFn(() => {
+    const doc = document.body.parentNode! as HTMLElement;
+    context.originDocumentStyle.overflow = doc.style.overflow;
+    context.originDocumentStyle.paddingRight = doc.style.paddingRight;
+    doc.style.overflow = 'hidden';
+    if (!doc.style.paddingRight) {
+      doc.style.paddingRight = `${window.innerWidth - util.docSize.width}px`;
+    }
+  })
+
+  // 还原 document.body.style.overflow 和 document.body.style.paddingRight
+  const resetDocumentOverflow = usePersistFn(() => {
+    const doc = document.body.parentNode! as HTMLElement;
+    doc.style.overflow = context.originDocumentStyle.overflow;
+    doc.style.paddingRight = context.originDocumentStyle.paddingRight;
+  })
+
   useEffect(() => {
     if (!props.hideMask) {
-      const doc = document.body.parentNode! as HTMLElement;
       if (visible) {
-        doc.style.overflow = 'hidden';
-        if (!doc.style.paddingRight) {
-          doc.style.paddingRight = `${window.innerWidth - util.docSize.width}px`;
-        }
+        setDocumentOverflow();
       } else {
         if (!context.isMask) return;
-        doc.style.paddingRight = '';
-        doc.style.overflow = '';
+        resetDocumentOverflow();
       }
     }
   }, [visible]);
@@ -173,6 +190,9 @@ const Modal = (props: ModalContentProps) => {
   useEffect(() => {
     // unmount
     return () => {
+      if (context.isMask) {
+        resetDocumentOverflow();
+      };
       props.shouldDestroy?.(true);
       // if (props.autoShow) {
       //   props.onClose?.();

--- a/packages/base/src/modal/modal-content.tsx
+++ b/packages/base/src/modal/modal-content.tsx
@@ -155,8 +155,10 @@ const Modal = (props: ModalContentProps) => {
   // 设置 document.body.style.overflow 和 document.body.style.paddingRight，并记录原始值到 context 中
   const setDocumentOverflow = usePersistFn(() => {
     const doc = document.body.parentNode! as HTMLElement;
-    context.originDocumentStyle.overflow = doc.style.overflow;
-    context.originDocumentStyle.paddingRight = doc.style.paddingRight;
+    if (context.isMask) {
+      context.originDocumentStyle.overflow = doc.style.overflow;
+      context.originDocumentStyle.paddingRight = doc.style.paddingRight;
+    }
     doc.style.overflow = 'hidden';
     if (!doc.style.paddingRight) {
       doc.style.paddingRight = `${window.innerWidth - util.docSize.width}px`;
@@ -194,18 +196,9 @@ const Modal = (props: ModalContentProps) => {
         resetDocumentOverflow();
       };
       props.shouldDestroy?.(true);
-      // if (props.autoShow) {
-      //   props.onClose?.();
-      // }
       if (context.isMask) {
         context.isMask = false;
         hasMask = false;
-      }
-      {
-        if (!context.isMask) return;
-        const doc = document.body.parentNode! as HTMLElement;
-        doc.style.paddingRight = '';
-        doc.style.overflow = '';
       }
     };
   }, []);

--- a/packages/shineout/src/modal/__doc__/changelog.cn.md
+++ b/packages/shineout/src/modal/__doc__/changelog.cn.md
@@ -1,3 +1,11 @@
+## 3.7.2-beta.3
+2025-06-12
+
+### 🐞 BugFix
+
+- 修复 `Modal` 被外部通过 ReactDOM.unmountComponentAtNode 卸载后，无法重置html元素的样式的问题 ([#1170](https://github.com/sheinsight/shineout-next/pull/1170))
+
+
 ## 3.7.0-beta.20
 2025-05-07
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id
e696c587-114c-4fb8-974e-02ecc0c4b15a

### Other information