### PR TITLE
fix: 修复 TreeSelect 开启 virtual 后传入 undefined 数据导致死循环问题、Upload.Button 传入 drop 属性失效的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.7.2-beta.4",
+  "version": "3.7.2-beta.5",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/tree-select/tree-select.tsx
+++ b/packages/base/src/tree-select/tree-select.tsx
@@ -27,6 +27,10 @@ import { FormFieldContext } from '../form/form-field-context';
 
 export type TreeSelectValueType = KeygenResult | KeygenResult[];
 
+const defaultProps = {
+  data: []
+}
+
 const TreeSelect = <DataItem, Value extends TreeSelectValueType>(
   props0: TreeSelectProps<DataItem, Value>,
 ) => {
@@ -42,7 +46,7 @@ const TreeSelect = <DataItem, Value extends TreeSelectValueType>(
     adjust = true,
     value: valueProp,
     defaultValue,
-    data = [],
+    data = defaultProps.data,
     multiple,
     mode = 1,
     line = false,

--- a/packages/base/src/upload/button.tsx
+++ b/packages/base/src/upload/button.tsx
@@ -18,7 +18,6 @@ const UploadButton = <T,>(props: UploadButtonProps<T>) => {
     canDelete: undefined,
     showUploadList: false,
     customResult: undefined,
-    drop: false,
     multiple: false,
     leftHandler: false,
     onPreview: undefined,

--- a/packages/base/src/upload/button.type.ts
+++ b/packages/base/src/upload/button.type.ts
@@ -9,7 +9,6 @@ export type ButtonUploadInnerPropsType = Pick<
   | 'canDelete'
   | 'showUploadList'
   | 'customResult'
-  | 'drop'
   | 'multiple'
   | 'leftHandler'
   | 'onPreview'

--- a/packages/shineout/src/tree-select/__doc__/changelog.cn.md
+++ b/packages/shineout/src/tree-select/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.7.2-beta.5
+2025-06-13
+
+### 🐞 BugFix
+- 修复 `TreeSelect` 开启 `virtual` 后传入 undefined 数据导致死循环问题 ([#1172](https://github.com/sheinsight/shineout-next/pull/1172))
+
 ## 3.7.1-beta.8
 2025-06-06
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

### Other information

死循环是因为 props 里的默认值直接给了 data=[] 引用疯狂刷新导致的

Upload.Button 新版本去掉了，老版本生效的，但是表现很诡异。用户使用了，所以对齐下诡异的表现