### PR TITLE
fix: 修复 TreeSelect 小尺寸的下拉框内边距

### DIFF
--- a/packages/base/src/tree-select/tree-select.tsx
+++ b/packages/base/src/tree-select/tree-select.tsx
@@ -670,11 +670,19 @@ const TreeSelect = <DataItem, Value extends TreeSelectValueType>(
     }
 
     const style = { maxHeight: height };
+    let rootStyle = { padding: '0 4px' };
+    if (!virtual) {
+      if(size === 'small') {
+        rootStyle = { padding: '3px 4px' };
+      } else if(size === 'large') {
+        rootStyle = { padding: '0 5px' };
+      }
+    }
 
     return (
       <div className={classNames(styles.tree, styles.treeWrapper)} style={style}>
         <Tree
-          rootStyle={{ padding: '0 4px' }}
+          rootStyle={rootStyle}
           jssStyle={jssStyle}
           renderItem={renderItem}
           {...treeProps}

--- a/packages/base/src/tree/tree-virtual.tsx
+++ b/packages/base/src/tree/tree-virtual.tsx
@@ -10,6 +10,12 @@ const SIZE_MAP = {
   'large': 42,
 }
 
+const PADDING_Y_MAP = {
+  'small': 3,
+  'default': 0,
+  'large': 0,
+}
+
 const TreeVirtual = <DataItem, Value extends KeygenResult[]>(
   props: VirtualTreeProps<DataItem, Value>,
 ) => {
@@ -100,6 +106,7 @@ const TreeVirtual = <DataItem, Value extends KeygenResult[]>(
       dynamicVirtual
       lineHeight={lineHeight}
       renderItem={renderItem}
+      paddingY={PADDING_Y_MAP[datum.size || 'default']}
     ></VirtualScrollList>
   );
 };

--- a/packages/shineout/src/button/__example__/s-005-status.tsx
+++ b/packages/shineout/src/button/__example__/s-005-status.tsx
@@ -30,30 +30,30 @@ export default () => {
     <div style={wrapperStyle}>
       <div style={buttonWrapperStyle}>
         <Button type='default' style={buttonStyle}>
-          Danger
+          Default
         </Button>
         <Button type='default' mode='outline' style={buttonStyle}>
-          Danger
+          Default
         </Button>
         <Button type='default' mode='dashed' style={buttonStyle}>
-          Danger
+          Default
         </Button>
         <Button type='default' mode='text' style={buttonStyle}>
-          Danger
+          Default
         </Button>
       </div>
       <div style={buttonWrapperStyle}>
         <Button type='primary' style={buttonStyle}>
-          Danger
+          Primary
         </Button>
         <Button type='primary' mode='outline' style={buttonStyle}>
-          Danger
+          Primary
         </Button>
         <Button type='primary' mode='dashed' style={buttonStyle}>
-          Danger
+          Primary
         </Button>
         <Button type='primary' mode='text' style={buttonStyle}>
-          Danger
+          Primary
         </Button>
       </div>
       <div style={buttonWrapperStyle}>


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

### Other information