### PR TITLE
fix: 更新版本号至 3.7.3-beta.3，修复 `Form` 组件在开启 `scrollToError` 后，Input组件的 `onEnterPress` 事件不触发的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.7.3-beta.2",
+  "version": "3.7.3-beta.3",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-form/use-form.ts
+++ b/packages/hooks/src/components/use-form/use-form.ts
@@ -7,6 +7,8 @@ import { insertValue, spliceValue } from '../../utils/flat';
 import { usePrevious } from '../../common/use-default-value';
 
 const globalKey = '__global__&&@@';
+const SUBMIT_TIMEOUT = 10;
+
 import { current, produce } from '../../utils/immer';
 import {
   deepGet,
@@ -250,7 +252,7 @@ const useForm = <T extends ObjectType>(props: UseFormProps<T>) => {
           docScroll.top -= scrollToError;
         }
       }
-    });
+    }, SUBMIT_TIMEOUT + 10);
   };
 
   const onChange = usePersistFn((change: T | ((v: T) => void | T)) => {
@@ -430,9 +432,9 @@ const useForm = <T extends ObjectType>(props: UseFormProps<T>) => {
         return;
       }
       const result = await validateFields(undefined, { ignoreBind: true }).catch((e) => e);
+      if (activeEl) activeEl.focus();
       if (result === true) {
         props.onSubmit?.((context.value ?? {}) as T);
-        if (activeEl) activeEl.focus();
       } else {
         handleSubmitError(result);
       }
@@ -445,7 +447,7 @@ const useForm = <T extends ObjectType>(props: UseFormProps<T>) => {
     setTimeout(() => {
       submit();
       other?.onSubmit?.(e);
-    }, 10);
+    }, SUBMIT_TIMEOUT);
   };
 
   const validateFieldset = (name: string, config?: ValidateFnConfig) => {

--- a/packages/shineout/src/form/__doc__/changelog.cn.md
+++ b/packages/shineout/src/form/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.7.3-beta.3
+2025-06-17
+
+### 🐞 BugFix
+- 修复 `Form` 开启了 `scrollToError` 后，Input组件的 `onEnterPress` 事件不触发的问题 ([#1181](https://github.com/sheinsight/shineout-next/pull/1181))
+
 ## 3.7.1-beta.6
 2025-06-10
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog
- 修复 `Form` 组件在开启 `scrollToError` 后，Input组件的 `onEnterPress` 事件不触发的问题
- 修复 `Form` 的scrollToError偶现的跳转不过去的问题
<!-- - Fix `Component` ... -->

### Playground id
3122a030-76ac-4989-b74e-29fc150ab496

### Other information