### PR TITLE
fix: 修复 `Input` 组件的 `onEnterPress` 事件在开启 `Form` 的`scrollToError` 后偶现无法触发的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.7.3-beta.3",
+  "version": "3.7.3-beta.4",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/input/simple-input.tsx
+++ b/packages/base/src/input/simple-input.tsx
@@ -1,6 +1,6 @@
 import { useInput, useKeyEvent, usePersistFn, util } from '@sheinx/hooks';
 import classNames from 'classnames';
-import React, { KeyboardEvent, useContext } from 'react';
+import React, { KeyboardEvent, useContext, useRef } from 'react';
 import { SimpleInputProps } from './input.type';
 import Icons from '../icons';
 import { useConfig } from '../config';
@@ -25,12 +25,31 @@ const Input = (props: SimpleInputProps) => {
     ...rest
   } = props;
 
+  const { current: context } = useRef({
+    needTriggerEnter: false,
+  });
+
   const inputStyle = jssStyle?.input?.();
   const config = useConfig();
   const { fieldId } = useContext(FormFieldContext);
   const { getRootProps, getClearProps, getInputProps, showClear, focused, disabled } = useInput({
     ...rest,
     onFocusedChange,
+    // 由于form的原生submit事件是在keydown中触发的，submit校验后触发scrollToError会导致当前焦点的input立即失焦，导致input的回车事件无法触发
+    // 所以这里在onKeyDown时机记录下needTriggerEnter标志，在onBlur时机判断是否需要触发onEnterPress
+    onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        context.needTriggerEnter = true;
+      }
+      props.onKeyDown?.(e);
+    },
+    onBlur: (e: any) => {
+      if (context.needTriggerEnter) {
+        context.needTriggerEnter = false;
+        onEnterPress?.(e.target.value || '', e);
+      }
+      props.onBlur?.(e);
+    },
   });
 
   const rootClass = classNames(
@@ -54,6 +73,9 @@ const Input = (props: SimpleInputProps) => {
   });
 
   const onKeyUp = usePersistFn((e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      context.needTriggerEnter = false;
+    };
     props.onKeyUp?.(e);
     keyHandler(e);
   });

--- a/packages/hooks/src/components/use-form/use-form.ts
+++ b/packages/hooks/src/components/use-form/use-form.ts
@@ -432,9 +432,9 @@ const useForm = <T extends ObjectType>(props: UseFormProps<T>) => {
         return;
       }
       const result = await validateFields(undefined, { ignoreBind: true }).catch((e) => e);
-      if (activeEl) activeEl.focus();
       if (result === true) {
         props.onSubmit?.((context.value ?? {}) as T);
+        if (activeEl) activeEl.focus();
       } else {
         handleSubmitError(result);
       }

--- a/packages/shineout/src/form/__doc__/changelog.cn.md
+++ b/packages/shineout/src/form/__doc__/changelog.cn.md
@@ -2,7 +2,7 @@
 2025-06-17
 
 ### 🐞 BugFix
-- 修复 `Form` 开启了 `scrollToError` 后，Input组件的 `onEnterPress` 事件不触发的问题 ([#1181](https://github.com/sheinsight/shineout-next/pull/1181))
+- 修复 `Form` 的 `scrollToError` 偶现的无法滚动到错误字段位置的问题 ([#1181](https://github.com/sheinsight/shineout-next/pull/1181))
 
 ## 3.7.1-beta.6
 2025-06-10

--- a/packages/shineout/src/input/__doc__/changelog.cn.md
+++ b/packages/shineout/src/input/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.7.3-beta.4
+2025-06-17
+
+### 🐞 BugFix
+- 修复 `Input` 的 `onEnterPress` 事件在开启了 Form 的 scrollToError 后偶现的无法触发的问题 ([#1182](https://github.com/sheinsight/shineout-next/pull/1182))
+
 ## 3.7.3-beta.1
 2025-06-16
 


### PR DESCRIPTION

<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id
91cf0081-3eb1-4e63-89bb-90265c7394a6

### Other information