### PR TITLE
fix: 更新版本号至 3.7.4-beta.8，修复 `Form.Item` 嵌套使用时，子级的 `required` 属性设置为 `false` 不生效的问题，并新增样式支持

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.7.4-beta.7",
+  "version": "3.7.4-beta.8",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/form/form-item.tsx
+++ b/packages/base/src/form/form-item.tsx
@@ -78,6 +78,7 @@ const FormItem = (props: FormItemProps) => {
           [formItemClasses?.wrapperInline]: inline,
           [formItemClasses?.wrapperKeepHeight]: keepErrorHeight,
           [formItemClasses?.wrapperRequired]: required,
+          [formItemClasses?.wrapperHideRequired]: required === false,
           [formItemClasses?.wrapperTip]: showError || tip,
         }
       )}

--- a/packages/base/src/form/form-item.type.ts
+++ b/packages/base/src/form/form-item.type.ts
@@ -13,6 +13,7 @@ export interface FormItemClasses {
   wrapperLabelVerticalBottom: string;
   wrapperKeepHeight: string;
   wrapperRequired: string;
+  wrapperHideRequired: string;
   wrapperTip: string;
   label: string;
   labelWithColon: string;

--- a/packages/shineout-style/src/form/form-item.ts
+++ b/packages/shineout-style/src/form/form-item.ts
@@ -126,6 +126,11 @@ const formItemStyle: JsStyles<keyof FormItemClasses> = {
       top: '2px',
     },
   },
+  wrapperHideRequired: {
+    '& $label::before': {
+      display: 'none',
+    },
+  },
   wrapperKeepHeight: {
     marginBottom: token.formItemTipMinHeight,
     '&$wrapperTip': {

--- a/packages/shineout/src/form/__doc__/changelog.cn.md
+++ b/packages/shineout/src/form/__doc__/changelog.cn.md
@@ -1,3 +1,8 @@
+## 3.7.4-beta.8
+2025-06-26
+### 🐞 BugFix
+- 修复 `Form.Item` 嵌套使用时，子级的 `required` 属性设置为 `false` 不生效的问题 ([#1210](https://github.com/sheinsight/shineout-next/pull/1210))
+
 ## 3.7.4-beta.7
 2025-06-26
 ### 🐞 BugFix


### PR DESCRIPTION


<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog
- 修复 Form.Item嵌套使用，父级设置required为true，子级设置为false不生效的问题

<!-- - Fix `Component` ... -->

### Playground id

### Other information