### PR TITLE
fix: 修复 `Dropdown` 组件在开启 `hover` 模式时鼠标移入非 dom 包含关系元素导致意外触发打开列表的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.7.5-beta.2",
+  "version": "3.7.5-beta.3",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-popup/use-popup.ts
+++ b/packages/hooks/src/components/use-popup/use-popup.ts
@@ -139,7 +139,10 @@ const usePopup = (props: BasePopupProps) => {
   const handleMouseEnter = usePersistFn((e: { target: EventTarget | null }) => {
     targetEvents?.onMouseEnter?.(e);
     if (trigger !== 'hover') return;
-    handleHoverToggle(true);
+    const isParentContainsCurrent = targetRef.current?.contains(e.target as Node);
+    if (isParentContainsCurrent) {
+      handleHoverToggle(true);
+    }
   });
 
   const handleMouseLeave = usePersistFn((e: { target: EventTarget | null }) => {

--- a/packages/shineout/src/modal/__doc__/changelog.cn.md
+++ b/packages/shineout/src/modal/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.7.5-beta.3
+2025-07-02
+
+### 🐞 BugFix
+
+- 修复 `Dropdown` 组件在开启 `hover` 模式时，鼠标移入非 dom 包含关系元素（如在 Dropdown 列表里打开一个 Modal）导致意外打开列表的问题 ([#1218](https://github.com/sheinsight/shineout-next/pull/1218))
+
 ## 3.7.2-beta.3
 2025-06-12
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

3e4a36d0-4693-428f-b804-146d342ad216

### Other information

gpt 的解释是：

### 为什么 “鼠标移入子组件（被 createRoot 挂到外面）时，父组件的 onMouseEnter 仍然会触发？”

1. **React 把所有鼠标事件都“绑”在 document 上统一处理**  
   当浏览器触发一次原生 mouseover / mouseout，React 会在 document 上收到，再把它转换成自己的 *SyntheticEvent*，然后沿 **React 组件树** 依次分发。  
   这一套“事件委托”机制与真实的 DOM 位置无关，只和 **Fiber 组件层级** 有关。

2. **createRoot / Portal 渲染的元素虽然 DOM 在外面，但逻辑上仍是父组件的后代**  
   你在子组件里调用 `createRoot(container).render(<Tooltip/>)`（或 `<Portal />`）时：  
   • DOM 节点放到了 `body` 等任意位置；  
   • 但生成的 Fiber 仍挂回 “触发 render 的那个子组件”——因此依旧在父组件的 React 子树里。  
   结果就是：当指针从父组件“管辖”范围外移入这个 tooltip，React 认为**进入了父组件的子孙**，于是合成了 `onMouseEnter` 并调用了你的回调。  
   React 官方文档也明确指出，`onMouseEnter` / `onMouseLeave` 在 React 中是 *会冒泡* 的合成事件，而原生的 `mouseenter` / `mouseleave` 本身并不冒泡 [Common components (e.g. \<div\>)](https://react.dev/reference/react-dom/components/common){target="_blank" class="gpt-web-url"}。

3. **事件触发顺序（简化）**  
   ```text
   原生 mouseover ---> React 捕获 ---> 计算 from / to 组件
                       |
                       | 生成 Synthetic MouseEnter
                       v
            父组件 onMouseEnter 被调用
   ```

### 如何避免父组件被触发？

1. **让“外部”元素真正脱离父组件的 React 树**  
   把 tooltip/popup 抽成一个 *独立* 的 React root，而不是在子组件内部 render：  
   ```js
   // 在应用初始化时就建一个全局 root
   const overlayRoot = createRoot(document.getElementById('overlay-root'));

   // 父组件里只发消息
   overlayRoot.render(<Tooltip open={true} />);
   ```

2. **利用事件属性过滤**  
   在父组件里检查 `event.relatedTarget`：如果 relatedTarget 位于你那块 tooltip DOM 中，就忽略。  
   ```js
   function handleEnter(e){
     if (tooltipRef.current?.contains(e.relatedTarget)) return;
     // 真正逻辑 …
   }
   ```

3. **CSS 层面直接“隔绝”**  
   给 tooltip 设置 `pointer-events: none;`（如果只是展示信息，不需要交互），鼠标就不会落在它身上，父组件也就不会再收到 enter/leave。

---

**总结**  
浏览器事件 → React 统一监听 → 根据 Fiber 关系生成合成事件。  
只要 Tooltip 还在同一棵 React 树里，鼠标移进去就会触发父组件的 `onMouseEnter`——即使 DOM 节点物理位置在组件树之外。