### PR TITLE
fix: 修复 `Select` 开启 `onLoadMore` 加载新数据时列表重置到第一条的问题

### DIFF
--- a/packages/base/src/select/list.tsx
+++ b/packages/base/src/select/list.tsx
@@ -19,6 +19,7 @@ const List = <DataItem, Value>(props: BaseListProps<DataItem, Value>) => {
     lineHeight: lineHeightProp,
     threshold,
     controlType,
+    keepScrollTop,
     hideCreateOption,
     optionListRef,
     isAnimationFinish,
@@ -194,6 +195,7 @@ const List = <DataItem, Value>(props: BaseListProps<DataItem, Value>) => {
         dynamicVirtual={dynamicVirtual}
         tagClassName={styles.virtualList}
         height={height}
+        keepScrollTop={keepScrollTop}
         onScroll={handleVirtualScroll}
         lineHeight={lineHeight}
         rowsInView={itemsInView}

--- a/packages/base/src/select/select.tsx
+++ b/packages/base/src/select/select.tsx
@@ -642,6 +642,7 @@ function Select<DataItem, Value>(props0: SelectPropsBase<DataItem, Value>) {
       renderItem,
       controlType,
       onLoadMore,
+      keepScrollTop: !!filterText ? false : true,
       isAnimationFinish,
       threshold,
       onControlTypeChange: setControlType,

--- a/packages/base/src/select/select.type.ts
+++ b/packages/base/src/select/select.type.ts
@@ -154,6 +154,7 @@ export interface BaseListProps<DataItem, Value>
   originalData: any;
   groupKey?: string;
   dynamicVirtual?: boolean;
+  keepScrollTop?: boolean;
   controlType?: 'mouse' | 'keyboard';
   optionListRef: React.MutableRefObject<OptionListRefType | undefined>;
   isAnimationFinish: boolean;

--- a/packages/base/src/virtual-scroll/virtual-scroll-list.tsx
+++ b/packages/base/src/virtual-scroll/virtual-scroll-list.tsx
@@ -12,6 +12,7 @@ const VirtualList = <DataItem,>(props: VirtualListProps<DataItem>) => {
     className,
     lineHeight,
     height,
+    keepScrollTop,
     keepScrollHeight,
     renderItem,
     customRenderItem,
@@ -223,6 +224,7 @@ const VirtualList = <DataItem,>(props: VirtualListProps<DataItem>) => {
 
   useLayoutEffect(() => {
     if (keepScrollHeight) return;
+    if (keepScrollTop) return;
     // 数据变化的时候清空掉 preIndex, 如果之前有缓存的index, setRowHeight 会有问题
     setTop(0);
     setStartIndex(0);

--- a/packages/base/src/virtual-scroll/virtual-scroll-list.type.ts
+++ b/packages/base/src/virtual-scroll/virtual-scroll-list.type.ts
@@ -26,6 +26,7 @@ export interface VirtualListProps<DataItem> extends Pick<CommonType, 'className'
   virtualRef?: React.MutableRefObject<VirtualListType>;
   scrollerStyle?: React.CSSProperties;
   dynamicVirtual?: boolean;
+  keepScrollTop?: boolean;
   keepScrollHeight?: boolean;
   onControlTypeChange?: React.Dispatch<React.SetStateAction<'mouse' | 'keyboard'>>;
   onScroll?: (info: {


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

20f98f94-f491-48ba-932e-f90a9585d65f

### Other information

和这次改动有关 https://github.com/sheinsight/shineout-next/pull/1157