### PR TITLE
fix: 修复 `Upload.Image` 不限制 `accept` 时选择非图片格式文件内部校验不通过后，报错信息无内容的问题

### DIFF
--- a/packages/base/src/config/locale/en_US.ts
+++ b/packages/base/src/config/locale/en_US.ts
@@ -83,6 +83,6 @@ export default {
   search: 'search',
   urlInvalidMsg: 'Picture format is incorrect, please upload again',
   invalidAccept: 'Invalid file format',
-
+  invalidImage: 'Invalid image format',
   notFound: 'not found',
 };

--- a/packages/base/src/config/locale/zh-CN.ts
+++ b/packages/base/src/config/locale/zh-CN.ts
@@ -84,6 +84,6 @@ export default {
   search: '搜索',
   urlInvalidMsg: '图片格式不正确，请重新上传',
   invalidAccept: '文件格式不正确',
-
+  invalidImage: '图片格式不正确',
   notFound: '未找到',
 };


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

### Other information

setLocal 里缺了词条，这个词条老版本没，v3 新加的，补一下