### PR TITLE
fix: 修复 `Form.FieldSet` 的 `onAppend` 和 `onInsert` 方法在非末尾位置插入 undefined 时，子表单组件不渲染的问题，并新增清空对象值的工具函数。

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.7.7-beta.6",
+  "version": "3.7.7-beta.8",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/form/form-fieldset.tsx
+++ b/packages/base/src/form/form-fieldset.tsx
@@ -68,8 +68,13 @@ const FormFieldSet = <T,>(props: FormFieldSetProps<T>) => {
         },
         onInsert: (val: T extends (infer U)[] ? U : never) => {
           const oldValue = formFunc?.getValue(name);
+          let insertValue = val;
+          const valueTemplate = oldValue[i]
+          if(insertValue === undefined){
+            insertValue = util.clearValue(util.deepClone(valueTemplate));
+          }
           const newValue = produce(oldValue, (draft) => {
-            draft.splice(i, 0, val);
+            draft.splice(i, 0, insertValue);
           }) as T;
           onChange(newValue);
           // context.ids.splice(i, 0, util.generateUUID());
@@ -77,8 +82,13 @@ const FormFieldSet = <T,>(props: FormFieldSetProps<T>) => {
         },
         onAppend: (val: T extends (infer U)[] ? U : never) => {
           const oldValue = formFunc?.getValue(name);
+          let insertValue = val;
+          const valueTemplate = oldValue[i]
+          if(insertValue === undefined){
+            insertValue = util.clearValue(util.deepClone(valueTemplate));
+          }
           const newValue = produce(oldValue, (draft) => {
-            draft.splice(i + 1, 0, val);
+            draft.splice(i + 1, 0, insertValue);
           }) as T;
           onChange(newValue);
           // context.ids.splice(i + 1, 0, util.generateUUID());

--- a/packages/hooks/src/utils/object.ts
+++ b/packages/hooks/src/utils/object.ts
@@ -299,3 +299,22 @@ export const getCompleteFieldKeys = (fields: string | string[], allFields: strin
   // 返回之前去重
   return Array.from(new Set(completeFields));
 }
+
+
+/**
+ * 将对象中的所有值设置为空, 如果值是数组，重置为空数组，如果是对象，重置为空对象，如果是基础类型，重置为undefined
+ * @param obj 对象
+ * @returns 空对象
+ */
+export const clearValue = (obj: ObjectType): any => {
+  if(isArray(obj)){
+    return obj.map(item => clearValue(item));
+  }
+  if(isObject(obj)){
+    return Object.keys(obj).reduce((acc: any, key) => {
+      acc[key] = clearValue(obj[key]);
+      return acc;
+    }, {});
+  }
+  return undefined;
+};

--- a/packages/shineout/src/form/__doc__/changelog.cn.md
+++ b/packages/shineout/src/form/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.7.7-beta.8
+2025-07-17
+### 🐞 BugFix
+
+- 修复 `Form.FieldSet` 的 `onAppend` 和 `onInsert` 在非末尾的位置插入插入undefined时，children的表单组件不渲染的问题 ([#1252](https://github.com/sheinsight/shineout-next/pull/1252))
+
 ## 3.7.5-beta.4
 2025-07-02
 ### 🐞 BugFix


### PR DESCRIPTION


<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id
c5feb798-3ad6-4aff-b504-cd2324fcbdb7

### Other information