### PR TITLE
chore: 更新 README 文件中的 React 版本要求，从 16.8.0 升级至 16.14.0

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://www.npmjs.com/package/shineout"><img src="https://img.shields.io/npm/v/shineout.svg?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/shineout"><img src="https://img.shields.io/npm/dm/shineout.svg?style=flat-square"></a>
-  <img src="https://img.shields.io/badge/React-%3E%3D16.8.0-green.svg?style=flat-square">
+  <img src="https://img.shields.io/badge/React-%3E%3D16.14.0-green.svg?style=flat-square">
 </p>
 
 ## ✨ 特性

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ English | [简体中文](./README-zh_CN.md)
 <p align="center">
   <a href="https://www.npmjs.com/package/shineout"><img src="https://img.shields.io/npm/v/shineout.svg?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/shineout"><img src="https://img.shields.io/npm/dm/shineout.svg?style=flat-square"></a>
-  <img src="https://img.shields.io/badge/React-%3E%3D16.8.0-green.svg?style=flat-square">
+  <img src="https://img.shields.io/badge/React-%3E%3D16.14.0-green.svg?style=flat-square">
 </p>
 
 ## ✨ Features

--- a/package.json
+++ b/package.json
@@ -67,8 +67,8 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": ">=16.8",
-    "react-dom": ">=16.8"
+    "react": ">=16.14.0",
+    "react-dom": ">=16.14.0"
   },
   "pnpm": {
     "overrides": {

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -25,7 +25,7 @@
     "@sheinx/shineout-style": "workspace:*"
   },
   "peerDependencies": {
-    "react": ">=16.8",
+    "react": ">=16.14.0",
     "core-js": ">=3"
   }
 }

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -24,8 +24,8 @@
     "immer": "10.0.2"
   },
   "peerDependencies": {
-    "react": ">=16.8",
-    "react-dom": ">=16.8",
+    "react": ">=16.14.0",
+    "react-dom": ">=16.14.0",
     "core-js": ">=3"
   }
 }

--- a/packages/shineout/package.json
+++ b/packages/shineout/package.json
@@ -38,7 +38,7 @@
   },
   "peerDependencies": {
     "core-js": ">=3",
-    "react": ">=16.8",
-    "react-dom": ">=16.8"
+    "react": ">=16.14.0",
+    "react-dom": ">=16.14.0"
   }
 }


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

将React最低版本要求提升至16.14.0，主要是因为组件库采用了新的JSX Transform（runtime: 'automatic'），这允许组件文件无需显式导入React。但这个特性需要React 16.14.0+的运行时支持，否则在用户项目中会因为找不到React引用而报错。

<!-- - Fix `Component` ... -->

### Playground id

### Other information