### PR TITLE
fix: 修复 `Dropdown` 的 `trigger` 为 `hover` 且设置 `absolute` 时，鼠标移入下拉框后下拉框…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.7.8-beta.4",
+  "version": "3.7.8-beta.5",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-popup/use-popup.ts
+++ b/packages/hooks/src/components/use-popup/use-popup.ts
@@ -140,7 +140,7 @@ const usePopup = (props: BasePopupProps) => {
     targetEvents?.onMouseEnter?.(e);
     if (trigger !== 'hover') return;
     const isParentContainsCurrent = targetRef.current?.contains(e.target as Node);
-    if (isParentContainsCurrent) {
+    if (isParentContainsCurrent || popupRef?.current?.contains(e.target as Node)) {
       handleHoverToggle(true);
     }
   });

--- a/packages/shineout/src/dropdown/__doc__/changelog.cn.md
+++ b/packages/shineout/src/dropdown/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.7.8-beta.5
+2025-07-25
+
+### 🐞 BugFix
+
+- 修复 `Dropdown` 的 `trigger` 为 `hover` 且设置 `absolute` 时，鼠标移入下拉框后下拉框自动消失的问题 (Regression: since v3.7.5) [#1262](https://github.com/sheinsight/shineout-next/pull/1262)）
+
 ## 3.6.0
 2024-03-21
 


### PR DESCRIPTION
…自动消失的问题 (Regression: since v3.7.5)

<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id
abc63795-007b-4ee2-ae7c-34815a240f66

### Other information