### PR TITLE
fix: 修复 `Select` 过滤过程中受 `trim` 属性影响，表现与老版本不一致的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.7.8-beta.7",
+  "version": "3.7.8-beta.8",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/select/select.tsx
+++ b/packages/base/src/select/select.tsx
@@ -399,7 +399,8 @@ function Select<DataItem, Value>(props0: SelectPropsBase<DataItem, Value>) {
     if (hideCreate) {
       // optionListRef.current?.hoverMove(filterData.length - 1, true);
     }
-    onFilter?.(trim ? text.trim() : text, from);
+    // onFilter?.(trim ? text.trim() : text, from);
+    onFilter?.(text.trim(), from);
   };
 
   const handleOptionClick = () => {

--- a/packages/shineout/src/select/__doc__/changelog.cn.md
+++ b/packages/shineout/src/select/__doc__/changelog.cn.md
@@ -1,8 +1,14 @@
+## 3.7.8-beta.8
+2025-07-28
+
+### 🐞 BugFix
+- 修复 `Select` 过滤过程中受 `trim` 属性影响，表现与老版本（v1、v2）不一致的问题 ([#1267](https://github.com/sheinsight/shineout-next/pull/1267))
+
 ## 3.7.6-beta.4
 2025-07-10
 
 ### 🐞 BugFix
-- 修复 Select 开启 onLoadMore 加载新数据时列表重置到第一条的问题(Regression: since v3.7.1) ([#1237](https://github.com/sheinsight/shineout-next/pull/1237))
+- 修复 `Select` 开启 `onLoadMore` 加载新数据时列表重置到第一条的问题(Regression: since v3.7.1) ([#1237](https://github.com/sheinsight/shineout-next/pull/1237))
 
 ## 3.7.6-beta.2
 2025-07-08


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

c1a27d6d-4660-40b3-b1c5-e221380ec8c3

### Other information

老版本 onFilter 的时候输入空格会过滤掉，新版本会携带，同步表现