### PR TITLE
fix: 修复 `Pagination` 的 `select` 下拉框在限制了高度的html或body滚动容器中第一次点击不出现的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.7.8-beta.9",
+  "version": "3.7.8-beta.10",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/common/use-position-style/index.ts
+++ b/packages/hooks/src/common/use-position-style/index.ts
@@ -5,7 +5,7 @@ import { useCheckElementBorderWidth } from './check-border';
 import { useCheckElementSize } from './check-element-size'
 import shallowEqual from '../../utils/shallow-equal';
 import usePersistFn from '../use-persist-fn';
-import { getCurrentCSSZoom } from '../../utils';
+import { getCurrentCSSZoom, getScrollPosition } from '../../utils';
 import { docSize } from '../../utils';
 
 export type HorizontalPosition =
@@ -274,8 +274,7 @@ export const usePositionStyle = (config: PositionStyleConfig) => {
     const rect = context.parentRect;
 
     const needCheck = !show || !shallowEqual(context.prevParentPosition, parentElNewPosition)
-    const scrollTop = scrollElRef?.current?.scrollTop || 0;
-    const scrollLeft = scrollElRef?.current?.scrollLeft || 0;
+    const { scrollTop, scrollLeft } = getScrollPosition(scrollElRef?.current);
 
     if (needCheck && scrollElRef?.current && scrollElRef.current?.contains(parentElRef.current)) {
       const visibleRect = scrollElRef.current?.getBoundingClientRect() || {};

--- a/packages/hooks/src/utils/dom/document.ts
+++ b/packages/hooks/src/utils/dom/document.ts
@@ -50,3 +50,18 @@ export const getCurrentCSSZoom = (): number => {
 //   }
 // }
 
+export const getScrollPosition = (element?: HTMLElement | null) => {
+  if (!element) return { scrollTop: 0, scrollLeft: 0 };
+
+  if (element === document.documentElement || element === document.body) {
+    return {
+      scrollTop: document.documentElement.scrollTop || document.body.scrollTop,
+      scrollLeft: document.documentElement.scrollLeft || document.body.scrollLeft
+    };
+  }
+
+  return {
+    scrollTop: element.scrollTop,
+    scrollLeft: element.scrollLeft
+  };
+};

--- a/packages/shineout/src/pagination/__doc__/changelog.cn.md
+++ b/packages/shineout/src/pagination/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.7.8-beta.10
+2025-07-28
+
+### 🐞 BugFix
+- 修复 `Pagination` 的 `select` 下拉框在限制了高度的html或body滚动容器中第一次点击不出现的问题 ([#1270](https://github.com/sheinsight/shineout-next/pull/1270))
+
 ## 3.7.5-beta.7
 2025-07-03
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

### Other information