### PR TITLE
fix: 修复 `Form` 对 `onChange` 的返回值直接修改数据后再设置新 value 不生效的问题 (Regression: since v3.7.8-beta.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.7.8-beta.10",
+  "version": "3.7.8-beta.11",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-form/use-form.ts
+++ b/packages/hooks/src/components/use-form/use-form.ts
@@ -256,8 +256,9 @@ const useForm = <T extends ObjectType>(props: UseFormProps<T>) => {
 
   const onChange = usePersistFn((change: T | ((v: T) => void | T)) => {
     const newValue = typeof change === 'function' ? produce(context.value as T, change) : change;
+
     context.value = newValue;
-    props.onChange?.(deepClone(context.value) as T);
+    props.onChange?.(newValue as T);
   });
 
   const scrollToField = usePersistFn(

--- a/packages/shineout/src/form/__doc__/changelog.cn.md
+++ b/packages/shineout/src/form/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.7.8-beta.11
+2025-07-29
+### 🐞 BugFix
+
+- 修复 `Form` 对 `onChange` 的返回值直接修改数据后再设置新 value 不生效的问题 (Regression: since v3.7.8-beta.1) ([#1272](https://github.com/sheinsight/shineout-next/pull/1272))
+
 ## 3.7.8-beta.1
 2025-07-21
 ### 🐞 BugFix


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id
0986381a-dc2c-4bb9-98dd-26ae3ca6a666

### Other information