### PR TITLE
fix(popover): 修复 children 函数在组件挂载时就执行的问题

### DIFF
--- a/packages/base/src/popover/popover.tsx
+++ b/packages/base/src/popover/popover.tsx
@@ -135,7 +135,7 @@ const Popover = (props: PopoverProps) => {
 
   context.rendered = true;
 
-  const childrened = util.isFunc(children) ? children(closePop) : children;
+  const childrened = util.isFunc(children) ? (open ? children(closePop) : null) : children;
   const containerStyle = {
     borderColor: props.border,
     backgroundColor: props.background,


### PR DESCRIPTION
- 问题：3.2.0-beta.2 版本后，Popover 的 children 函数在组件挂载时就会执行，而不是在 Popover 打开时才执行
- 原因：在提交 4e47d2e0 中，lazy 逻辑修改导致默认不再懒加载，children 函数会在渲染时立即执行
- 修复：只有当 Popover 打开时才执行 children 函数，未打开时返回 null

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

274871cf-feb7-4362-b365-15dc877a57d6

### Other information