### PR TITLE
fix: 修复 Cascader 的 renderCompressed 在特殊交互后 Popover 无法打开的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.7.10-beta.1",
+  "version": "3.7.10-beta.2",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/select/result.tsx
+++ b/packages/base/src/select/result.tsx
@@ -357,7 +357,7 @@ const Result = <DataItem, Value>(props: ResultProps<DataItem, Value>) => {
         setShouldResetMore(true);
       });
     } else {
-      setMore(-1);
+      if(!renderCompressed) setMore(-1);
       setShouldResetMore(true);
     }
   };

--- a/packages/shineout/src/cascader/__doc__/changelog.cn.md
+++ b/packages/shineout/src/cascader/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.7.10-beta.2
+2025-08-11
+
+### 🐞 BugFix
+- 修复 `Cascader` 的 `renderCompressed` 在某些特殊交互后，自定义的Popover无法正常打开的问题 ([#1297](https://github.com/sheinsight/shineout-next/pull/1297))
+
+
 ## 3.7.8-beta.3
 2025-07-23
 


### PR DESCRIPTION
- 在 Result 组件中，当使用 renderCompressed 时避免重置 more 状态
- 修复多选压缩显示情况下，自定义 Popover 无法正常打开的问题
- 确保 renderCompressed 功能的交互体验一致性

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id
fa08469d-2336-4bed-8a07-ef09e2232655

### Other information