### PR TITLE
fix: 修复 Modal panel 面板的 margin 样式问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.0-beta.25",
+  "version": "3.8.0-beta.26",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/modal/modal.ts
+++ b/packages/shineout-style/src/modal/modal.ts
@@ -320,6 +320,7 @@ const modalStyle: JsStyles<ModalClassType> = {
     background: token.modalPanelBackground,
     borderRadius: token.modalPanelRadius,
     padding: `${token.modalPanelPaddingY} ${token.modalPanelPaddingX}`,
+    margin: '0 auto',
     fontSize: token.modalPanelFontSize,
     boxSizing: 'border-box',
     boxShadow: token.modalPanelShadow,

--- a/packages/shineout/src/modal/__doc__/changelog.cn.md
+++ b/packages/shineout/src/modal/__doc__/changelog.cn.md
@@ -1,3 +1,11 @@
+## 3.8.0-beta.26
+2025-08-12
+
+### 🐞 BugFix
+- 修复 `Modal` 的 panel 面板的 margin 样式问题 ([#1298](https://github.com/sheinsight/shineout-next/pull/1298))
+
+
+
 ## 3.8.0-beta.23
 2025-08-04
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog
- 为 Modal 的 panel 样式添加 margin: '0 auto'
- 修复 Modal 面板在某些布局情况下的居中显示问题
- 确保 Modal 面板始终水平居中

<!-- - Fix `Component` ... -->

### Playground id

### Other information