### PR TITLE
fix: 修复 Form.Field name 为数组时错误信息重复渲染的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.0-beta.26",
+  "version": "3.8.0-beta.27",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/form/form-item.tsx
+++ b/packages/base/src/form/form-item.tsx
@@ -73,6 +73,23 @@ const FormItem = (props: FormItemProps) => {
     labelText += ` (tip: ${labelTipRef.current?.textContent})`;
   }
 
+  const renderError = () => {
+    if(!showError) return null;
+    let uniqueErrors = errors;
+    if(errors.length > 1) {
+      uniqueErrors = errors.filter((error, index, self) =>
+        index === self.findIndex((t) => t.message === error.message)
+      )
+    }
+    return (
+      <div className={formItemClasses?.error}>
+        {uniqueErrors.map((error, index) => (
+          <div key={index}>{error && <ErrorTrans error={error} />}</div>
+        ))}
+      </div>
+    )
+  }
+
   return (
     <div
       className={classNames(
@@ -116,13 +133,7 @@ const FormItem = (props: FormItemProps) => {
 
         {!!tip && (!showError || keepErrorBelow) && <div ref={labelTipRef} className={formItemClasses?.tip}>{tip}</div>}
 
-        {showError && (
-          <div className={formItemClasses?.error}>
-            {errors.map((error, index) => (
-              <div key={index}>{error && <ErrorTrans error={error} />}</div>
-            ))}
-          </div>
-        )}
+        {renderError()}
       </div>
     </div>
   );

--- a/packages/hooks/src/components/use-form/use-form-item/use-form-item.ts
+++ b/packages/hooks/src/components/use-form/use-form-item/use-form-item.ts
@@ -23,7 +23,7 @@ const UseFormItem = () => {
     }
   });
 
-  const msg = Object.values(errors).filter(Boolean);
+  const msg = Object.values(errors).filter(Boolean) as Error[];
 
   const showError = msg && msg.length > 0;
 

--- a/packages/shineout/src/form/__doc__/changelog.cn.md
+++ b/packages/shineout/src/form/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.8.0-beta.27
+2025-08-12
+
+### 🐞 BugFix
+
+- 修复 `Form.Field` 的 `name` 为数组时，错误信息重复渲染的问题 ([#1299](https://github.com/sheinsight/shineout-next/pull/1299))
+
 ## 3.8.0-beta.25
 2025-08-11
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog
- 在 FormItem 组件中对错误信息进行去重处理
- 修复当 Form.Field 的 name 属性为数组时，相同的错误信息可能重复显示的问题
- 优化错误信息的显示逻辑，确保相同内容的错误只显示一次
- 改进 use-form-item hook 中的错误类型定义

<!-- - Fix `Component` ... -->

### Playground id
76166e1c-ed36-47d5-9d7b-56c8dcd2f8e4

### Other information