### PR TITLE
fix: 修复 Form Schema Builder 对 Checkbox.Group、Radio.Group、Switch 组件的类型识别

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.0-beta.28",
+  "version": "3.8.0-beta.29",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-form/use-form-schema/form-schema-builder.ts
+++ b/packages/hooks/src/components/use-form/use-form-schema/form-schema-builder.ts
@@ -148,13 +148,18 @@ export class SchemaBuilder {
           fieldSchemaInfo.description += `默认时间：${componentElement.props.defaultTime?.toString() || ''}; 格式：${componentElement.props.format || ''} `
           break;
         case 'Checkbox':
+        case 'CheckboxGroup':
           fieldSchemaInfo.type = 'array';
           fieldSchemaInfo.items = {
             type: 'string',
           };
           break;
         case 'Radio':
+        case 'RadioGroup':
           fieldSchemaInfo.type = 'string';
+          break;
+        case 'Switch':
+          fieldSchemaInfo.type = 'boolean';
           break;
         case 'Rate':
           fieldSchemaInfo.type = 'number';

--- a/packages/shineout/src/checkbox/group.tsx
+++ b/packages/shineout/src/checkbox/group.tsx
@@ -7,7 +7,7 @@ const jssStyle = {
   checkbox: useCheckboxStyle,
   input: useInputStyle,
 };
-const BaseCheckboxGroup = <DataItem, Value extends any[]>(
+const CheckboxGroup = <DataItem, Value extends any[]>(
   props: BaseCheckboxGroupProps<DataItem, Value>,
 ) => {
   return <UnStyledCheckboxGroup {...props} jssStyle={jssStyle} />;
@@ -16,7 +16,7 @@ const BaseCheckboxGroup = <DataItem, Value extends any[]>(
 const CheckboxGroupWithField = <DataItem, Value extends any[]>(
   props: CheckboxGroupProps<DataItem, Value>,
 ) => {
-  return useFieldCommon(props, BaseCheckboxGroup<DataItem, Value>, 'array');
+  return useFieldCommon(props, CheckboxGroup<DataItem, Value>, 'array');
 };
 
 export default CheckboxGroupWithField;

--- a/packages/shineout/src/form/__example__/test-001-base-form.tsx
+++ b/packages/shineout/src/form/__example__/test-001-base-form.tsx
@@ -4,7 +4,7 @@
  * en - Test Form
  *    -- Test Form
  */
-import { Form, Input, Select, Rule, Textarea, DatePicker, Button } from 'shineout';
+import { Form, Input, Select, Switch, Rule, Radio, Textarea, DatePicker, Button, Checkbox } from 'shineout';
 
 const rules = Rule();
 export default () => {
@@ -22,6 +22,26 @@ export default () => {
 
       <Form.Item label='工作代理人' required>
         <Input name='agent' rules={[rules.required()]} />
+      </Form.Item>
+
+      <Form.Item label='喜欢的颜色' required>
+        <Checkbox.Group
+          name="likeColors"
+          keygen
+          data={['red', 'green']}
+        />
+      </Form.Item>
+
+      <Form.Item label='不喜欢的颜色' required>
+        <Radio.Group
+          name="dislikeColor"
+          keygen
+          data={['red', 'green']}
+        />
+      </Form.Item>
+
+      <Form.Item label='是否支持颜色' required>
+        <Switch name="isSupportColor" />
       </Form.Item>
 
       <Form.Item label='请假事由' required>

--- a/packages/shineout/src/radio/group.tsx
+++ b/packages/shineout/src/radio/group.tsx
@@ -7,12 +7,12 @@ const jssStyle = {
   radio: useRadioStyle,
   button: useButtonStyle,
 };
-const BaseRadioGroup = <DataItem, Value>(props: BaseRadioGroupProps<DataItem, Value>) => {
+const RadioGroup = <DataItem, Value>(props: BaseRadioGroupProps<DataItem, Value>) => {
   return <UnStyledRadioGroup {...props} jssStyle={jssStyle} />;
 };
 
 const RadioGroupWithField = <DataItem, Value>(props: RadioGroupProps<DataItem, Value>) => {
-  return useFieldCommon(props, BaseRadioGroup<DataItem, Value>, 'array');
+  return useFieldCommon(props, RadioGroup<DataItem, Value>, 'array');
 };
 
 export default RadioGroupWithField;

--- a/packages/shineout/src/switch/switch.tsx
+++ b/packages/shineout/src/switch/switch.tsx
@@ -7,10 +7,10 @@ const jssStyle = {
   switch: useSwitchStyle,
 };
 
-const BaseSwitch = (props: BaseSwitchProps) => {
+const Switch = (props: BaseSwitchProps) => {
   return <UnStyleSwitch jssStyle={jssStyle} {...props} />;
 };
 
 export default (props: SwitchProps) => {
-  return useFieldCommon(props, BaseSwitch);
+  return useFieldCommon(props, Switch);
 };

--- a/packages/shineout/src/textarea/textarea.tsx
+++ b/packages/shineout/src/textarea/textarea.tsx
@@ -8,10 +8,10 @@ const jssStyle = {
   popover: usePopoverStyle,
   innerTitle: useInnerTitleStyle,
 };
-const BaseTextarea = (props: BaseTextareaProps) => {
+const Textarea = (props: BaseTextareaProps) => {
   return <UnStyledTextarea {...props} jssStyle={jssStyle} />;
 };
 
 export default (props: TextareaProps) => {
-  return useFieldCommon(props, BaseTextarea);
+  return useFieldCommon(props, Textarea);
 };


### PR DESCRIPTION
- 在 SchemaBuilder 中添加对 CheckboxGroup、RadioGroup、Switch 组件的类型识别
- 修复 Checkbox.Group 返回正确的 array 类型 schema
- 修复 Radio.Group 返回正确的 string 类型 schema
- 新增 Switch 组件的 boolean 类型 schema 支持
- 完善表单组件的 JSON Schema 生成功能

注：本次修复是对 3.8.0-beta.21 FormRef.getFormSchema 功能的能力补全， 属于 3.8.0 版本范围内的内容，故未单独添加 changelog 条目

<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

### Other information