### PR TITLE
fix: 修复 DatePicker 的时间范围选择器设置的 min、max、defaultTime 属性不生效的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.0-beta.29",
+  "version": "3.8.0-beta.30",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/date-picker/time.tsx
+++ b/packages/base/src/date-picker/time.tsx
@@ -7,8 +7,10 @@ import { getLocale, useConfig } from '../config';
 import PickerTitle from './pickerTitle';
 import Confirm from './confirm';
 
+type TimeType = 'H' | 'h' | 'm' | 's' | 'ampm';
+
 const TimeScroll = (props: {
-  mode: string;
+  mode: TimeType;
   jssStyle: TimeProps['jssStyle'];
   times: {
     str: string;
@@ -132,6 +134,7 @@ const Time = (props: TimeProps) => {
     secondStep: props.secondStep,
     position: props.position,
     rangeDate: props.rangeDate,
+    defaultTime: props.defaultTime,
   });
 
   const selNow = () => {

--- a/packages/hooks/src/components/use-datepicker/use-time.tsx
+++ b/packages/hooks/src/components/use-datepicker/use-time.tsx
@@ -3,6 +3,19 @@ import useLatestObj from '../../common/use-latest-obj';
 import dateUtil from './util';
 
 type TimeType = 'H' | 'h' | 'm' | 's' | 'ampm';
+type TimesType = {
+  mode: TimeType;
+  times: {
+    str: string;
+    date: Date;
+    disabled: boolean;
+  }[];
+  currentIndex: number;
+};
+
+const getStepIndex = (index: number, step: number) => Math.floor(index / step);
+
+
 const useTime = (props: UseTimeProps) => {
   const {
     options,
@@ -21,9 +34,19 @@ const useTime = (props: UseTimeProps) => {
   const min = dateUtil.resetTimeByFormat(mi, format, options);
   const max = dateUtil.resetTimeByFormat(ma, format, options);
 
-  const current = props.value || dateUtil.newDate(undefined, options);
-
-  const getStepIndex = (index: number, step: number) => Math.floor(index / step);
+  let current = props.value || dateUtil.newDate(undefined, options);
+  if(!props.value && typeof props.defaultTime === 'string' && /^\d{1,2}(:\d{2}(:\d{2})?)?$/.test(props.defaultTime)) {
+    const today = new Date();
+    const todayStr = today.getFullYear() + '-' + (today.getMonth() + 1) + '-' + today.getDate();
+    const timesStr = props.defaultTime.split(':');
+    const hStr = timesStr[0];
+    const mStr = timesStr[1] || '00';
+    const sStr = timesStr[2] || '00';
+    const timeStr = hStr + ':' + mStr + ':' + sStr;
+    const dayStr = todayStr + ' ' + timeStr;
+    const val = new Date(dayStr)
+    if(val) current = val;
+  }
 
   const time = {
     hour: dateUtil.getDateInfo(current, 'hour', options),
@@ -133,39 +156,39 @@ const useTime = (props: UseTimeProps) => {
       .filter((item) => item) as Array<{ str: string; date: Date; disabled: boolean }>;
   };
 
-  const getTimes = () => {
-    const res = [];
+  const getTimes = (): TimesType[] => {
+    const res: TimesType[] = [];
     if (format.indexOf('H') >= 0) {
       res.push({
-        mode: 'H',
+        mode: 'H' as TimeType,
         times: getModeArr('H', 24),
         currentIndex: getStepIndex(time.hour, hourStep),
       });
     }
     if (format.indexOf('h') >= 0) {
       res.push({
-        mode: 'h',
+        mode: 'h' as TimeType,
         times: getModeArr('h', 12),
         currentIndex: getStepIndex(time.hour, hourStep),
       });
     }
     if (format.indexOf('m') >= 0) {
       res.push({
-        mode: 'm',
+        mode: 'm' as TimeType,
         times: getModeArr('m', 60),
         currentIndex: getStepIndex(time.minute, minuteStep),
       });
     }
     if (format.indexOf('s') >= 0) {
       res.push({
-        mode: 's',
+        mode: 's' as TimeType,
         times: getModeArr('s', 60),
         currentIndex: getStepIndex(time.second, secondStep),
       });
     }
     if (/a|A/.test(format)) {
       res.push({
-        mode: 'ampm',
+        mode: 'ampm' as TimeType,
         times: getModeArr('ampm', 2),
         currentIndex: time.apm === 'pm' ? 1 : 0,
       });

--- a/packages/hooks/src/components/use-datepicker/use-time.type.ts
+++ b/packages/hooks/src/components/use-datepicker/use-time.type.ts
@@ -1,3 +1,5 @@
+import { DateTimeType } from "./util";
+
 export interface UseTimeProps {
   format: string;
   options: {
@@ -17,4 +19,5 @@ export interface UseTimeProps {
   secondStep?: number;
   position?: 'start' | 'end';
   rangeDate?: Array<Date | undefined>;
+  defaultTime?: DateTimeType;
 }

--- a/packages/hooks/src/components/use-datepicker/util.ts
+++ b/packages/hooks/src/components/use-datepicker/util.ts
@@ -257,7 +257,16 @@ function toDate(day: DateTimeType, options?: DateOptions): Date {
   if (!day) return new Date('');
   if (day instanceof Date) return dayjs(day).toDate();
   if (typeof day === 'number') return new Date(day);
-  if (typeof day === 'string') return transDateWithZone(dayjs(day).toDate(), options, true);
+  if (typeof day === 'string') {
+    // 当 day 只有时间部分，没有日期部分时
+    if (/^\d{1,2}(:\d{2}(:\d{2})?)?$/.test(day)) {
+      const today = new Date();
+      const todayStr = today.getFullYear() + '-' + (today.getMonth() + 1) + '-' + today.getDate();
+      const dayStr = todayStr + ' ' + day;
+      return transDateWithZone(dayjs(dayStr).toDate(), options, true);
+    }
+    return transDateWithZone(dayjs(day).toDate(), options, true);
+  }
   return dayjs(day).toDate();
 }
 

--- a/packages/shineout/src/date-picker/__doc__/changelog.cn.md
+++ b/packages/shineout/src/date-picker/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.8.0-beta.30
+2025-08-14
+
+### 🐞 BugFix
+- 修复 `DatePicker` 的时间范围选择器设置的 `min` 、 `max`、`defaultTime` 属性不生效的问题 ([#1301](https://github.com/sheinsight/shineout-next/pull/1301))
+
+
 ## 3.7.8-beta.2
 2025-07-22
 


### PR DESCRIPTION
## Summary
- 修复 DatePicker 时间范围选择器的 min、max、defaultTime 属性不生效的问题
- 增强了时间字符串的处理逻辑，支持纯时间格式的输入
- 改进了类型定义，提升代码安全性

## Test plan
- [x] 测试时间范围选择器的 min/max 限制功能
- [x] 测试 defaultTime 属性在时间模式下的默认值设置
- [x] 验证纯时间字符串格式（如 "12:00"）的正确解析
- [x] 确保修改不影响现有的日期时间功能

## Playground
playground-id: 1e29eb1a-a37d-4799-b56d-b4e0bdeb6661

🤖 Generated with [Claude Code](https://claude.ai/code)