### PR TITLE
fix: 修复生产环境中组件类型识别失败的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.0-beta.30",
+  "version": "3.8.0-beta.31",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-form/use-form-schema/form-schema-builder.ts
+++ b/packages/hooks/src/components/use-form/use-form-schema/form-schema-builder.ts
@@ -68,20 +68,27 @@ export class SchemaBuilder {
 
     let itemType;
     if (typeof componentElement.type === 'function') {
-      switch (componentElement.type.name) {
+      const componentName = componentElement.type.displayName || componentElement.type.name;
+      switch (componentName) {
+        case 'ShineoutInput':
         case 'Input':
           fieldSchemaInfo.type = 'string';
           break;
+        case 'ShineoutInputNumber':
         case 'InputNumber':
           fieldSchemaInfo.type = 'number';
           break;
+        case 'ShineoutInputPassword':
         case 'InputPassword':
           fieldSchemaInfo.type = 'string';
           break;
+        case 'ShineoutTextarea':
         case 'Textarea':
           fieldSchemaInfo.type = 'string';
           break;
+        case 'ShineoutSelect':
         case 'Select':
+        case 'ShineoutTreeSelect':
         case 'TreeSelect': {
           const format = componentElement.props.format || componentElement.props.keygen;
           if (typeof componentElement.props.keygen !== 'boolean') {
@@ -128,6 +135,7 @@ export class SchemaBuilder {
           };
           break;
         }
+        case 'ShineoutDatePicker':
         case 'DatePicker':
           if (componentElement.props.range) {
             if (finalFieldId?.includes(separator || '')) {
@@ -147,20 +155,26 @@ export class SchemaBuilder {
 
           fieldSchemaInfo.description += `默认时间：${componentElement.props.defaultTime?.toString() || ''}; 格式：${componentElement.props.format || ''} `
           break;
+        case 'ShineoutCheckbox':
         case 'Checkbox':
+        case 'ShineoutCheckboxGroup':
         case 'CheckboxGroup':
           fieldSchemaInfo.type = 'array';
           fieldSchemaInfo.items = {
             type: 'string',
           };
           break;
+        case 'ShineoutRadio':
         case 'Radio':
+        case 'ShineoutRadioGroup':
         case 'RadioGroup':
           fieldSchemaInfo.type = 'string';
           break;
+        case 'ShineoutSwitch':
         case 'Switch':
           fieldSchemaInfo.type = 'boolean';
           break;
+        case 'ShineoutRate':
         case 'Rate':
           fieldSchemaInfo.type = 'number';
           break;

--- a/packages/shineout-style/src/version.ts
+++ b/packages/shineout-style/src/version.ts
@@ -1,1 +1,1 @@
-export default '3.8.0-beta.22';
+export default '3.8.0-beta.31';

--- a/packages/shineout/src/form/__example__/test-001-base-form.tsx
+++ b/packages/shineout/src/form/__example__/test-001-base-form.tsx
@@ -4,9 +4,31 @@
  * en - Test Form
  *    -- Test Form
  */
-import { Form, Input, Select, Switch, Rule, Radio, Textarea, DatePicker, Button, Checkbox } from 'shineout';
+import {
+  Form,
+  Input,
+  Select,
+  Switch,
+  Rule,
+  Radio,
+  Textarea,
+  DatePicker,
+  Button,
+  Checkbox,
+} from 'shineout';
 
 const rules = Rule();
+
+const checkboxGroupData = [
+  { id: 1, color: 'red' },
+  { id: 2, color: 'cyan' },
+  { id: 3, color: 'blue' },
+  { id: 4, color: 'green' },
+  { id: 5, color: 'yellow' },
+  { id: 6, color: 'orange' },
+  { id: 7, color: 'violet' },
+];
+
 export default () => {
   const [form, setForm] = Form.useForm();
   return (
@@ -20,36 +42,59 @@ export default () => {
         />
       </Form.Item>
 
+      <Form.Item label='下拉' required>
+        <Select
+          data={checkboxGroupData}
+          keygen='id'
+          renderItem={(d) => d.color}
+          format='id'
+          name='select'
+        />
+      </Form.Item>
+
+      <Form.Item label='下拉多选' required>
+        <Select
+          data={checkboxGroupData}
+          keygen='id'
+          renderItem='color'
+          format='id'
+          name='multiSelect'
+          multiple
+          compressed
+        />
+      </Form.Item>
+
       <Form.Item label='工作代理人' required>
         <Input name='agent' rules={[rules.required()]} />
       </Form.Item>
 
       <Form.Item label='喜欢的颜色' required>
-        <Checkbox.Group
-          name="likeColors"
-          keygen
-          data={['red', 'green']}
-        />
+        <Checkbox.Group name='likeColors' keygen data={['red', 'green']} />
       </Form.Item>
 
       <Form.Item label='不喜欢的颜色' required>
-        <Radio.Group
-          name="dislikeColor"
-          keygen
-          data={['red', 'green']}
-        />
+        <Radio.Group name='dislikeColor' keygen data={['red', 'green']} />
       </Form.Item>
 
       <Form.Item label='是否支持颜色' required>
-        <Switch name="isSupportColor" />
+        <Switch name='isSupportColor' />
       </Form.Item>
 
       <Form.Item label='请假事由' required>
-        <Textarea name='reason' rules={[rules.required(), { max: 100, message: '请假事由不能超过100个字' }]} />
+        <Textarea
+          name='reason'
+          rules={[rules.required(), { max: 100, message: '请假事由不能超过100个字' }]}
+        />
       </Form.Item>
 
-      <Form.Item label='请假时间' required tip="工作日时间：09:00 - 18:00">
-        <DatePicker range name='holidayTime' format='YYYY-MM-DD HH:mm' defaultTime={['09:00', '18:00']} rules={[rules.required()]} />
+      <Form.Item label='请假时间' required tip='工作日时间：09:00 - 18:00'>
+        <DatePicker
+          range
+          name='holidayTime'
+          format='YYYY-MM-DD HH:mm'
+          defaultTime={['09:00', '18:00']}
+          rules={[rules.required()]}
+        />
       </Form.Item>
 
       <Form.Item label='相关流程'>
@@ -58,8 +103,8 @@ export default () => {
 
       <Form.Item label=''>
         <Button onClick={() => console.log(form.getFormSchema())}>Get Schema</Button>
-      <Form.Submit>Submit</Form.Submit>
-      <Form.Reset>Reset</Form.Reset>
+        <Form.Submit>Submit</Form.Submit>
+        <Form.Reset>Reset</Form.Reset>
       </Form.Item>
     </Form>
   );

--- a/packages/shineout/src/index.ts
+++ b/packages/shineout/src/index.ts
@@ -67,4 +67,4 @@ export * from './deprecated';
 
 export * as TYPE from './type';
 
-export default { version: '3.8.0-beta.22' };
+export default { version: '3.8.0-beta.31' };


### PR DESCRIPTION
## Summary
- 修复 SchemaBuilder 在生产环境中无法正确识别组件类型的问题
- 同时检查 `displayName` 和 `name` 属性，确保在代码压缩后仍能正确识别
- 支持带前缀的组件名称（ShineoutInput）和不带前缀的名称（Input）

## 问题描述
在生产环境构建时，JavaScript 代码会被压缩混淆，函数名会被重命名为短字符，导致 `componentElement.type.name` 获取不到原始的组件名称，从而无法正确生成 form schema。

## 解决方案
1. 优先使用 `displayName` 属性（不会被压缩工具修改）
2. 回退到 `name` 属性（开发环境可用）
3. 同时支持带前缀和不带前缀的组件名称判断

## Test plan
- [x] 验证所有组件的 displayName 已正确设置
- [x] 测试构建后的 CJS/ESM 版本保留 displayName
- [x] 测试 UMD 压缩版本保留 displayName
- [x] 确认 typeof 检查在所有环境下有效

🤖 Generated with [Claude Code](https://claude.ai/code)