### PR TITLE
fix: 修复 `Tree` 在设置了 `defaultExpandAll` 后，组件初始化完再更改数据导致默认展开不生效的问题

### DIFF
--- a/packages/hooks/src/components/use-tree/use-tree.ts
+++ b/packages/hooks/src/components/use-tree/use-tree.ts
@@ -699,6 +699,19 @@ const useTree = <DataItem>(props: BaseTreeProps<DataItem>) => {
   });
 
   useEffect(() => {
+    if (props.datum) return;
+    if (!dataUpdate) return;
+    setData(data);
+    const nextExpanded = props.expanded || props.defaultExpanded || [];
+    if (!defaultExpandAll && !shallowEqual(nextExpanded, expanded)) {
+      onExpand(nextExpanded);
+      updateExpanded(nextExpanded, true);
+    }
+
+    updateInnerCheckStatus();
+  }, [props.data]);
+
+  useEffect(() => {
     if (defaultExpandAll) {
       const nextExpanded = [] as KeygenResult[];
       context.dataMap.forEach((item, k) => {
@@ -710,20 +723,6 @@ const useTree = <DataItem>(props: BaseTreeProps<DataItem>) => {
       updateExpanded(nextExpanded, true);
     }
   }, [context.dataMap, props.data]);
-
-  useEffect(() => {
-    if (props.datum) return;
-    if (!dataUpdate) return;
-    setData(data);
-    const nextExpanded = props.expanded || props.defaultExpanded || [];
-
-    if (!defaultExpandAll && !shallowEqual(nextExpanded, expanded)) {
-      onExpand(nextExpanded);
-      updateExpanded(nextExpanded, true);
-    }
-
-    updateInnerCheckStatus();
-  }, [props.data]);
 
   useEffect(() => {
     if (props.datum) return;


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

746a2918-9ea7-4a53-9db4-022b1c68040c

### Other information