### PR TITLE
fix: 修复 Tabs 暗黑主题下 card 模式的下划线样式问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.7.10-beta.3",
+  "version": "3.7.10-beta.4",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/tabs/tabs.ts
+++ b/packages/shineout-style/src/tabs/tabs.ts
@@ -64,10 +64,10 @@ const getCardStyle = () => {
             height: '100%',
           },
         },
-        ...active({ top: 0, bottom: 0, right: -1, width: 1, background: '#FFFFFF' }),
+        ...active({ top: 0, bottom: 0, right: -1, width: 1, background: Token.tabsCardCheckedBackgroundColor }),
       },
       '&[dir=rtl]': {
-        ...active({ top: 0, bottom: 0, left: -1, width: 1, background: '#FFFFFF' }),
+        ...active({ top: 0, bottom: 0, left: -1, width: 1, background: Token.tabsCardCheckedBackgroundColor }),
 
         '& $cardHr': {
           '&:before': {
@@ -95,7 +95,7 @@ const getCardStyle = () => {
             height: '100%',
           },
         },
-        ...active({ top: 0, bottom: 0, left: -1, width: 1, background: '#FFFFFF' }),
+        ...active({ top: 0, bottom: 0, left: -1, width: 1, background: Token.tabsCardCheckedBackgroundColor }),
       },
 
       '&[dir=rtl]': {
@@ -106,7 +106,7 @@ const getCardStyle = () => {
             height: '100%',
           },
         },
-        ...active({ top: 0, bottom: 0, right: -1, width: 1, background: '#FFFFFF' }),
+        ...active({ top: 0, bottom: 0, right: -1, width: 1, background: Token.tabsCardCheckedBackgroundColor }),
       },
     },
     '&[data-soui-position^="top-"][data-soui-shape="card"]': {
@@ -114,7 +114,7 @@ const getCardStyle = () => {
         borderRadius: `${Token.tabsTabBorderRadius} ${Token.tabsTabBorderRadius} 0 0`,
       },
       '& $hr': { bottom: 0, height: 1, width: '100%' },
-      ...active({ bottom: -1, left: 0, right: 0, height: 1, background: '#FFFFFF' }),
+      ...active({ bottom: -1, left: 0, right: 0, height: 1, background: Token.tabsCardCheckedBackgroundColor }),
     },
     '&[data-soui-position^="bottom-"][data-soui-shape="card"]': {
       '& $tab,& $next,& $prev': {
@@ -127,14 +127,14 @@ const getCardStyle = () => {
           bottom: 'auto',
         },
       },
-      ...active({ top: -1, left: 0, right: 0, height: 1, background: '#FFFFFF' }),
+      ...active({ top: -1, left: 0, right: 0, height: 1, background: Token.tabsCardCheckedBackgroundColor }),
     },
   };
 };
 
 const getLineStyle = () => {
   return {
-    '$tab':  {
+    '&[data-soui-shape="line"] $tab':  {
       '&:after': {
         display: 'none',
       },

--- a/packages/shineout-style/src/version.ts
+++ b/packages/shineout-style/src/version.ts
@@ -1,1 +1,1 @@
-export default '3.7.9';
+export default '3.7.10-beta.4';

--- a/packages/shineout/src/index.ts
+++ b/packages/shineout/src/index.ts
@@ -67,4 +67,4 @@ export * from './deprecated';
 
 export * as TYPE from './type';
 
-export default { version: '3.7.9' };
+export default { version: '3.7.10-beta.4' };

--- a/packages/shineout/src/tabs/__doc__/changelog.cn.md
+++ b/packages/shineout/src/tabs/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.7.10-beta.4
+2025-08-14
+### 🐞 BugFix
+
+- 修复 `Tabs` 暗黑主题下 card 模式的下划线样式问题 ([#1308](https://github.com/sheinsight/shineout-next/pull/1308))
+
 ## 3.7.0-beta.8
 2025-04-21
 


### PR DESCRIPTION
## Summary
- 修复 Tabs 暗黑主题下 card 模式的下划线样式问题

## Test plan
- 测试 Tabs 组件在暗黑主题下的样式显示
- 验证 card 模式下的下划线样式正确性

🤖 Generated with [Claude Code](https://claude.ai/code)