### PR TITLE
fix: Radio.Group 函数式 disabled 导致子组件都被禁用的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.0-beta.36",
+  "version": "3.8.0-beta.37",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/radio/radio.tsx
+++ b/packages/base/src/radio/radio.tsx
@@ -17,8 +17,17 @@ const Radio = <T,>(props: RadioProps<T>) => {
     return checked;
   };
 
+  // 对齐v1,v2版本的表现
+  const getDisabled = () => {
+    if(typeof props.disabled === 'function') {
+      return !!props.disabled(htmlValue);
+    }
+
+    return props.disabled;
+  };
+
   return (
-    <SimpleRadio jssStyle={jssStyle} {...rest} checked={getChecked()} onChange={handleChange}>
+    <SimpleRadio jssStyle={jssStyle} {...rest} checked={getChecked()} onChange={handleChange} disabled={getDisabled()}>
       {children}
     </SimpleRadio>
   );

--- a/packages/base/src/radio/radio.type.ts
+++ b/packages/base/src/radio/radio.type.ts
@@ -52,7 +52,7 @@ export interface SimpleRadioProps
   theme?: 'dark';
 }
 
-export interface RadioProps<T> extends Omit<SimpleRadioProps, 'onChange' | 'checked' | 'theme'> {
+export interface RadioProps<T> extends Omit<SimpleRadioProps, 'onChange' | 'checked' | 'theme' | 'disabled'> {
   /**
    * @en Specifies the result
    * @cn 选中后返回的值
@@ -74,4 +74,11 @@ export interface RadioProps<T> extends Omit<SimpleRadioProps, 'onChange' | 'chec
    * @cn 勾选框点击回调
    */
   onClick?: (e: React.MouseEvent<HTMLInputElement>) => void;
+
+  /**
+   * @en When the value is true, disabled all checkboxes; When the value is function, disable the checkbox that this function returns true
+   * @cn 如果 disabled 为 true，禁用全部选项，如果 disabled 为函数，根据函数反回结果禁用选项
+   * @default false
+   */
+  disabled?: boolean | ((data: T) => boolean);
 }

--- a/packages/shineout-style/src/version.ts
+++ b/packages/shineout-style/src/version.ts
@@ -1,1 +1,1 @@
-export default '3.8.0-beta.36';
+export default '3.8.0-beta.37';

--- a/packages/shineout/src/index.ts
+++ b/packages/shineout/src/index.ts
@@ -67,4 +67,4 @@ export * from './deprecated';
 
 export * as TYPE from './type';
 
-export default { version: '3.8.0-beta.36' };
+export default { version: '3.8.0-beta.37' };

--- a/packages/shineout/src/radio/__doc__/changelog.cn.md
+++ b/packages/shineout/src/radio/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.8.0-beta.37
+2025-08-18
+
+### 🐞 BugFix
+- 修复 `Radio.Group` 设置的函数式 `disabled` 导致的子Radio组件(非推荐用法)都被禁用的问题 ([#1314](https://github.com/sheinsight/shineout-next/pull/1314))
+
+
 ## 3.7.9-beta.8
 2025-08-06
 ### 🐞 BugFix


### PR DESCRIPTION
## Summary
- 修复 Radio.Group 设置的函数式 disabled 导致的子Radio组件(非推荐用法)都被禁用的问题
- 对齐v1,v2版本的表现，确保函数式 disabled 正确应用于各个 Radio 选项
- 更新版本号至 3.8.0-beta.37

## Test plan
- [x] 验证 Radio.Group 设置函数式 disabled 时，各个子 Radio 组件按函数返回值正确启用/禁用
- [x] 确认兼容性与v1、v2版本保持一致
- [x] 运行相关单元测试确保功能正常

🤖 Generated with [Claude Code](https://claude.ai/code)