### PR TITLE
fix: Select 组件修复 onCreate 功能中创建选项的显示问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.0-beta.39",
+  "version": "3.8.0-beta.40",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/select/select.tsx
+++ b/packages/base/src/select/select.tsx
@@ -229,9 +229,11 @@ function Select<DataItem, Value>(props0: SelectPropsBase<DataItem, Value>) {
     }
   };
 
+
+  const finalData = createdData ? [createdData, ...(data || [])] : data;
   const { datum, value } = useSelect<DataItem, Value>({
     value: valueProp,
-    data,
+    data: finalData,
     separator,
     treeData,
     childrenKey,
@@ -364,12 +366,12 @@ function Select<DataItem, Value>(props0: SelectPropsBase<DataItem, Value>) {
         return;
       }
     }
-    
+
     // 当开启 preventEnterSelect 且存在 onCreate 功能时，阻止选中已有选项
     if (preventEnterSelect && onCreate && !createdData) {
       return;
     }
-    
+
     const currentDataItem = filterData?.[hoverIndex];
     if (currentDataItem && !currentDataItem[groupKey as keyof typeof currentDataItem]) {
       handleChange(currentDataItem);

--- a/packages/shineout/src/select/__example__/t-05-renderUnmatch-onCreate.tsx
+++ b/packages/shineout/src/select/__example__/t-05-renderUnmatch-onCreate.tsx
@@ -1,0 +1,54 @@
+/**
+ * cn - renderUnmatch + onCreate
+ *    -- 使用 `renderUnmatched` 和 `onCreate` 属性来处理未匹配的输入
+ * en - renderUnmatch + onCreate
+ *    -- use `renderUnmatched` and `onCreate` to handle unmatched input
+ */
+import React from 'react';
+import { Select } from 'shineout';
+
+type DataItem = {
+  id: string;
+  name: string;
+};
+
+const data: DataItem[] = [];
+for (let i = 0; i < 15; i++) {
+  data.push({
+    id: `id-${i}`,
+    name: `标签 ${i}`,
+  });
+}
+
+export default () => {
+  const data = ['red', 'orange', 'yellow', 'green', 'cyan', 'blue', 'violet', 'pink'];
+
+  const dataObj = [{ postCode: "1111", postCodeId: 1 }];
+  // const dataObj = [];
+  return (
+    <div>
+      <Select
+        style={{ marginLeft: 24 }}
+        width={300}
+        data={dataObj}
+        onCreate={(t) => ({
+          postCodeId: dataObj.find(d => d.postCode === t)?.postCodeId ?? -1,
+          postCode: t,
+        })}
+        filterDelay={0}
+        trim
+        format="postCode"
+        renderItem="postCode"
+        keygen="postCodeId"
+        height={250}
+        autoAdapt
+        onFilter={(text) => (d) => {
+          return d?.postCode?.indexOf(text) >= 0;
+        }}
+        renderUnmatched={() => undefined}
+        placeholder='Select Color'
+        clearable
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- 新增 finalData 变量，确保创建选项在回车时能被正常展示
- 修复即使设置了 renderUnmatch 也能正常展示创建选项的问题
- 添加相关示例文件

## Test plan
- [x] 测试 Select 组件的 onCreate 功能
- [x] 验证创建选项在回车时的正常展示
- [x] 确认设置 renderUnmatch 时创建选项仍能正常工作

## Playground ID
398db8f2-fb53-40ac-b3c3-d8ac57819386

🤖 Generated with [Claude Code](https://claude.ai/code)