### PR TITLE
feat: 优化 Sticky 组件在 document.body 样式异常时的表现

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.0-beta.42",
+  "version": "3.8.0-beta.43",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/sticky/sticky.tsx
+++ b/packages/base/src/sticky/sticky.tsx
@@ -240,7 +240,7 @@ const Sticky = (props: StickyProps) => {
     if (top !== undefined && Math.ceil(selfRect.top) <= top) {
       setFixedStyle(true, 'top', selfRect.left);
       return;
-    } else if (bottom !== undefined && Math.ceil(selfRect.bottom) + bottom > scrollRect.bottom) {
+    } else if (bottom !== undefined && (Math.ceil(selfRect.bottom) + bottom > Math.max(window.innerHeight, scrollRect.bottom) || selfRect.bottom + bottom >= window.innerHeight)) {
       setFixedStyle(true, 'bottom', selfRect.left);
       return;
     } else {

--- a/packages/shineout/src/table/__doc__/changelog.cn.md
+++ b/packages/shineout/src/table/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.8.0-beta.43
+2025-08-21
+
+### 🐞 BugFix
+- 修复 `Table` 设置了 `showBottomScrollbar` 属性后可能出现双滚动条的问题 ([#1320](https://github.com/sheinsight/shineout-next/pull/1320))
+
+
 ## 3.8.0-beta.5
 2025-06-18
 


### PR DESCRIPTION
## 摘要
- 修复当 document.body 设置为 height:100% 但未设置 overflow 时的异常表现
- 更新相关版本和变更日志文档

## 测试计划
- [x] 验证在 document.body 设置 height:100% 且未设置 overflow 时 Sticky 组件表现正常
- [x] 确认现有功能不受影响
- [x] 检查相关单元测试通过

🤖 Generated with [Claude Code](https://claude.ai/code)