### PR TITLE
fix: 修复 `Input.Number` 的 `coin` 属性不生效，与 v1 v2 表现不一致的问题

### DIFF
--- a/packages/base/src/input/input-number.tsx
+++ b/packages/base/src/input/input-number.tsx
@@ -19,10 +19,11 @@ const InputNumber = (props: InputNumberProps) => {
     max,
     step,
     allowNull,
+    coin,
     ...restProps
   } = commonProps;
   const inputStyle = jssStyle?.input?.();
-
+  
   const numberFormatParams = {
     onBlur: restProps.onBlur,
     onFocus: restProps.onFocus,
@@ -33,6 +34,7 @@ const InputNumber = (props: InputNumberProps) => {
     max: max,
     step: step,
     allowNull: allowNull,
+    coin: coin,
   };
 
   const { onMinus, onPlus, ...numberFormatProps } = useInputNumber({

--- a/packages/hooks/src/components/use-input/use-input-number.ts
+++ b/packages/hooks/src/components/use-input/use-input-number.ts
@@ -19,6 +19,7 @@ const useNumberFormat = (props: InputNumberProps) => {
     step = 1,
     cancelBlurChange,
     disabled,
+    coin,
   } = props;
 
   const getStringValue = (value: string | number | null | undefined) => {
@@ -149,6 +150,7 @@ const useNumberFormat = (props: InputNumberProps) => {
       numType,
       integerLimit,
       digits,
+      coin,
       onChange: onNumberChange,
       onBlur: onNumberBlur,
       onFocus: props.onFocus,

--- a/packages/hooks/src/components/use-input/use-input-number.type.ts
+++ b/packages/hooks/src/components/use-input/use-input-number.type.ts
@@ -2,7 +2,7 @@ import { InputFormatProps } from './use-input-format.type';
 
 export type NumberValue = string | number | undefined | null;
 export interface InputNumberProps
-  extends Omit<InputFormatProps, 'value' | 'onChange' | 'autoFix' | 'trim' | 'coin' | 'type'> {
+  extends Omit<InputFormatProps, 'value' | 'onChange' | 'autoFix' | 'trim' | 'type'> {
   value: NumberValue;
   onChange: (value: NumberValue) => void | undefined;
   /**


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

719fc9a2-05f6-43c0-96ae-e0bebdc6c9e8

### Other information