### PR TITLE
fix: 修复 `Message` 在 bottom-left 和 bottom-right 位置手动关闭弹窗时可能出现动画闪一下的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.7.11-beta.1",
+  "version": "3.7.11-beta.2",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/message/message.ts
+++ b/packages/shineout-style/src/message/message.ts
@@ -75,10 +75,10 @@ const messageStyle: JsStyles<MessageClassType> = {
   },
   itemDismissed: {
     ' [data-soui-position="bottom-left"] &': {
-      animation: `$left-out ${animationDuration} ease-in-out`,
+      animation: `$left-out ${animationDuration} ease-in-out forwards`,
     },
     ' [data-soui-position="bottom-right"] &': {
-      animation: `$right-out ${animationDuration} ease-in-out`,
+      animation: `$right-out ${animationDuration} ease-in-out forwards`,
     },
   },
   itemShow: {

--- a/packages/shineout/src/message/__doc__/changelog.cn.md
+++ b/packages/shineout/src/message/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.7.11-beta.2
+2025-08-25
+### 🐞 BugFix
+
+- 修复 `Message` 在 bottom-left 和 bottom-right 位置手动关闭弹窗时可能出现动画闪一下的问题 ([#1325](https://github.com/sheinsight/shineout-next/pull/1325))
+
+
 ## 3.4.3
 2024-10-14
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

### Other information