### PR TITLE
fix: DatePicker range模式name为数组时强制设置undefined的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.0-beta.46",
+  "version": "3.8.0-beta.47",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-form/use-form-control/use-form-control.ts
+++ b/packages/hooks/src/components/use-form/use-form-control/use-form-control.ts
@@ -86,7 +86,9 @@ export default function useFormControl<T>(props: BaseFormControlProps<T>) {
   const update = usePersistFn(
     (formValue: ObjectType = {}, errors: ObjectType, severErrors: ObjectType) => {
       if (!name) return;
-      if (isArray(name)) {
+      // 加入defaultValue的判断，让其只对 https://github.com/sheinsight/shineout-next/pull/742 的场景生效
+      // 如果不加入defaultValue的判断，会导致 8ea43144-36a5-403a-9147-59d54087a110 的问题
+      if (isArray(name) && defaultValue !== undefined) {
         const value = getValue(name, formValue) as T[];
         const error = getError(name, errors, severErrors);
         if (error !== errorState) {

--- a/packages/shineout/src/date-picker/__doc__/changelog.cn.md
+++ b/packages/shineout/src/date-picker/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.8.0-beta.47
+2025-08-27
+
+### 🐞 BugFix
+- 修复 `DatePicker` 的 `range` 设置了name为数组的场景下强制在 `onPickerChange` 中设置name对应值为undefined后，结果框中无法选中值的问题 ([#1326](https://github.com/sheinsight/shineout-next/pull/1326))
+
 ## 3.8.0-beta.30
 2025-08-14
 


### PR DESCRIPTION
## Summary
修复 DatePicker 的 range 设置了name为数组的场景下强制在 onPickerChange 中设置name对应值为undefined后，结果框中无法选中值的问题

## Changes
- 在 `use-form-control.ts` 中加入 `defaultValue` 的判断，让修复只对特定场景生效
- 避免影响其他正常使用场景
- 版本号升级到 3.8.0-beta.47

## Test plan
- [x] 测试 DatePicker range 模式下设置 name 为数组的场景
- [x] 测试在 onPickerChange 中强制设置 undefined 后能否正常选中值
- [x] 回归测试其他 Form 控件的正常功能

## Playground ID
acd930fc-b39d-4c89-81ed-495621a67bb7


🤖 Generated with [Claude Code](https://claude.ai/code)