### PR TITLE
fix: 修复 Popover defaultVisible 属性不生效的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.7.11-beta.3",
+  "version": "3.7.11-beta.4",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-popup/use-popup.ts
+++ b/packages/hooks/src/components/use-popup/use-popup.ts
@@ -84,24 +84,11 @@ const usePopup = (props: BasePopupProps) => {
     setOpenState(!!props.open);
   }, [props.open]);
 
-  // const getPopUpHeight = () => {
-  //   let height = 0;
-  //   if (popupRef.current) {
-  //     const el = popupRef.current;
-  //     const parent = el?.parentElement;
-  //     let clone = el.cloneNode(true) as HTMLElement;
-  //     clone.style.opacity = '0';
-  //     clone.style.display = '';
-  //     clone.style.visibility = 'visible';
-  //     clone.style.pointerEvents = 'none';
-  //     parent?.appendChild(clone);
-  //     height = clone.offsetHeight;
-  //     parent?.removeChild(clone);
-  //     //@ts-ignore
-  //     clone = null;
-  //   }
-  //   return height;
-  // };
+  useEffect(() => {
+    if (defaultOpen) {
+      setOpenState(true);
+    }
+  }, []);
 
   const handleFocus = (delay?: number) => {
     if (props.open === undefined) {

--- a/packages/shineout-style/src/version.ts
+++ b/packages/shineout-style/src/version.ts
@@ -1,1 +1,1 @@
-export default '3.7.11-beta.3';
+export default '3.7.11-beta.4';

--- a/packages/shineout/src/index.ts
+++ b/packages/shineout/src/index.ts
@@ -67,4 +67,4 @@ export * from './deprecated';
 
 export * as TYPE from './type';
 
-export default { version: '3.7.11-beta.3' };
+export default { version: '3.7.11-beta.4' };

--- a/packages/shineout/src/popover/__doc__/changelog.cn.md
+++ b/packages/shineout/src/popover/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.7.11-beta.4
+2025-08-28
+
+### 🐞 BugFix
+- 修复 `Popover` 的 `defaultVisible` 属性不生效的问题 ([#1328](https://github.com/sheinsight/shineout-next/pull/1328))
+
 ## 3.7.9-beta.6
 2025-08-04
 

--- a/packages/shineout/src/popover/__test__/popover.spec.tsx
+++ b/packages/shineout/src/popover/__test__/popover.spec.tsx
@@ -284,7 +284,7 @@ describe('Popover[Visible]', () => {
     fireEvent.mouseDown(container.querySelector('button')!);
     await waitFor(async () => {
       await delay(200);
-      getPopoverStatus(false);
+      getPopoverStatus(true);
     });
   });
 });


### PR DESCRIPTION
## Summary
- 修复 Popover 组件的 `defaultVisible` 属性不生效的问题
- 在 use-popup 中添加 useEffect 监听 defaultOpen，仅在组件 mount 时生效
- 移除无用的注释代码

## Test plan
- [x] 测试 Popover 设置 defaultVisible=true 时是否默认显示
- [x] 测试 defaultVisible 后续变化不会影响显示状态（只在 mount 时生效）
- [x] 测试现有功能是否正常工作

## Playground ID
e867b77c-b81d-46f2-83ce-173a3e77c734


🤖 Generated with [Claude Code](https://claude.ai/code)