### PR TITLE
fix: 修复 Drawer 设置 destroy 属性后 html overflow 样式无法正常销毁的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.0",
+  "version": "3.8.1-beta.1",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/modal/modal-content.tsx
+++ b/packages/base/src/modal/modal-content.tsx
@@ -225,8 +225,7 @@ const Modal = (props: ModalContentProps) => {
       if (visible) {
         setDocumentOverflow();
       } else {
-        if (config.instanceIds.length && config.instanceIds[config.instanceIds.length - 1] === context.instanceId) return;
-        resetDocumentOverflow();
+        if (config.instanceIds.length === 0) resetDocumentOverflow();
       }
     }
   }, [visible, config.instanceIds]);
@@ -241,9 +240,7 @@ const Modal = (props: ModalContentProps) => {
     // unmount
     return () => {
       removeModalInstance(context.instanceId)
-      if (context.isMask) {
-        resetDocumentOverflow();
-      };
+      resetDocumentOverflow();
       props.shouldDestroy?.(true);
       if (context.isMask) {
         context.isMask = false;

--- a/packages/base/src/modal/modal-content.tsx
+++ b/packages/base/src/modal/modal-content.tsx
@@ -33,6 +33,10 @@ const removeModalInstance = (instanceId: string) => {
   state.mutate.instanceIds = state.mutate.instanceIds.filter(id => id !== instanceId)
 }
 
+const getInstanceIds = () => {
+  return state.mutate.instanceIds;
+}
+
 
 let mousePosition: { x: number; y: number } | null = null;
 
@@ -240,7 +244,10 @@ const Modal = (props: ModalContentProps) => {
     // unmount
     return () => {
       removeModalInstance(context.instanceId)
-      resetDocumentOverflow();
+      const instanceIds = getInstanceIds();
+      if (instanceIds.length === 0) {
+        resetDocumentOverflow();
+      }
       props.shouldDestroy?.(true);
       if (context.isMask) {
         context.isMask = false;

--- a/packages/shineout/src/drawer/__doc__/changelog.cn.md
+++ b/packages/shineout/src/drawer/__doc__/changelog.cn.md
@@ -1,3 +1,11 @@
+## 3.8.1-beta.1
+2025-09-01
+
+### 🐞 BugFix
+
+- 修复 `Drawer` 设置了 `destroy` 属性后，html元素的overflow样式无法正常销毁的问题 (Regression: since v3.8.0) ([#1336](https://github.com/sheinsight/shineout-next/pull/1336))
+
+
 ## 3.0.5
 2024-04-24
 


### PR DESCRIPTION
## Summary
修复 Drawer 组件设置了 `destroy` 属性后，html 元素的 overflow 样式无法正常销毁的问题

此问题由 #1321 引入，本 PR 修复该回归问题。

## Changes
- 修复多个 Modal/Drawer 实例时 overflow 样式管理逻辑
- 确保只有在所有实例都关闭时才重置 overflow 样式  
- 简化组件卸载时的 overflow 重置逻辑

## Root Cause
在 #1321 中修改了 Modal overflow 样式的管理逻辑，但没有正确处理组件销毁时的场景，导致页面滚动样式无法正常恢复。

## Test plan
- [x] 测试单个 Drawer 的 destroy 功能
- [x] 测试多个 Drawer 实例的 overflow 样式管理
- [x] 确认页面滚动行为正常
- [x] 验证 #1321 的原始修复仍然有效

## Additional Info
- **Regression**: since v3.8.0 (introduced by #1321)
- **Related**: #1321
- **Version**: 3.8.1-beta.1

🤖 Generated with [Claude Code](https://claude.ai/code)