### PR TITLE
fix: 修复 Select 开启 renderOptionList 后数据为空时不渲染的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.1-beta.1",
+  "version": "3.8.1-beta.2",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/cascader/cascader.tsx
+++ b/packages/base/src/cascader/cascader.tsx
@@ -703,6 +703,7 @@ const Cascader = <DataItem, Value extends KeygenResult[]>(
       return renderLoading();
     }
     if (isDataEmpty) {
+      // todo: 空数据时 是否 支持一下也能走到renderOptionList
       return renderEmpty();
     }
     if (!filterText || (filterText && mode !== undefined) || (data && data.length === 0)) {

--- a/packages/base/src/select/select.tsx
+++ b/packages/base/src/select/select.tsx
@@ -714,6 +714,7 @@ function Select<DataItem, Value>(props0: SelectPropsBase<DataItem, Value>) {
   };
 
   const renderEmpty = () => {
+    if (props.emptyText === false) return null;
     return (
       <div className={styles?.option}>
         <div className={styles?.optionInner}>
@@ -727,12 +728,13 @@ function Select<DataItem, Value>(props0: SelectPropsBase<DataItem, Value>) {
     if (loading) return renderLoading();
 
     const isEmpty = !filterData?.length;
-    if (isEmpty && props.emptyText !== false) return renderEmpty();
 
     const options = 'treeData' in props ? renderTreeList() : renderList();
     if (renderOptionList) {
-      return renderOptionList(options, { loading: loading });
+      return renderOptionList(isEmpty ? renderEmpty() : options, { loading: loading });
     }
+
+    if (isEmpty) return renderEmpty();
 
     return options;
   };

--- a/packages/shineout/src/select/__doc__/changelog.cn.md
+++ b/packages/shineout/src/select/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.8.1-beta.2
+2025-09-02
+
+### 🐞 BugFix
+- 修复 `Select` 开启 `renderOptionList` 后，当数据为空时，`renderOptionList` 不渲染的问题 ([#1337](https://github.com/sheinsight/shineout-next/pull/1337))
+
+
 ## 3.8.0-beta.45
 2025-08-22
 


### PR DESCRIPTION
## Summary
- 修复 Select 组件在开启 renderOptionList 且数据为空时，renderOptionList 不被调用的问题
- 调整空数据渲染逻辑，确保 renderOptionList 能正确处理空状态
- 添加 emptyText 为 false 时返回 null 的逻辑，对齐 v1/v2 版本表现

## Changes
- 修改 `packages/base/src/select/select.tsx` 中的空数据渲染逻辑
- 确保 renderOptionList 在数据为空时也能被正确调用
- 更新版本号至 3.8.1-beta.2
- 更新 changelog 记录修复内容

## Test plan
- [ ] 测试 Select 组件在启用 renderOptionList 且数据为空时的渲染行为
- [ ] 验证 emptyText 为 false 时的显示效果
- [ ] 确认修复后 v1/v2 版本行为一致

## Playground ID
7de5f022-9dea-4abe-8a5d-2888cfc37ef2

🤖 Generated with [Claude Code](https://claude.ai/code)