### PR TITLE
fix: 修复 GitHub Pages 资源路径问题

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: build
         run: pnpm run build:doc
+        env:
+          LEGO_FRONTEND_PUBLIC_PATH: ./
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
- 在 gh-pages workflow 中添加 LEGO_FRONTEND_PUBLIC_PATH 环境变量
- 设置为相对路径 './' 以修复 GitHub Pages 中 JS 资源加载失败的问题
- 解决访问 https://sheinsight.github.io/shineout-next/ 时 app.js 404 的问题
