### PR TITLE
fix: 修复 Table 右对齐列筛选图标位置偏移问题

### DIFF
--- a/packages/shineout-style/src/table/table.ts
+++ b/packages/shineout-style/src/table/table.ts
@@ -379,6 +379,10 @@ const tableStyle: JsStyles<TableClassType> = {
   hasFilter: {
     display: 'inline-flex',
     alignItems: 'center',
+
+    '$cellAlignRight &': {
+      marginInlineEnd: -5,
+    },
   },
 
   filterIconContainer: {


### PR DESCRIPTION
## Summary
- 修复 Table 右对齐列筛选图标位置偏移问题
- 调整右对齐单元格中筛选图标的边距，使其与列标题文本对齐

## Test plan
- [x] 验证右对齐列的筛选图标位置是否正确对齐
- [x] 确认其他对齐方式的列筛选图标没有受到影响
- [x] 检查不同浏览器下的显示效果

🤖 Generated with [Claude Code](https://claude.ai/code)