### PR TITLE
fix: 修复 Cascader 开启 renderOptionList 时数据为空时不渲染的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.1-beta.3",
+  "version": "3.8.1-beta.4",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/cascader/cascader.tsx
+++ b/packages/base/src/cascader/cascader.tsx
@@ -637,10 +637,10 @@ const Cascader = <DataItem, Value extends KeygenResult[]>(
   };
 
   const renderEmpty = () => {
-    if (emptyText) {
-      return <div className={styles?.empty}>{emptyText}</div>;
+    if (renderOptionList) {
+      return renderOptionList(null as any, { loading: !!loading });
     }
-    return <div className={styles?.empty}>{getLocale(locale, 'noData')}</div>;
+    return <div className={styles?.empty}>{emptyText || getLocale(locale, 'noData')}</div>;
   };
 
   const renderNormalList = () => {
@@ -703,7 +703,6 @@ const Cascader = <DataItem, Value extends KeygenResult[]>(
       return renderLoading();
     }
     if (isDataEmpty) {
-      // todo: 空数据时 是否 支持一下也能走到renderOptionList
       return renderEmpty();
     }
     if (!filterText || (filterText && mode !== undefined) || (data && data.length === 0)) {

--- a/packages/shineout/src/cascader/__doc__/changelog.cn.md
+++ b/packages/shineout/src/cascader/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.8.1-beta.4
+2025-09-03
+
+### 🐞 BugFix
+- 修复 `Cascader` 开启 `renderOptionList` 时，当数据为空时，`renderOptionList` 不渲染的问题 ([#1342](https://github.com/sheinsight/shineout-next/pull/1342))
+
+
 ## 3.8.0-beta.45
 2025-08-22
 


### PR DESCRIPTION
## Summary
- 修复 Cascader 开启 renderOptionList 属性时，当数据为空时 renderOptionList 不渲染的问题
- 确保空数据状态下 renderOptionList 能够正常调用并渲染

## Test plan
- [x] 验证开启 renderOptionList 时空数据状态下能够正确渲染
- [x] 确认未开启 renderOptionList 时空数据显示不受影响
- [x] 检查不同场景下的渲染逻辑

🤖 Generated with [Claude Code](https://claude.ai/code)