### PR TITLE
fix: 优化 Steps 设置了 labelPlacement 属性后标题布局超出情况下的展示效果

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.1-beta.5",
+  "version": "3.8.1-beta.6",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/steps/steps.ts
+++ b/packages/shineout-style/src/steps/steps.ts
@@ -798,7 +798,7 @@ const stepsStyle: JsStyles<StepsClassType> = {
               },
               '&::after': {
                 position: 'static',
-                width:  '100%',
+                width: '100%',
               }
             }
           }

--- a/packages/shineout-style/src/steps/steps.ts
+++ b/packages/shineout-style/src/steps/steps.ts
@@ -784,6 +784,26 @@ const stepsStyle: JsStyles<StepsClassType> = {
           width: `calc(100% - ${Token.stepsIconWidth} + 4px)`,
         },
       },
+      '& $horizontalLabel': {
+        '& > $default': {
+          display: 'flex',
+          '& $content': {
+            flex: 1,
+            minWidth: 0,
+            '& $title': {
+              display: 'flex',
+              alignItems: 'center',
+              '& > *': {
+                maxWidth: '100%',
+              },
+              '&::after': {
+                position: 'static',
+                width:  '100%',
+              }
+            }
+          }
+        }
+      }
     },
     '& $verticalLabel': {
       '& $title': {

--- a/packages/shineout/src/steps/__doc__/changelog.cn.md
+++ b/packages/shineout/src/steps/__doc__/changelog.cn.md
@@ -1,6 +1,12 @@
+## 3.8.1-beta.6
+2025-09-04
+### 💅 Style
+
+- 优化 `Steps` 设置了 `labelPlacement` 属性后标题布局超出情况下的展示效果 ([#1346](https://github.com/sheinsight/shineout-next/pull/1346))
+
 ## 3.8.1-beta.3
 2025-09-03
-### 🌈 Style
+### 💅 Style
 
 - 优化 `Steps` 垂直方向下 `description`的样式，支持换行 ([#1341](https://github.com/sheinsight/shineout-next/pull/1341))
 

--- a/packages/shineout/src/table/__doc__/changelog.cn.md
+++ b/packages/shineout/src/table/__doc__/changelog.cn.md
@@ -2,7 +2,7 @@
 2025-09-04
 
 ### 🐞 BugFix
-- 修复 `Table` 在可展开内嵌套使用时，斑马纹样式不正确的问题 ([#1345](https://github.com/sheinsight/shineout-next/pull/1345))
+- 修复 `Table` 在可展开行内嵌套使用时，斑马纹样式不正确的问题 ([#1345](https://github.com/sheinsight/shineout-next/pull/1345))
 
 
 ## 3.8.0-beta.43


### PR DESCRIPTION
## Summary
- 修复了 Steps 组件在设置 labelPlacement 属性后，标题内容超出容器时的布局问题
- 通过调整 flex 布局和 maxWidth 属性，确保标题内容能够正确换行和显示
- 版本升级至 3.8.1-beta.6

## Test plan
- [x] 测试 Steps 组件设置 labelPlacement 属性后的标题显示效果
- [x] 验证长标题内容的换行和布局是否正确
- [x] 确认样式修改不影响其他 Steps 组件功能

🤖 Generated with [Claude Code](https://claude.ai/code)