### PR TITLE
fix: 修复 Form 设置了 name 属性用法下的TreeSelect组件的keygen函数报错问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.1-beta.6",
+  "version": "3.8.1-beta.7",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/form/form-field.tsx
+++ b/packages/base/src/form/form-field.tsx
@@ -14,7 +14,7 @@ import { FormFieldContext } from './form-field-context';
 const FormField = <T extends any = any>(props: FormFieldProps<T>) => {
   const { children } = props;
 
-  const formConfig = useFormConfig()
+  const formConfig = useFormConfig();
 
   const getValidateProps = usePersistFn(() => {
     if (props.getValidateProps) return props.getValidateProps();
@@ -96,23 +96,29 @@ const FormField = <T extends any = any>(props: FormFieldProps<T>) => {
   const { label } = useContext(FormItemContext);
   const finalFieldId = formFieldId || fieldId || fieldsetPathId;
 
-  // 只有当 formConfig.formName 存在时才运行 schema 逻辑
-  if (formConfig.formName && formSchema && finalFieldId) {
-    const schemaFields = finalFieldId.split(separator) || [];
-    const schemaMeta = formSchema.buildSchemaFromComponent({
-      componentElement: finalChildren,
-      rules: props.rules,
-      label,
-      finalFieldId,
-      separator,
-    });
-
-    schemaFields.forEach((field: string) => {
-      formSchema.updateSchema({
-        path: util.getOriginField(field, formConfig.formName),
-        meta: schemaMeta,
+  try {
+    // 只有当 formConfig.formName 存在时才运行 schema 逻辑
+    if (formConfig.formName && formSchema && finalFieldId) {
+      const schemaFields = finalFieldId.split(separator) || [];
+      const schemaMeta = formSchema.buildSchemaFromComponent({
+        componentElement: finalChildren,
+        rules: props.rules,
+        label,
+        finalFieldId,
+        separator,
       });
-    });
+
+      schemaFields.forEach((field: string) => {
+        formSchema.updateSchema({
+          path: util.getOriginField(field, formConfig.formName),
+          meta: schemaMeta,
+        });
+      });
+    }
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      util.devUseWarning.warn(`formSchema buildSchemaFromComponent error: >>${error}`);
+    }
   }
 
   return (

--- a/packages/hooks/src/components/use-form/use-form-schema/form-schema-builder.ts
+++ b/packages/hooks/src/components/use-form/use-form-schema/form-schema-builder.ts
@@ -90,7 +90,7 @@ export class SchemaBuilder {
           if (typeof componentElement.props.keygen !== 'boolean') {
             if (typeof format === 'string') {
               itemType = typeof data?.[0] === 'object' ? typeof data?.[0]?.[format] : typeof data?.[0];
-            } else if (typeof format === 'function') {
+            } else if (typeof format === 'function' && data?.[0]) {
               itemType = typeof format(data?.[0]);
             } else {
               itemType = typeof data?.[0];
@@ -153,7 +153,7 @@ export class SchemaBuilder {
           if (typeof componentElement.props.keygen !== 'boolean') {
             if (typeof format === 'string') {
               itemType = typeof data?.[0] === 'object' ? typeof data?.[0]?.[format] : typeof data?.[0];
-            } else if (typeof format === 'function') {
+            } else if (typeof format === 'function' && data?.[0]) {
               itemType = typeof format(data?.[0]);
             } else {
               itemType = typeof data?.[0];
@@ -182,7 +182,7 @@ export class SchemaBuilder {
           if (typeof componentElement.props.keygen !== 'boolean') {
             if (typeof format === 'string') {
               itemType = typeof data?.[0] === 'object' ? typeof data?.[0]?.[format] : typeof data?.[0];
-            } else if (typeof format === 'function') {
+            } else if (typeof format === 'function' && data?.[0]) {
               itemType = typeof format(data?.[0]);
             } else {
               itemType = typeof data?.[0];
@@ -191,7 +191,9 @@ export class SchemaBuilder {
             itemType = typeof data?.[0];
           }
 
-          fieldSchemaInfo.type = itemType;
+          if (itemType !== 'undefined') {
+            fieldSchemaInfo.type = itemType;
+          }
 
           // ShineoutRadioGroup 有 data 时（单选的）
           if (itemType === 'object') {

--- a/packages/shineout/src/form/__doc__/changelog.cn.md
+++ b/packages/shineout/src/form/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.8.1-beta.7
+2025-09-05
+
+### 🐞 BugFix
+
+- 修复 `Form` 设置了 `name` 属性用法下的TreeSelect组件的keygen函数报错问题 (Regression: since v3.8.0) ([#1347](https://github.com/sheinsight/shineout-next/pull/1347))
+
 ## 3.8.0-beta.27
 2025-08-12
 


### PR DESCRIPTION
## Summary
- 修复 Form 设置了 name 属性用法下的TreeSelect组件的keygen函数报错问题
- 这是一个回归问题，从 v3.8.0 开始出现

## Test plan
- [x] 测试 Form 中 TreeSelect 组件的 keygen 函数正常工作
- [x] 验证修复不会影响其他表单组件功能
- [x] 回归测试确保问题已解决

## Playground
Playground ID: aea4d386-0d9d-4870-adfb-bde0c79873ff

🤖 Generated with [Claude Code](https://claude.ai/code)