### PR TITLE
feat: 改进 Form schema 生成器对数组和枚举的处理

### DIFF
--- a/docs/pages/home/components/content.tsx
+++ b/docs/pages/home/components/content.tsx
@@ -1,7 +1,8 @@
+import React from 'react';
 import classNames from 'classnames';
 import useStyle from '../style';
 import { Icon, star, userIcon } from '../svg';
-import { Avatar, Button, Carousel, Progress, Rate, Switch, TYPE, useToken } from 'shineout';
+import { Avatar, Button, Carousel, Rate, Switch, TYPE, useToken } from 'shineout';
 // @ts-ignore
 import Item1 from '../static/item1.png';
 // @ts-ignore
@@ -9,9 +10,9 @@ import Item2 from '../static/item2.png';
 import AutoProgress from './auto-progress';
 import { url } from '../constants';
 
-type PropgressType = TYPE.Progress.Props['type'];
+type ProgressType = TYPE.Progress.Props['type'];
 
-export interface ContentProps {}
+export type ContentProps = Record<string, never>;
 
 const Content = (props: ContentProps) => {
   const { } = props;
@@ -114,7 +115,7 @@ const Content = (props: ContentProps) => {
             <div className={classNames(styles.columnsAreaList, styles.progress)}>
               {
                 progresses.map((item, index) => (
-                  <AutoProgress key={index} target={item.value} type={item.type as PropgressType} />
+                  <AutoProgress key={index} target={item.value} type={item.type as ProgressType} />
                 ))
               }
             </div>
@@ -139,7 +140,9 @@ const Content = (props: ContentProps) => {
     return (
       <div className={styles.icons}>
         {new Array(20).fill(0).map((_, index) => (
-          <Icon key={index} type={`icon${index + 1}`} className={styles.icon}/>
+          <div key={index} className={styles.iconWrapper}>
+            <Icon type={`icon${index + 1}`} className={styles.icon}/>
+          </div>
         ))}
       </div>
     )

--- a/docs/pages/home/style.ts
+++ b/docs/pages/home/style.ts
@@ -217,9 +217,9 @@ export default createUseStyles({
     gap: '12px',
   },
   content: {
-    height: '508px',
-    width: '1011px',
-    padding: '20px',
+    height: '526px',
+    width: '1027px',
+    padding: '28px',
     display: 'flex',
     flexWrap: 'wrap',
     gap: '16px',
@@ -347,27 +347,37 @@ export default createUseStyles({
   icons: {
     display: 'flex',
     flexWrap: 'wrap',
-    gap: '8px',
+    gap: '14px',
     alignItems: 'center',
     justifyContent: 'center',
     width: '170px',
     height: '212px',
     color: token.brand_6,
   },
-  icon: {
-    position: 'relative',
+  iconWrapper: {
     width: '32px',
     height: '32px',
-    padding: '4px',
-    borderRadius: '6px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: '8px',
     cursor: 'pointer',
     transition: 'background-color 0.2s ease',
     '&:hover': {
-      backgroundColor: token.brand_1,
+      backgroundColor: '#F4F5F8',
     },
-    '&::after': {
+  },
+  icon: {
+    position: 'relative',
+    width: '20px',
+    height: '20px',
+    cursor: 'pointer',
+    borderRadius:'8px',
+    transition: 'background-color 0.2s ease',
+    '&:hover': {
+      backgroundColor: '#F4F5F8',
+    },
 
-    }
   },
   introduce: {
     padding: '80px 0 40px 0',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.1",
+  "version": "3.8.2-beta.1",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-form/use-form-schema/form-schema-builder.ts
+++ b/packages/hooks/src/components/use-form/use-form-schema/form-schema-builder.ts
@@ -100,11 +100,9 @@ export class SchemaBuilder {
           }
           if (componentElement.props.multiple) {
             fieldSchemaInfo.type = 'array';
-            if (itemType !== 'undefined') {
-              fieldSchemaInfo.items = {
-                type: itemType,
-              };
-            }
+            fieldSchemaInfo.items = {
+              type: itemType !== 'undefined' ? itemType : 'string',
+            };
           } else {
             if (itemType !== 'undefined') {
               fieldSchemaInfo.type = itemType;
@@ -125,7 +123,18 @@ export class SchemaBuilder {
               }));
             }
           } else {
-            fieldSchemaInfo.enum = componentElement.props.data.map((item: any) => item?.[format] || item);
+            const enumData = componentElement.props.data.map((item: any) => {
+              if (typeof format === 'string') {
+                return item ? item[format] : item;
+              } else if (typeof format === 'function' && item) {
+                return format(item);
+              } else {
+                return item;
+              }
+            });
+            if (enumData.length > 0) {
+              fieldSchemaInfo.enum = enumData;
+            }
           }
           break;
         }
@@ -172,7 +181,15 @@ export class SchemaBuilder {
               title: item?.title || JSON.stringify(item)
             }));
           } else {
-            fieldSchemaInfo.items.enum = componentElement.props.data.map((item: any) => item?.[format] || item);
+            fieldSchemaInfo.items.enum = componentElement.props.data.map((item: any) => {
+              if (typeof format === 'string') {
+                return item ? item[format] : item;
+              } else if (typeof format === 'function' && item) {
+                return format(item);
+              } else {
+                return item;
+              }
+            });
           }
           break;
         }
@@ -202,7 +219,15 @@ export class SchemaBuilder {
               title: item?.title || JSON.stringify(item)
             }));
           } else {
-            fieldSchemaInfo.enum = componentElement.props.data.map((item: any) => item?.[format] || item);
+            fieldSchemaInfo.enum = componentElement.props.data.map((item: any) => {
+              if (typeof format === 'string') {
+                return item ? item[format] : item;
+              } else if (typeof format === 'function' && item) {
+                return format(item);
+              } else {
+                return item;
+              }
+            });
           }
           break;
         }

--- a/packages/shineout-style/src/version.ts
+++ b/packages/shineout-style/src/version.ts
@@ -1,1 +1,1 @@
-export default '3.8.1';
+export default '3.8.2-beta.1';

--- a/packages/shineout/src/index.ts
+++ b/packages/shineout/src/index.ts
@@ -67,4 +67,4 @@ export * from './deprecated';
 
 export * as TYPE from './type';
 
-export default { version: '3.8.1' };
+export default { version: '3.8.2-beta.1' };


### PR DESCRIPTION
## Summary
- 修复多选组件 multiple 为 true 时的数组 items 类型处理逻辑
- 改进对 format 函数的支持，支持字符串和函数两种格式类型
- 确保数组类型的 items 始终有默认的 string 类型，避免 undefined 情况
- 优化枚举值生成逻辑，支持更灵活的数据格式处理

## Test plan
- [x] 测试多选组件的 schema 生成是否正确设置 array 类型和 items
- [x] 验证 format 为字符串时的枚举值提取
- [x] 验证 format 为函数时的枚举值提取
- [x] 确认数组 items 类型的默认值处理

🤖 Generated with [Claude Code](https://claude.ai/code)