### PR TITLE
feat: 改进 Form schema 生成器对数组和枚举的处理

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.1",
+  "version": "3.8.2-beta.1",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-form/use-form-schema/form-schema-builder.ts
+++ b/packages/hooks/src/components/use-form/use-form-schema/form-schema-builder.ts
@@ -31,6 +31,18 @@ export class SchemaBuilder {
     };
   }
 
+  private mapEnumData(data: any[], format: any): any[] {
+    return data.map((item: any) => {
+      if (typeof format === 'string') {
+        return item ? item[format] : item;
+      } else if (typeof format === 'function' && item) {
+        return format(item);
+      } else {
+        return item;
+      }
+    });
+  }
+
   updateSchema({ path, meta }: { path: string; meta: SchemaMeta }): void {
     const pathSegments = this.parsePath(path);
     if (!pathSegments) return
@@ -100,11 +112,9 @@ export class SchemaBuilder {
           }
           if (componentElement.props.multiple) {
             fieldSchemaInfo.type = 'array';
-            if (itemType !== 'undefined') {
-              fieldSchemaInfo.items = {
-                type: itemType,
-              };
-            }
+            fieldSchemaInfo.items = {
+              type: itemType !== 'undefined' ? itemType : 'string',
+            };
           } else {
             if (itemType !== 'undefined') {
               fieldSchemaInfo.type = itemType;
@@ -125,7 +135,10 @@ export class SchemaBuilder {
               }));
             }
           } else {
-            fieldSchemaInfo.enum = componentElement.props.data.map((item: any) => item?.[format] || item);
+            const enumData = this.mapEnumData(componentElement.props.data, format);
+            if (enumData.length > 0) {
+              fieldSchemaInfo.enum = enumData;
+            }
           }
           break;
         }
@@ -172,7 +185,7 @@ export class SchemaBuilder {
               title: item?.title || JSON.stringify(item)
             }));
           } else {
-            fieldSchemaInfo.items.enum = componentElement.props.data.map((item: any) => item?.[format] || item);
+            fieldSchemaInfo.items.enum = this.mapEnumData(componentElement.props.data, format);
           }
           break;
         }
@@ -202,7 +215,7 @@ export class SchemaBuilder {
               title: item?.title || JSON.stringify(item)
             }));
           } else {
-            fieldSchemaInfo.enum = componentElement.props.data.map((item: any) => item?.[format] || item);
+            fieldSchemaInfo.enum = this.mapEnumData(componentElement.props.data, format);
           }
           break;
         }

--- a/packages/shineout-style/src/version.ts
+++ b/packages/shineout-style/src/version.ts
@@ -1,1 +1,1 @@
-export default '3.8.1';
+export default '3.8.2-beta.1';

--- a/packages/shineout/src/index.ts
+++ b/packages/shineout/src/index.ts
@@ -67,4 +67,4 @@ export * from './deprecated';
 
 export * as TYPE from './type';
 
-export default { version: '3.8.1' };
+export default { version: '3.8.2-beta.1' };


### PR DESCRIPTION
## Summary
- 修复多选组件 multiple 为 true 时的数组 items 类型处理逻辑
- 改进对 format 函数的支持，支持字符串和函数两种格式类型
- 确保数组类型的 items 始终有默认的 string 类型，避免 undefined 情况
- 优化枚举值生成逻辑，支持更灵活的数据格式处理

## Test plan
- [x] 测试多选组件的 schema 生成是否正确设置 array 类型和 items
- [x] 验证 format 为字符串时的枚举值提取
- [x] 验证 format 为函数时的枚举值提取
- [x] 确认数组 items 类型的默认值处理

🤖 Generated with [Claude Code](https://claude.ai/code)