### PR TITLE
fix: 修复 Form.FieldSet 的 value 参数是基本类型时渲染不正确的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.2-beta.1",
+  "version": "3.8.2-beta.2",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/form/form-fieldset.tsx
+++ b/packages/base/src/form/form-fieldset.tsx
@@ -99,7 +99,7 @@ const FormFieldSet = <T,>(props: FormFieldSetProps<T>) => {
       >
         {children({
           list: valueArr,
-          value: valueProxy,
+          value: (v && typeof v === 'object') ? valueProxy : v,
           index: i,
           error: errorList,
         onChange: (val: T extends (infer U)[] ? U : never, options) => {

--- a/packages/shineout/src/form/__doc__/changelog.cn.md
+++ b/packages/shineout/src/form/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.8.2-beta.2
+
+### 🐞 BugFix
+
+- 修复 `Form.FieldSet` 的 children 函数用法的 value 参数是基本类型时渲染不正确的问题 (Regression: since v3.8.0) ([#1352](https://github.com/sheinsight/shineout-next/pull/1352))
+
 ## 3.8.1-beta.7
 2025-09-05
 


### PR DESCRIPTION
## Summary
修复 PR #1295 引入的回归问题：当 `Form.FieldSet` 的 `valueArr` 包含基本类型（如字符串、数字）时，无法正确渲染的问题。

### 问题描述
- PR #1295 引入了 Proxy 机制来支持 `{...value}` 展开操作
- 但是 Proxy 实现对基本类型处理不当，导致字符串、数字等基本类型值无法正确传递给子组件
- 具体表现：`executeTime: ['12:01']` 中的字符串 `'12:01'` 无法在 DatePicker 中正确显示

### 解决方案
- 对于基本类型值（字符串、数字、布尔值等）：直接传递原值，不使用 Proxy
- 对于对象类型：继续使用 Proxy 以支持 `{...value}` 展开操作
- 通过 `(v && typeof v === 'object') ? valueProxy : v` 来区分处理

### 测试用例
- ✅ 基本类型数组：`['12:01']`、`[123]`、`[true]` 等能正确显示
- ✅ 对象类型数组：`[{name: 'test'}]` 仍支持 `{...value}` 操作
- ✅ 向后兼容：不影响现有代码

### 相关文件
- `packages/base/src/form/form-fieldset.tsx` - 核心修复
- `packages/shineout/src/form/__doc__/changelog.cn.md` - 更新日志

### Regression Info
- **引入版本**: v3.8.0-beta.25 (PR #1295)
- **影响范围**: Form.FieldSet 组件在处理基本类型数组时的渲染
- **严重级别**: High (影响常见使用场景)

🤖 Generated with [Claude Code](https://claude.ai/code)