### PR TITLE
fix: 修复 Select result-more 组件的 RangeError: Invalid array length 错误

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.2-beta.2",
+  "version": "3.8.2-beta.3",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/select/result-more.tsx
+++ b/packages/base/src/select/result-more.tsx
@@ -97,7 +97,8 @@ const More = <DataItem, Value>(props: ResultMoreProps<DataItem, Value>) => {
       .fill(undefined)
       .map((_item, index) => data[index] as React.ReactElement);
 
-    after = new Array(data.length - showNum!)
+    const afterCount = Math.max(0, data.length - showNum!);
+    after = new Array(afterCount)
       .fill(undefined)
       .map((_item, index) => data[showNum! + index] as React.ReactElement);
     afterLength = after.length;

--- a/packages/shineout/src/cascader/__doc__/changelog.cn.md
+++ b/packages/shineout/src/cascader/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.8.2-beta.3
+2025-09-09
+
+### 🐞 BugFix
+- 修复 `Cascader` 开启 `compressed` 时，在 `onFilter` 中重新设置 `data` 后可能报RangeError的问题 ([#1353](https://github.com/sheinsight/shineout-next/pull/1353))
+
+
 ## 3.8.1-beta.4
 2025-09-03
 


### PR DESCRIPTION
## Summary
- 修复了当 showNum 大于 data.length 时，new Array(data.length - showNum!) 会创建负长度数组导致的 RangeError 错误
- 使用 Math.max(0, data.length - showNum!) 确保数组长度始终为非负数
- 版本升级至 3.8.2-beta.3 并更新相关 changelog

## Test plan
- [x] 验证修复后的代码不会再抛出 RangeError
- [x] 确认 Select 组件在 compressed 模式下的正常功能
- [x] 测试边界情况下的数组长度计算

🤖 Generated with [Claude Code](https://claude.ai/code)