### PR TITLE
fix: 修复 Select result-more 组件的 RangeError 错误

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.2-beta.4",
+  "version": "3.8.2-beta.5",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/select/result-more.tsx
+++ b/packages/base/src/select/result-more.tsx
@@ -87,20 +87,21 @@ const More = <DataItem, Value>(props: ResultMoreProps<DataItem, Value>) => {
 
   const styles = classes;
 
-  const shouldShowMore = showNum! < 0 || showNum! >= data.length;
+  const shouldShowMore = !showNum || showNum < 0 || showNum >= data.length;
   let before: React.ReactElement[] = [];
   let after: React.ReactElement[] = [];
   let afterLength = 0;
 
   if (!shouldShowMore) {
-    before = new Array(showNum!)
+    const validShowNum = showNum || 0;
+    before = new Array(validShowNum)
       .fill(undefined)
       .map((_item, index) => data[index] as React.ReactElement);
 
-    const afterCount = Math.max(0, data.length - showNum!);
+    const afterCount = Math.max(0, data.length - validShowNum);
     after = new Array(afterCount)
       .fill(undefined)
-      .map((_item, index) => data[showNum! + index] as React.ReactElement);
+      .map((_item, index) => data[validShowNum + index] as React.ReactElement);
     afterLength = after.length;
   }
 


### PR DESCRIPTION
## Summary
- 更新版本号到 3.8.2-beta.5
- 修复当 showNum 为 undefined/null/NaN 时导致的 RangeError: Invalid array length 错误
- 添加 showNum 的空值检查和默认值处理

## Test plan
- [x] 验证 showNum 为 undefined 时不会抛出 RangeError
- [x] 验证 showNum 为 null 时不会抛出 RangeError  
- [x] 验证 showNum 为 NaN 时不会抛出 RangeError
- [x] 确认正常情况下功能仍然正常工作
- [x] 确认版本号已正确更新

🤖 Generated with [Claude Code](https://claude.ai/code)