### PR TITLE
docs: 调整 MyIcon 组件的宽度并优化前后缀图标的样式

### DIFF
--- a/packages/shineout/src/input/__example__/04-02-prefix-suffix.tsx
+++ b/packages/shineout/src/input/__example__/04-02-prefix-suffix.tsx
@@ -10,7 +10,7 @@ import { Input, icons } from 'shineout';
 
 function MyIcon(props: any){
   const style={
-    width: 20,
+    width: 14,
     height: 20,
     display: 'flex',
     alignItems: 'center',
@@ -26,8 +26,8 @@ const App: React.FC = () => (
   <Input
     placeholder='please enter'
     width={300}
-    prefix={<MyIcon style={{ marginRight: 8 }}>{icons.Calendar}</MyIcon>}
-    suffix={<MyIcon style={{ marginLeft: 8 }}>{icons.Search}</MyIcon>}
+    prefix={<MyIcon style={{ marginRight: 8, flexShrink: 0 }}>{icons.Calendar}</MyIcon>}
+    suffix={<MyIcon style={{ marginLeft: 8, flexShrink: 0 }}>{icons.Search}</MyIcon>}
   />
 );
 


### PR DESCRIPTION
- 将 MyIcon 组件的宽度从 20 调整为 14
- 为前缀和后缀图标添加 flexShrink 样式以优化布局

<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

### Other information