### PR TITLE
fix: 修复 Table 虚拟列表 compressed 弹出层内部无法滚动的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.2-beta.6",
+  "version": "3.8.2-beta.7",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/virtual-scroll/scroll-table.tsx
+++ b/packages/base/src/virtual-scroll/scroll-table.tsx
@@ -47,7 +47,6 @@ const Scroll = (props: ScrollProps) => {
   const { current: context } = useRef({
     isMouseDown: false,
     lastTableHeight: 0,
-    unmounted: false,
   });
   const { scrollHeight = 0, scrollWidth = 0, defaultHeight = 0 } = props;
   const { width, height: h } = useResize({ targetRef: containerRef, timer: 100 });
@@ -152,9 +151,13 @@ const Scroll = (props: ScrollProps) => {
 
   // 非定高的Table但依旧采用了virtual渲染方式，需要渲染出全部的data
   useLayoutEffect(() => {
-    if (!props.tableRef.current || context.unmounted) return;
+    if (!props.tableRef.current) return;
     const rootTableHeight = props.tableRef.current.clientHeight;
     const container = containerRef.current
+
+    const isContainerVisible = container?.offsetParent !== null;
+    if(!isContainerVisible) return;
+
     // 判断内容滚动高度是否真的超过了容器高度
     const isRealScroll = container?.scrollHeight !== undefined && container.scrollHeight > rootTableHeight
     // 判断Table的根节点dom高度是否发生变化，如果变化了，则是因为不定高，被内部元素撑高了导致的
@@ -163,9 +166,6 @@ const Scroll = (props: ScrollProps) => {
       context.lastTableHeight = 0;
     } else {
       context.lastTableHeight = rootTableHeight;
-    }
-    return () => {
-      context.unmounted = true;
     }
   }, [paddingTop]);
 

--- a/packages/shineout-style/src/version.ts
+++ b/packages/shineout-style/src/version.ts
@@ -1,1 +1,1 @@
-export default '3.8.2-beta.6';
+export default '3.8.2-beta.7';

--- a/packages/shineout/src/index.ts
+++ b/packages/shineout/src/index.ts
@@ -67,4 +67,4 @@ export * from './deprecated';
 
 export * as TYPE from './type';
 
-export default { version: '3.8.2-beta.6' };
+export default { version: '3.8.2-beta.7' };

--- a/packages/shineout/src/table/__doc__/changelog.cn.md
+++ b/packages/shineout/src/table/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.8.2-beta.7
+2025-09-12
+
+### 🐞 BugFix
+- 修复 `Table` 不定设置固定高度的虚拟列表下，compressed 弹出层内部无法滚动的问题 （Regression: since v3.7.7） ([#1358](https://github.com/sheinsight/shineout-next/pull/1358))
+
 ## 3.8.2-beta.6
 2025-09-10
 


### PR DESCRIPTION
## Summary
- 修复 Table 组件在不定高设置固定高度的虚拟列表场景下，compressed 弹出层内部无法滚动的问题
- 移除不必要的 unmounted 标记逻辑，优化性能
- 增加容器可见性检查，避免在隐藏状态下执行不必要的计算

## 关联 PR
这是对 PR #1248 的改进，解决了虚拟列表在某些特定场景下的滚动问题。两个 PR 相互关联：
- PR #1248: 原始的虚拟列表优化
- 本 PR: 针对 compressed 弹出层滚动问题的进一步修复

## Test Plan
- [x] 测试 Table 虚拟列表的基本功能
- [x] 测试 compressed 弹出层的滚动交互
- [x] 验证修复不会影响其他 Table 功能
- [ ] 回归测试相关场景

## 影响范围
- Table 组件虚拟滚动相关逻辑
- compressed 弹出层交互体验

🤖 Generated with [Claude Code](https://claude.ai/code)