### PR TITLE
perf: 优化 result-more 组件滚动事件冒泡问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.2-beta.8",
+  "version": "3.8.2-beta.9",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/select/result-more.tsx
+++ b/packages/base/src/select/result-more.tsx
@@ -156,7 +156,7 @@ const More = <DataItem, Value>(props: ResultMoreProps<DataItem, Value>) => {
             visible={visible}
             onVisibleChange={setVisible}
           >
-            <div className={styles.moreWrapper} onClick={(e) => e.stopPropagation()}>
+            <div className={styles.moreWrapper} onClick={(e) => e.stopPropagation()} onScroll={(e) => e.stopPropagation()}>
               {compressed === 'no-repeat' ? null : before}
               {after}
             </div>

--- a/packages/base/src/table/table.tsx
+++ b/packages/base/src/table/table.tsx
@@ -314,6 +314,7 @@ export default <Item, Value>(props: TableProps<Item, Value>) => {
 
       syncHeaderScroll(info.scrollLeft);
 
+      if(props.virtual !== "lazy") return;
       if (context.scrollingTimer) {
         clearTimeout(context.scrollingTimer);
       }


### PR DESCRIPTION
## Summary

- 修复 result-more 组件的 scroll 事件会冒泡至 table 的 handleVirtualScroll 的问题
- 添加 onScroll 事件阻止冒泡处理
- 优化虚拟滚动判断条件，仅在 lazy 模式下处理滚动事件
- 版本升级至 3.8.2-beta.9

## 变更内容

### result-more.tsx
- 在 moreWrapper div 上添加 `onScroll={(e) => e.stopPropagation()}` 阻止滚动事件冒泡

### table.tsx  
- 在 handleVirtualScroll 中添加 `if(props.virtual !== "lazy") return;` 条件判断
- **这是从3.7.0-beta.9版本开始带来的副作用，增加该判断后，默认情况下组件的scrollingTimer的开销将不再有了**

### package.json
- 版本从 3.8.2-beta.8 升级到 3.8.2-beta.9

## Test plan

- [x] 测试 result-more 组件在 table 中的滚动行为
- [x] 验证滚动事件不再冒泡影响 table 的虚拟滚动
- [x] 确保虚拟列表功能正常工作

🤖 Generated with [Claude Code](https://claude.ai/code)