### PR TITLE
perf: 优化 form schema 构建器对多选组件的枚举处理

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.2-beta.9",
+  "version": "3.8.2-beta.10",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-form/use-form-schema/form-schema-builder.ts
+++ b/packages/hooks/src/components/use-form/use-form-schema/form-schema-builder.ts
@@ -137,7 +137,11 @@ export class SchemaBuilder {
           } else {
             const enumData = this.mapEnumData(componentElement.props.data, format);
             if (enumData.length > 0) {
-              fieldSchemaInfo.enum = enumData;
+              if (componentElement.props.multiple) {
+                fieldSchemaInfo.items.enum = enumData;
+              } else {
+                fieldSchemaInfo.enum = enumData;
+              }
             }
           }
           if(componentElement.props.data.length > 0) {

--- a/packages/shineout/src/form/__example__/test-001-base-form.tsx
+++ b/packages/shineout/src/form/__example__/test-001-base-form.tsx
@@ -59,6 +59,33 @@ export default () => {
           />
         </Form.Item>
 
+        <Form.Item label='下拉2' required>
+          <Select
+            data={[1,2,3,4,5,6,7,8,9,10]}
+            multiple
+            keygen
+            name='select2'
+          />
+        </Form.Item>
+        <Form.Item label='下拉3' required>
+          <Select
+            data={[{id: 1, color: 'red'}, {id: 2, color: 'green'}, {id: 3, color: 'blue'}]}
+            multiple
+            keygen="id"
+            format="id"
+            name='select3'
+          />
+        </Form.Item>
+        <Form.Item label='下拉4' required>
+          <Select
+            data={[{id: 1, color: 'red'}, {id: 2, color: 'green'}, {id: 3, color: 'blue'}]}
+            multiple
+            keygen="id"
+            format={d => d.color}
+            name='select4'
+          />
+        </Form.Item>
+
         <Form.Item label='下拉多选' required>
           <Select
             data={[]}


### PR DESCRIPTION
## Summary

- 修复表单 schema 构建器在处理多选组件时的枚举数据生成逻辑
- 当组件为多选模式时，正确将枚举数据设置到 `items.enum` 而非根级别的 `enum`
- 增加了多个 Select 多选组件的测试用例用于验证功能
- 版本升级至 3.8.2-beta.10

## 变更内容

### form-schema-builder.ts
- 在 `mapEnumData` 处理逻辑中添加对 `multiple` 属性的判断
- 多选组件时设置 `fieldSchemaInfo.items.enum = enumData`
- 单选组件时设置 `fieldSchemaInfo.enum = enumData`

### test-001-base-form.tsx
- 添加多个 Select 多选组件测试用例
- 包含不同数据格式和配置的多选场景

### package.json
- 版本从 3.8.2-beta.9 升级到 3.8.2-beta.10

## Test plan

- [x] 测试单选 Select 组件的 schema 生成是否正确
- [x] 测试多选 Select 组件的 schema 生成是否正确
- [x] 验证枚举数据在不同格式下的正确性
- [x] 确保表单验证功能正常工作

🤖 Generated with [Claude Code](https://claude.ai/code)