### PR TITLE
fix: 修复 Modal 全屏模式下 footer 可能被遮挡的样式问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.2-beta.10",
+  "version": "3.8.2-beta.11",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/modal/modal.ts
+++ b/packages/shineout-style/src/modal/modal.ts
@@ -392,12 +392,16 @@ const modalStyle: JsStyles<ModalClassType> = {
   },
   body: {
     flex: '1 1 auto',
-    minHeight: '1px',
+    minHeight: 0,
     // overflow: 'auto',
     color: token.modalBodyFontColor,
     fontSize: token.modalBodyFontSize,
     fontWeight: token.modalBodyFontWeight,
     lineHeight: token.lineHeightDynamic,
+
+    '$wrapperFullScreen &': {
+      minHeight: 'unset',
+    },
   },
   bodyWithIcon: {
     paddingLeft: `calc(${token.modalHeaderIconMarginEnd} + ${token.modalHeaderIconSize})`,

--- a/packages/shineout/src/modal/__doc__/changelog.cn.md
+++ b/packages/shineout/src/modal/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.8.2-beta.11
+2025-09-12
+
+### 🐞 BugFix
+- 修复 `Modal` 设置了 `fullScreen` 属性后 `footer` 可能被遮挡的样式问题 ([#1335](https://github.com/sheinsight/shineout-next/pull/1335))
+
 ## 3.8.0-beta.44
 2025-08-21
 


### PR DESCRIPTION
## Summary
- 修复 Modal 组件在全屏模式下 footer 可能被遮挡的样式问题
- 优化 modal body 的 minHeight 设置，在全屏模式下提供更好的布局体验

## Changes
- 修改 modal body 的 minHeight 从 `1px` 到 `0`
- 在全屏模式下设置 minHeight 为 `unset`，避免 footer 被遮挡
- 更新版本号到 3.8.2-beta.11
- 更新 changelog 文档

## Test plan
- [x] 验证 Modal 在普通模式下的显示正常
- [x] 验证 Modal 在全屏模式下 footer 不会被遮挡
- [x] 验证样式修改不影响其他 Modal 功能

🤖 Generated with [Claude Code](https://claude.ai/code)