### PR TITLE
feat(Empty): 优化全局配置 icon 为函数类型并修复配置更新逻辑

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.3-beta.5",
+  "version": "3.8.3-beta.6",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/config/index.ts
+++ b/packages/base/src/config/index.ts
@@ -28,7 +28,7 @@ type EmptyConfig = {
    * @en Global default icon for Empty component
    * @cn Empty组件的全局默认图标
    */
-  icon?: React.ReactNode;
+  icon?: () => React.ReactNode;
   /**
    * @en Global default description for Empty component
    * @cn Empty组件的全局默认描述
@@ -69,10 +69,7 @@ export let config: ConfigOption = {
 const state = create<ConfigOption>(config);
 
 state.subscribe(() => {
-  const snapshot = getSnapshot(state.mutate);
-  if (snapshot) {
-    config = snapshot;
-  }
+  config = getSnapshot(state.mutate);
 });
 
 export function getDefaultContainer() {
@@ -94,7 +91,7 @@ export const useConfig = () => {
 
 export const setConfig = (option: Partial<ConfigOption>) => {
   for (const [key, value] of Object.entries(option)) {
-    if (config && key in config) {
+    if (key in config) {
       const k = key as keyof ConfigOption;
       // @ts-ignore
       state.mutate[k] = value;

--- a/packages/base/src/empty/empty.tsx
+++ b/packages/base/src/empty/empty.tsx
@@ -30,18 +30,18 @@ const Empty = (props: EmptyProps) => {
       );
     }
 
-    return <div className={styles?.image}>{icon || empty?.icon || Icons.empty.NoData}</div>;
+    return <div className={styles?.image}>{icon || empty?.icon?.() || Icons.empty.NoData}</div>;
   };
 
   const renderDescription = () => {
     // 确定最终使用的description值，优先级：props.description > 全局配置description > 默认locale文本
     const finalDescription = description !== undefined ? description : (empty?.description !== undefined ? empty?.description : getLocale(locale, 'noData'));
-    
+
     // 如果最终确定的description值为false，则不显示描述
     if (finalDescription === false) {
       return null;
     }
-    
+
     return <div className={styles?.description}>{finalDescription}</div>;
   };
 


### PR DESCRIPTION
## Summary
- 将 Empty 组件全局配置的 icon 类型改为函数，提高响应式更新能力
- 简化 config 订阅逻辑，移除不必要的条件判断  
- 更新版本至 3.8.3-beta.6

## Test plan
- [x] 验证 Empty 组件全局配置 icon 功能正常
- [x] 确认配置更新能够正确响应
- [x] 检查现有功能未受影响

🤖 Generated with [Claude Code](https://claude.ai/code)