### PR TITLE
fix: 修复 `Textarea` 在 Safari 浏览器中使用 autosize 时，高度不正确的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.3",
+  "version": "3.8.4-beta.1",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/textarea/textarea.ts
+++ b/packages/shineout-style/src/textarea/textarea.ts
@@ -95,7 +95,14 @@ const input: JsStyles<keyof TextareaClasses> = {
     },
 
     '&:not($shadow)': {
-      minHeight: '-webkit-fill-available',
+      // 非 Safari 浏览器使用 -webkit-fill-available
+      '@supports not ((-webkit-hyphens: none))': {
+        minHeight: '-webkit-fill-available',
+      },
+      // Safari 使用 100%（Safari 支持 -webkit-hyphens）
+      '@supports (-webkit-hyphens: none)': {
+        minHeight: 'unset',
+      },
     }
   },
   resize: {

--- a/packages/shineout-style/src/version.ts
+++ b/packages/shineout-style/src/version.ts
@@ -1,1 +1,1 @@
-export default '3.8.3';
+export default '3.8.4-beta.1';

--- a/packages/shineout/src/index.ts
+++ b/packages/shineout/src/index.ts
@@ -67,4 +67,4 @@ export * from './deprecated';
 
 export * as TYPE from './type';
 
-export default { version: '3.8.3' };
+export default { version: '3.8.4-beta.1' };

--- a/packages/shineout/src/textarea/__doc__/changelog.cn.md
+++ b/packages/shineout/src/textarea/__doc__/changelog.cn.md
@@ -1,3 +1,11 @@
+## 3.8.4-beta.1
+2025-09-22
+
+### 🐞 BugFix
+
+- 修复 `Textarea` 在 Safari 浏览器中使用 autosize 时，高度不正确的问题 (Regression: since v3.7.9) ([#1377](https://github.com/sheinsight/shineout-next/pull/1377))
+
+
 ## 3.7.9-beta.1
 2025-07-30
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

### Other information