### PR TITLE
fix: 修复 `Upload` 上传结果的图标在Safari浏览器中不可见的问题

### DIFF
--- a/packages/shineout-style/src/upload/upload.ts
+++ b/packages/shineout-style/src/upload/upload.ts
@@ -111,6 +111,10 @@ const uploadStyle: JsStyles<UploadClassType> = {
     alignItems: 'center',
     '$resultError $resultText &': { color: token.uploadResultErrorFontColor },
     '$resultDeleted $resultText &': { color: token.uploadResultDeletedFontColor },
+
+    '& > svg': {
+      width: '100%',
+    }
   },
   iconHover: {
     '&:hover': {

--- a/packages/shineout/src/upload/__doc__/changelog.cn.md
+++ b/packages/shineout/src/upload/__doc__/changelog.cn.md
@@ -1,3 +1,11 @@
+## 3.8.4-beta.1
+2025-09-22
+
+### 🐞 BugFix
+
+- 修复 `Upload` 上传结果的图标在Safari浏览器中不可见的问题 ([#1378](https://github.com/sheinsight/shineout-next/pull/1378))
+
+
 ## 3.8.0-beta.42
 2025-08-20
 


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

### Other information