### PR TITLE
fix: 优化 CardGroup 懒加载性能并修复 Image 组件配置

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.4-beta.3",
+  "version": "3.8.4-beta.4",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/card-group/item.tsx
+++ b/packages/base/src/card-group/item.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useRef } from 'react';
 import { useInView, usePersistFn } from '@sheinx/hooks';
 import classNames from 'classnames';
 import { CardGroupContext } from './card-group-context';
@@ -10,12 +10,19 @@ import type { CardGroupItemProps } from './item.type';
 const Item = <V,>(props: CardGroupItemProps<V>) => {
   const { container } = useContext(CardGroupContext);
   const classes = props.jssStyle?.cardGroup?.();
+  const { current: context } = useRef({
+    isInView: false,
+  });
 
-  const { ref: itemRef, isInView  } = useInView<HTMLDivElement>({
+  const { ref: itemRef, isInView } = useInView<HTMLDivElement>({
     rootMargin: `${container?.offsetHeight || 500}px`,
     root: container,
-    threshold:[0, 1]
-  })
+    threshold: [0, 1],
+  });
+
+  if (isInView && !context.isInView) {
+    context.isInView = true;
+  }
 
   const handleChange = usePersistFn((_: any, checked: boolean) => {
     if (props.onChange) props.onChange(checked, props.value!);
@@ -24,7 +31,7 @@ const Item = <V,>(props: CardGroupItemProps<V>) => {
   const renderChildren = (content: React.ReactNode) => {
     if (!props.placeholder) return content;
     return (
-      <Lazyload container={container} placeholder={props.placeholder} isInView={isInView}>
+      <Lazyload container={container} placeholder={props.placeholder} isInView={context.isInView}>
         {content}
       </Lazyload>
     );
@@ -48,7 +55,7 @@ const Item = <V,>(props: CardGroupItemProps<V>) => {
     </>
   );
 
-  const hiddenStyle = isInView ? undefined : { visibility: 'hidden' };
+  const hiddenStyle = context.isInView ? undefined : { visibility: 'hidden' };
   const itemStyle = { ...props.style, ...hiddenStyle } as React.CSSProperties;
 
   return (

--- a/packages/shineout/src/card-group/__example__/t-001-lazyout.tsx
+++ b/packages/shineout/src/card-group/__example__/t-001-lazyout.tsx
@@ -156,13 +156,13 @@ function ImageDemo(){
       >
         <Image.Group fit='fill' target='_modal' pile lazy>
           {images.map((item, index) => {
-            return <Image inViewOnly key={index} width={128} height={128} src={item} href={item}></Image>;
+            return <Image key={index} width={128} height={128} src={item} href={item}></Image>;
           })}
         </Image.Group>
 
         <Image.Group fit='fill' target='_modal' pile showCount lazy>
           {images.map((item, index) => {
-            return <Image inViewOnly key={index} width={128} height={128} src={item} href={item}></Image>;
+            return <Image key={index} width={128} height={128} src={item} href={item}></Image>;
           })}
         </Image.Group>
       </div>


### PR DESCRIPTION
## Summary
- 使用 useRef 持久化 CardGroup 中 isInView 状态，避免组件重复渲染
- 移除 Image 组件示例中不必要的 inViewOnly 属性
- 升级版本至 3.8.4-beta.4

## Test plan
- [x] 验证 CardGroup 懒加载功能正常工作
- [x] 确认 Image 组件在 CardGroup 中正确显示
- [x] 检查性能优化效果

🤖 Generated with [Claude Code](https://claude.ai/code)