### PR TITLE
fix: 修复 Tabs 的 card 模式下 hideSplit 属性失效的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.4-beta.4",
+  "version": "3.8.4-beta.5",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/tabs/tabs-header.tsx
+++ b/packages/base/src/tabs/tabs-header.tsx
@@ -202,7 +202,7 @@ const TabsHeader = (props: TabsHeaderProps) => {
   };
 
   const renderTab = () => {
-    const headerClass = classNames(headerStyle.header, shape === 'card' ? headerStyle.cardHr : '');
+    const headerClass = classNames(headerStyle.header);
     return (
       <div ref={headerRef} className={headerClass}>
         <div
@@ -300,7 +300,7 @@ const TabsHeader = (props: TabsHeaderProps) => {
       {...getDataProps({ position: props.getPosition, shape })}
       dir={config.direction}
     >
-      {!hideSplit && shape !== 'card' && renderHr()}
+      {!hideSplit && renderHr()}
       {collapsible && renderCollapsibleButton()}
       {shouldScroll && renderPrevButton()}
       {renderTab()}

--- a/packages/base/src/tabs/tabs.type.ts
+++ b/packages/base/src/tabs/tabs.type.ts
@@ -24,7 +24,6 @@ export interface TabsClasses {
   bordered: string;
   card: string;
   dash: string;
-  cardHr: string;
   active: string;
   disabled: string;
   show: string;

--- a/packages/shineout-style/src/tabs/tabs.ts
+++ b/packages/shineout-style/src/tabs/tabs.ts
@@ -56,26 +56,13 @@ const getCardStyle = () => {
       },
 
       '&[dir=ltr]': {
-        '& $cardHr': {
-          '&:before': {
-            right: 0,
-            left: 'auto',
-            width: '1px',
-            height: '100%',
-          },
-        },
+        '& $hr': { right: 0, height: '100%', width: 1 },
         ...active({ top: 0, bottom: 0, right: -1, width: 1, background: Token.tabsCardCheckedBackgroundColor }),
       },
       '&[dir=rtl]': {
         ...active({ top: 0, bottom: 0, left: -1, width: 1, background: Token.tabsCardCheckedBackgroundColor }),
 
-        '& $cardHr': {
-          '&:before': {
-            left: 0,
-            width: 1,
-            height: '100%',
-          },
-        },
+        '& $hr': { left: 0, height: '100%', width: 1 },
       },
     },
     '&[data-soui-position^="right-"][data-soui-shape="card"]': {
@@ -88,24 +75,12 @@ const getCardStyle = () => {
         },
       },
       '&[dir=ltr]': {
-        '& $cardHr': {
-          '&:before': {
-            left: 0,
-            width: 1,
-            height: '100%',
-          },
-        },
+        '& $hr': { left: 0, height: '100%', width: 1 },
         ...active({ top: 0, bottom: 0, left: -1, width: 1, background: Token.tabsCardCheckedBackgroundColor }),
       },
 
       '&[dir=rtl]': {
-        '& $cardHr': {
-          '&:before': {
-            right: 0,
-            width: 1,
-            height: '100%',
-          },
-        },
+        '& $hr': { right: 0, height: '100%', width: 1 },
         ...active({ top: 0, bottom: 0, right: -1, width: 1, background: Token.tabsCardCheckedBackgroundColor }),
       },
     },
@@ -121,12 +96,6 @@ const getCardStyle = () => {
         borderRadius: `0 0 ${Token.tabsTabBorderRadius} ${Token.tabsTabBorderRadius}`,
       },
       '& $hr': { top: 0, height: 1, width: '100%' },
-      '& $cardHr': {
-        '&:before': {
-          top: 0,
-          bottom: 'auto',
-        },
-      },
       ...active({ top: -1, left: 0, right: 0, height: 1, background: Token.tabsCardCheckedBackgroundColor }),
     },
   };
@@ -328,17 +297,6 @@ const tabsStyle: JsStyles<keyof TabsClasses> = {
 
     '$headerWrapper[data-soui-shape="line"] &': {
       background: Token.tabsLineHrBackgroundColor,
-    },
-  },
-  cardHr: {
-    '&:before': {
-      position: 'absolute',
-      content: '""',
-      bottom: 0,
-      left: 0,
-      width: '100%',
-      height: 1,
-      background: Token.tabsBorderColor,
     },
   },
   headerWrapper: {

--- a/packages/shineout/src/tabs/__doc__/changelog.cn.md
+++ b/packages/shineout/src/tabs/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.8.4-beta.5
+2025-09-24
+
+### 🐞 BugFix
+- 修复 `Tabs` 的 card 模式下 `hideSplit` 属性失效的问题 ([#1383](https://github.com/sheinsight/shineout-next/pull/1383))
+
+
 ## 3.8.0-beta.35
 2025-08-15
 


### PR DESCRIPTION
## Summary
- 修复 Tabs 组件在 card 模式下 hideSplit 属性失效的问题
- 移除针对 card 模式的特殊判断，使 hideSplit 在所有 shape 下生效
- 简化样式类的使用，统一使用 hr 类名处理分隔线
- 升级版本至 3.8.4-beta.5

## Test plan
- [x] 验证 card 模式下 hideSplit=true 时分隔线被隐藏
- [x] 验证其他 shape 模式下 hideSplit 功能正常
- [x] 确认样式优化后显示效果一致

## Playground ID
a5e81525-4c3e-4a9b-951f-67c9cb76c107

🤖 Generated with [Claude Code](https://claude.ai/code)