### PR TITLE
fix: 修复 Tooltip 子元素事件重复触发问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.4-beta.7",
+  "version": "3.8.4-beta.8",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/tooltip/tooltip.tsx
+++ b/packages/base/src/tooltip/tooltip.tsx
@@ -1,6 +1,6 @@
 import { usePersistFn, usePopup, util } from '@sheinx/hooks';
 import classNames from 'classnames';
-import React, { cloneElement, isValidElement, useEffect } from 'react';
+import React, { cloneElement, isValidElement, useEffect, useMemo } from 'react';
 import { TooltipProps } from './tooltip.type';
 import AbsoluteList from '../absolute-list';
 import { useConfig } from '../config';
@@ -102,6 +102,18 @@ const Tooltip = (props: TooltipProps) => {
     children
   );
 
+  const innerProps = useMemo(() => {
+    if (persistent) {
+      return {
+        ...events,
+        onMouseEnter: undefined,
+        onMouseLeave: undefined,
+        onClick: undefined,
+      };
+    }
+    return events;
+  }, [persistent, events]);
+
   return (
     <>
       <noscript
@@ -114,7 +126,7 @@ const Tooltip = (props: TooltipProps) => {
         }}
         key='ns'
       />
-      {cloneElement(inner, events)}
+      {cloneElement(inner, innerProps)}
       <AbsoluteList
         focus={open}
         parentElRef={targetRef}

--- a/packages/shineout-style/src/version.ts
+++ b/packages/shineout-style/src/version.ts
@@ -1,1 +1,1 @@
-export default '3.8.4-beta.7';
+export default '3.8.4-beta.8';

--- a/packages/shineout/src/index.ts
+++ b/packages/shineout/src/index.ts
@@ -67,4 +67,4 @@ export * from './deprecated';
 
 export * as TYPE from './type';
 
-export default { version: '3.8.4-beta.7' };
+export default { version: '3.8.4-beta.8' };

--- a/packages/shineout/src/tooltip/__doc__/changelog.cn.md
+++ b/packages/shineout/src/tooltip/__doc__/changelog.cn.md
@@ -1,3 +1,11 @@
+## 3.8.4-beta.8
+2025-09-25
+
+### 🐞 BugFix
+- 修复 `Tooltip` 在 `persistent` 模式下 children 的 `onMouseEnter`、`onMouseLeave`、`onClick` 事件会触发两次的问题 ([#1386](https://github.com/sheinsight/shineout-next/pull/1386))
+
+
+
 ## 3.8.1-beta.8
 2025-09-05
 


### PR DESCRIPTION
## Summary
- 修复了 Tooltip 组件中子元素事件重复触发的问题
- 更新了相关版本号和文档

## Test plan
- [ ] 验证 Tooltip 组件子元素事件不会重复触发
- [ ] 检查现有功能是否正常工作
- [ ] 运行相关单元测试

🤖 Generated with [Claude Code](https://claude.ai/code)