### PR TITLE
fix: 移除 Cascader 组件中 focusSelected 属性的使用

### DIFF
--- a/packages/base/src/cascader/cascader.tsx
+++ b/packages/base/src/cascader/cascader.tsx
@@ -67,7 +67,6 @@ const Cascader = <DataItem, Value extends KeygenResult[]>(
     renderItem: renderItemProp = (d) => d as React.ReactNode,
     renderResult: renderResultProp,
     placeholder,
-    focusSelected = true,
     renderCompressed,
     compressedClassName,
     resultClassName,
@@ -530,7 +529,6 @@ const Cascader = <DataItem, Value extends KeygenResult[]>(
           renderUnmatched={renderUnmatched}
           renderResultContent={hideTag && !multiple ? renderResultContent : undefined}
           allowOnFilter={showInput}
-          focusSelected={focusSelected}
           inputText={inputText}
           filterText={filterText}
           onFilter={handleFilter}


### PR DESCRIPTION
## Summary
- 从 Cascader 组件中移除 focusSelected 属性的解构和传递
- 清理无效的属性使用，提高代码质量

## Test plan
- [x] 测试 Cascader 组件功能正常
- [x] 确认移除 focusSelected 属性不影响现有功能
- [x] 验证组件的焦点行为正常

🤖 Generated with [Claude Code](https://claude.ai/code)