### PR TITLE
feat: enhance Cascader renderOptionList prop to support filter results

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.5-beta.3",
+  "version": "3.9.0-beta.1",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/cascader/cascader.tsx
+++ b/packages/base/src/cascader/cascader.tsx
@@ -635,10 +635,11 @@ const Cascader = <DataItem, Value extends KeygenResult[]>(
   };
 
   const renderEmpty = () => {
+    const $empty = <div className={styles?.empty}>{emptyText || getLocale(locale, 'noData')}</div>;
     if (renderOptionList) {
-      return renderOptionList(null as any, { loading: !!loading });
+      return renderOptionList($empty as any, { loading: !!loading });
     }
-    return <div className={styles?.empty}>{emptyText || getLocale(locale, 'noData')}</div>;
+    return $empty;
   };
 
   const renderNormalList = () => {
@@ -658,7 +659,7 @@ const Cascader = <DataItem, Value extends KeygenResult[]>(
 
   const renderFilterList = () => {
     const listStyle = data && data.length === 0 ? { maxHeight: height } : { maxHeight: height };
-    return (
+    const $filterList = (
       <div className={classNames(styles.listContent, styles.filterList)} style={listStyle}>
         <CascaderFilterList
           jssStyle={jssStyle}
@@ -682,6 +683,10 @@ const Cascader = <DataItem, Value extends KeygenResult[]>(
         ></CascaderFilterList>
       </div>
     );
+    if (renderOptionList) {
+      return renderOptionList($filterList, { loading: !!loading });
+    }
+    return $filterList;
   };
 
   const renderLoading = () => {

--- a/packages/shineout/src/cascader/__doc__/changelog.cn.md
+++ b/packages/shineout/src/cascader/__doc__/changelog.cn.md
@@ -1,3 +1,11 @@
+## 3.9.0-beta.1
+2025-09-29
+
+### 💎 Enhancement
+- 增强 `Cascader` 的 `renderOptionList` 属性，支持其在搜索结果面板也生效 ([#1395](https://github.com/sheinsight/shineout-next/pull/1395))
+
+
+
 ## 3.8.2-beta.3
 2025-09-09
 


### PR DESCRIPTION
## Summary
- Enhanced `renderOptionList` prop in Cascader component to also work with filter/search results panel
- Updated changelog documentation for version 3.9.0-beta.1

## Changes
- Modified `renderFilterList` function to respect `renderOptionList` prop when rendering filtered results
- Updated `renderEmpty` function to pass the empty content through `renderOptionList` when available
- Version bump to 3.9.0-beta.1

## Test plan
- [ ] Test that `renderOptionList` prop works with normal cascader options
- [ ] Test that `renderOptionList` prop works with filtered/search results
- [ ] Test that empty state is properly handled through `renderOptionList`
- [ ] Verify no regression in existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)