### PR TITLE
fix: 修复 Tabs card 模式按钮样式和优化 Input/Textarea TypeScript 类型

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.5-beta.3",
+  "version": "3.8.5-beta.4",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/input/input.type.ts
+++ b/packages/base/src/input/input.type.ts
@@ -98,7 +98,7 @@ export interface SimpleInputProps
    * @en The callback function for enter key
    * @cn 回车键回调函数
    */
-  onEnterPress?: (value: string, e: React.KeyboardEvent) => void;
+  onEnterPress?: (value: string, e: React.KeyboardEvent<HTMLInputElement> & { target: HTMLInputElement }) => void;
   /**
    * @en Whether to show clear button when has value, higher priority than clearable
    * @cn 有值时，是否常驻显示清除按钮，优先级高于 clearable

--- a/packages/base/src/textarea/textarea.type.ts
+++ b/packages/base/src/textarea/textarea.type.ts
@@ -89,7 +89,7 @@ export interface SimpleTextareaProps
    * @en The callback function for enter key
    * @cn 回车键的回调函数
    */
-  onEnterPress?: (value: string, e: React.KeyboardEvent) => void;
+  onEnterPress?: (value: string, e: React.KeyboardEvent<HTMLTextAreaElement> & { target: HTMLTextAreaElement }) => void;
   /**
    * @en Custom rendering Textarea
    * @cn 自定义渲染Textarea

--- a/packages/shineout-style/src/tabs/tabs.ts
+++ b/packages/shineout-style/src/tabs/tabs.ts
@@ -388,6 +388,10 @@ const tabsStyle: JsStyles<keyof TabsClasses> = {
 
     '&[data-soui-shape="card"] $prev, &[data-soui-shape="card"] $next': {
       background: '#FFFFFF',
+      alignSelf: 'stretch',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
       border: `1px solid ${Token.tabsBorderColor}`,
 
       '&[data-soui-state="disabled"]': {

--- a/packages/shineout/src/input/__doc__/changelog.cn.md
+++ b/packages/shineout/src/input/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.8.5-beta.4
+2025-09-29
+
+### 🐞 BugFix
+- 修复 `Input` 的 `onEnterPress` 事件的第二参数ts类型错误问题 ([#1396](https://github.com/sheinsight/shineout-next/pull/1396))
+
+
 ## 3.8.3-beta.8
 2025-09-19
 

--- a/packages/shineout/src/tabs/__doc__/changelog.cn.md
+++ b/packages/shineout/src/tabs/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.8.5-beta.4
+2025-09-29
+
+### 🐞 BugFix
+- 修复 `Tabs` 的 card 模式下 prev 和 next 按钮的样式问题 ([#1396](https://github.com/sheinsight/shineout-next/pull/1396))
+
 ## 3.8.4-beta.6
 2025-09-24
 

--- a/packages/shineout/src/textarea/__doc__/changelog.cn.md
+++ b/packages/shineout/src/textarea/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.8.5-beta.4
+2025-09-29
+
+### 🐞 BugFix
+- 修复 `Textarea` 的 `onEnterPress` 事件的第二参数ts类型错误问题 ([#1396](https://github.com/sheinsight/shineout-next/pull/1396))
+
+
 ## 3.8.4-beta.1
 2025-09-22
 


### PR DESCRIPTION
## 概述
本次 PR 包含两个重要修复：
- 修复了 Tabs 组件在 card 模式下 prev 和 next 按钮的样式问题
- 优化了 Input 和 Textarea 组件 onEnterPress 事件的 TypeScript 类型定义

## 变更内容

### Tabs 组件样式修复
- 修复 card 模式下 prev/next 按钮的布局和对齐问题
- 添加了 `alignSelf: 'stretch'`, `display: 'flex'`, `alignItems: 'center'`, `justifyContent: 'center'` 样式属性
- 确保按钮在不同高度的标签页中正确显示

### TypeScript 类型优化  
- 优化了 Input 和 Textarea 组件中 `onEnterPress` 回调函数的类型定义
- 修复了 `e.target.blur()` 需要类型转换才能访问的问题
- 用户现在可以直接访问 `e.target.blur()` 和其他 HTMLInputElement 方法，无需类型转换

## 测试计划
- [x] 验证 Tabs card 模式下 prev/next 按钮样式显示正常
- [x] 验证 TypeScript 编译通过，无类型错误
- [x] 测试在 onEnterPress 回调中可以直接使用 `e.target.blur()` 而无需类型转换
- [x] 确保现有功能无回归问题

🤖 Generated with [Claude Code](https://claude.com/claude-code)