### PR TITLE
fix: 修复 DatePicker type 为 week 时 needConfirm 属性不生效的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.5-beta.4",
+  "version": "3.8.5-beta.5",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/date-picker/day.tsx
+++ b/packages/base/src/date-picker/day.tsx
@@ -138,7 +138,7 @@ const Day = (props: DayProps) => {
 
   const renderFooter = () => {
     const showLeft =
-      (props.type === 'datetime' || props.type === 'date');
+      (props.type === 'datetime' || props.type === 'date' || props.type === 'week');
 
     const timeStr = func.getTimeStr();
     if (!showLeft && !props.showSelNow) return null;

--- a/packages/shineout/src/date-picker/__doc__/changelog.cn.md
+++ b/packages/shineout/src/date-picker/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.8.5-beta.5
+
+### 🐞 BugFix
+- 修复 `DatePicker` 的 `type` 为 week 时，`needConfirm` 属性不生效的问题 ([#1398](https://github.com/sheinsight/shineout-next/pull/1398))
+
+
 ## 3.8.0-beta.47
 2025-08-27
 


### PR DESCRIPTION
## 概述
修复了 DatePicker 组件在 `type` 为 `week` 时 `needConfirm` 属性不生效的问题。

## 问题描述
当 DatePicker 组件设置为周选择模式（`type="week"`）时，`needConfirm` 属性无法正常工作，用户无法看到确认按钮。

## 解决方案
在 `day.tsx` 的 `renderFooter` 函数中，修改了 `showLeft` 的逻辑判断，添加了对 `'week'` 类型的支持：

```tsx
const showLeft = (props.type === 'datetime' || props.type === 'date' || props.type === 'week');
```

## 变更内容
- 修复 DatePicker 周选择模式下 needConfirm 功能
- 更新版本号为 3.8.5-beta.5
- 更新 changelog 文档

## 测试计划
- [x] 验证 week 模式下 needConfirm 属性正常工作
- [x] 验证其他 type 模式的 needConfirm 功能无回归
- [x] 确保确认按钮在 week 模式下正确显示和工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)