### PR TITLE
fix: 修复 Modal 方法调用时在低性能设备上出现的关闭闪烁一下的问题

### DIFF
--- a/packages/base/src/modal/modal-content.tsx
+++ b/packages/base/src/modal/modal-content.tsx
@@ -271,7 +271,6 @@ const Modal = (props: ModalContentProps) => {
     if (props.setInnerClose) {
       props.setInnerClose(() => {
         setVisible(false);
-        setAnimation(true);
       });
     }
   }, [props.setInnerClose]);


### PR DESCRIPTION
## Summary
- 修复 Modal 方法调用时在低性能设备上出现的关闭闪烁问题
- 移除不必要的动画状态设置，优化关闭体验

## Changes
- **modal-content.tsx**: 移除 `setInnerClose` 中的 `setAnimation(true)` 调用

## Root Cause
在低性能设备上，调用 `Modal.show()` 创建的弹窗在关闭时会出现闪烁：
1. 关闭时 `setInnerClose` 会同时调用 `setVisible(false)` 和 `setAnimation(true)`
2. `setAnimation(true)` 会触发不必要的重新渲染
3. 在低性能设备上，这会导致视觉上的闪烁效果

## Solution
移除 `setAnimation(true)` 的调用，因为：
- `setVisible(false)` 已经足够触发关闭动画
- 额外的动画状态设置会造成重复渲染
- 移除后可避免低性能设备上的闪烁问题

## Test plan
- [x] 在低性能设备/CPU降速模式下测试 Modal 方法调用
- [x] 验证关闭动画流畅，无闪烁现象
- [x] 确认正常性能设备下功能正常
- [x] 测试多次连续开关的场景

🤖 Generated with [Claude Code](https://claude.com/claude-code)