### PR TITLE
fix: 修复 Select、TreeSelect、Cascader 在大尺寸模式下结果样式垂直不居中的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.6-beta.6",
+  "version": "3.8.6-beta.7",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/cascader/cascader.ts
+++ b/packages/shineout-style/src/cascader/cascader.ts
@@ -135,12 +135,6 @@ const cascaderStyle: JsStyles<CascaderClassType> = {
       },
     },
     '&$wrapperLarge': {
-      '& $tag': {
-        height: selectLargeTagHeight,
-        '&  *': {
-          lineHeight: selectLargeTagHeight,
-        },
-      },
       '& $placeholder,$ellipsis,$space,input': {
         marginTop: token.cascaderLargePlaceholderMarginY,
         marginBottom: token.cascaderLargePlaceholderMarginY,

--- a/packages/shineout-style/src/select/select.ts
+++ b/packages/shineout-style/src/select/select.ts
@@ -123,12 +123,6 @@ const selectStyle: JsStyles<SelectClassType> = {
       },
     },
     '&$wrapperLarge': {
-      '& $tag': {
-        height: selectLargeTagHeight,
-        '&  *': {
-          lineHeight: selectLargeTagHeight,
-        },
-      },
       '& $placeholder,$ellipsis,$space,input': {
         marginTop: token.selectLargePlaceholderMarginY,
         marginBottom: token.selectLargePlaceholderMarginY,

--- a/packages/shineout-style/src/tree-select/tree-select.ts
+++ b/packages/shineout-style/src/tree-select/tree-select.ts
@@ -134,12 +134,6 @@ const treeSelectStyle: JsStyles<TreeSelectClassType> = {
       },
     },
     '&$wrapperLarge': {
-      '& $tag': {
-        height: selectLargeTagHeight,
-        '&  *': {
-          lineHeight: selectLargeTagHeight,
-        },
-      },
       '& $placeholder,$ellipsis,$space,input': {
         marginTop: token.treeSelectLargePlaceholderMarginY,
         marginBottom: token.treeSelectLargePlaceholderMarginY,

--- a/packages/shineout/src/cascader/__doc__/changelog.cn.md
+++ b/packages/shineout/src/cascader/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.8.6-beta.7
+2025-10-13
+
+### 🐞 BugFix
+- 修复 `Cascader` 在大尺寸模式下的结果样式垂直不居中的问题 （Regression: since v3.7.2）([#1409](https://github.com/sheinsight/shineout-next/pull/1409))
+
 ## 3.8.2-beta.3
 2025-09-09
 

--- a/packages/shineout/src/select/__doc__/changelog.cn.md
+++ b/packages/shineout/src/select/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.8.6-beta.7
+2025-10-13
+
+### 🐞 BugFix
+- 修复 `Select` 在大尺寸模式下的结果样式垂直不居中的问题 （Regression: since v3.7.2）([#1409](https://github.com/sheinsight/shineout-next/pull/1409))
+
 ## 3.8.5-beta.3
 2025-09-28
 

--- a/packages/shineout/src/tree-select/__doc__/changelog.cn.md
+++ b/packages/shineout/src/tree-select/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.8.6-beta.7
+2025-10-13
+
+### 🐞 BugFix
+- 修复 `TreeSelect` 在大尺寸模式下的结果样式垂直不居中的问题 （Regression: since v3.7.2）([#1409](https://github.com/sheinsight/shineout-next/pull/1409))
+
+
 ## 3.8.5-beta.3
 2025-09-28
 


### PR DESCRIPTION
## Summary
- 修复 `Select`、`TreeSelect`、`Cascader` 在大尺寸模式下的结果样式垂直不居中的问题
- 回归问题出现在 v3.7.2 版本的 PR #1169
- 更新版本号至 3.8.6-beta.7

## Problem
在 v3.7.2 版本的 PR #1169 中引入的样式变更导致大尺寸（large）模式下的选中结果项垂直不居中：
- `Select` 组件的选中项 tag 显示不居中
- `TreeSelect` 组件的选中项 tag 显示不居中
- `Cascader` 组件的选中项 tag 显示不居中

根本原因是在 `wrapperLarge` 样式中强制设置了 tag 的高度和行高，导致与实际内容高度不匹配。

**相关 PR**: #1169 引入了该问题

## Solution
移除 `wrapperLarge` 中对 tag 高度和行高的强制设置，让组件自适应计算合适的高度。

### 核心改动
在三个组件的样式文件中移除类似的代码：
```diff
 '&$wrapperLarge': {
-  '& $tag': {
-    height: xxxLargeTagHeight,
-    '&  *': {
-      lineHeight: xxxLargeTagHeight,
-    },
-  },
   '& $placeholder,$ellipsis,$space,input': {
```

受影响文件：
- `packages/shineout-style/src/select/select.ts`
- `packages/shineout-style/src/tree-select/tree-select.ts`
- `packages/shineout-style/src/cascader/cascader.ts`

## Changes
- **select.ts**: 移除 wrapperLarge 中的 tag 高度强制设置
- **tree-select.ts**: 移除 wrapperLarge 中的 tag 高度强制设置
- **cascader.ts**: 移除 wrapperLarge 中的 tag 高度强制设置
- **changelog**: 更新三个组件的变更日志，标注 Regression: since v3.7.2
- **package.json**: 版本号升级至 3.8.6-beta.7

## Test plan
- [x] 测试 Select large 模式下选中结果垂直居中显示
- [x] 测试 TreeSelect large 模式下选中结果垂直居中显示
- [x] 测试 Cascader large 模式下选中结果垂直居中显示
- [x] 测试 small 和 default 尺寸不受影响
- [x] 测试单选和多选模式都正常显示
- [x] 验证不影响其他样式和功能

## Regression Info
- **引入版本**: v3.7.2
- **引入 PR**: #1169
- **影响范围**: Select、TreeSelect、Cascader 的 large 尺寸模式
- **严重程度**: 中等（UI 显示问题，不影响功能）

## Playground ID
3b6cd28b-c1d9-4fbf-8040-d5daf879b98e

🤖 Generated with [Claude Code](https://claude.com/claude-code)