### PR TITLE
chore: 发布 3.8.6 正式版本

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.6-beta.7",
+  "version": "3.8.6",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/version.ts
+++ b/packages/shineout-style/src/version.ts
@@ -1,1 +1,1 @@
-export default '3.8.6-beta.5';
+export default '3.8.6';

--- a/packages/shineout/src/index.ts
+++ b/packages/shineout/src/index.ts
@@ -67,4 +67,4 @@ export * from './deprecated';
 
 export * as TYPE from './type';
 
-export default { version: '3.8.6-beta.5' };
+export default { version: '3.8.6' };


### PR DESCRIPTION
## Summary
发布 3.8.6 正式版本

## Changes
- 更新版本号至 `3.8.6`
- 从 beta 版本升级为正式版本

## Version Files Updated
- `package.json`: 3.8.6-beta.7 → 3.8.6
- `packages/shineout-style/src/version.ts`: 3.8.6-beta.5 → 3.8.6
- `packages/shineout/src/index.ts`: 3.8.6-beta.5 → 3.8.6

## Release Notes

本次版本包含 3.8.6-beta.2 ~ 3.8.6-beta.7 的所有更新内容：

### 🐞 Bug Fixes

#### 3.8.6-beta.7 (2025-10-13)
- **Select**: 修复在大尺寸模式下的结果样式垂直不居中的问题 (Regression: since v3.7.2) ([#1409](https://github.com/sheinsight/shineout-next/pull/1409))
- **TreeSelect**: 修复在大尺寸模式下的结果样式垂直不居中的问题 (Regression: since v3.7.2) ([#1409](https://github.com/sheinsight/shineout-next/pull/1409))
- **Cascader**: 修复在大尺寸模式下的结果样式垂直不居中的问题 (Regression: since v3.7.2) ([#1409](https://github.com/sheinsight/shineout-next/pull/1409))

#### 3.8.6-beta.4 (2025-10-11)
- 无

#### 3.8.6-beta.3 (2025-10-10)
- **Divider**: 修复带文字的分割线样式在微前端下不正常显示的问题 ([#1403](https://github.com/sheinsight/shineout-next/pull/1403))

#### 3.8.6-beta.2 (2025-10-10)
- 无

### 💎 Enhancements

#### 3.8.6-beta.4 (2025-10-11)
- **Menu**: 优化垂直模式下子级菜单高度超出窗口后的展示效果 ([#1404](https://github.com/sheinsight/shineout-next/pull/1404))

#### 3.8.6-beta.2 (2025-10-10)
- **Tooltip**: 优化在设置了非 `auto` 位置时的滚动跟随行为，提升用户体验 ([#1401](https://github.com/sheinsight/shineout-next/pull/1401))

## Highlights

本版本主要修复了以下重要问题：

1. **样式回归修复**: 修复了 Select、TreeSelect、Cascader 组件在 large 尺寸模式下选中结果垂直不居中的问题（该问题在 v3.7.2 版本引入）
2. **Menu 体验优化**: 优化了 Menu 垂直模式下子级菜单高度超出窗口时的展示效果，增加了自动滚动和高度限制
3. **微前端兼容性**: 修复了 Divider 组件带文字分割线在微前端环境下的样式问题
4. **Tooltip 交互优化**: 改进了 Tooltip 在滚动场景下的跟随行为

## Test plan
- [x] 确认版本号更新正确
- [x] 验证所有包的版本号一致性
- [x] 确认 beta 功能稳定可发布
- [x] 回归测试所有修复的问题

🤖 Generated with [Claude Code](https://claude.com/claude-code)