### PR TITLE
fix: 修复 Breadcrumb 设置 max 属性且设置了自定义的 renderItem 后,超宽标题的Tooltip弹出效果不展示的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.7-beta.3",
+  "version": "3.8.7-beta.4",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/breadcrumb/breadcrumb-item.tsx
+++ b/packages/base/src/breadcrumb/breadcrumb-item.tsx
@@ -50,7 +50,13 @@ const BreadcrumbItem = <Item = BreadcrumbDataType,>({dataItem, renderItem, jssSt
     }
   }
   if(renderItem) {
-    return renderItem(dataItem);
+    if (max !== undefined) {
+      item = <span className={contentClass} ref={contentRef}>
+        {renderItem(dataItem)}
+      </span>
+    } else {
+      return renderItem(dataItem);
+    }
   }
 
   if(isOverflow && d.title && max !== undefined) {

--- a/packages/base/src/breadcrumb/breadcrumb.tsx
+++ b/packages/base/src/breadcrumb/breadcrumb.tsx
@@ -54,7 +54,7 @@ const Breadcrumb = <Item = BreadcrumbDataType,>(props: BreadcrumbProps<Item>) =>
               className={breadcrumbClasses?.item}
               key={props.keygen ? getKey(props.keygen, itemFirst as Item, index) : index}
             >
-              {Array.isArray(d) ? renderArray(d) : <BreadcrumbItem dataItem={d as Item} renderItem={renderItem} jssStyle={props.jssStyle} max={maxCount} />}
+              {Array.isArray(d) ? renderArray(d) : <BreadcrumbItem dataItem={d as Item} renderItem={props.renderItem} jssStyle={props.jssStyle} max={maxCount} />}
               {!isLastItem && <div className={breadcrumbClasses?.separator}>{separator}</div>}
             </div>
           );

--- a/packages/shineout/src/breadcrumb/__doc__/changelog.cn.md
+++ b/packages/shineout/src/breadcrumb/__doc__/changelog.cn.md
@@ -1,3 +1,11 @@
+## 3.8.7-beta.4
+2025-10-17
+
+### 🐞 BugFix
+
+- 修复 `Breadcrumb` 设置 `max` 属性且设置了自定义的 `renderItem` 后，超宽标题的Tooltip弹出效果不展示的问题([#1418](https://github.com/sheinsight/shineout-next/pull/1418))
+
+
 ## 3.7.6-beta.3
 2025-07-08
 


### PR DESCRIPTION
## Summary
- 修复了当 Breadcrumb 组件同时设置 max 属性和自定义 renderItem 时,超宽标题的 Tooltip 无法正常展示的问题

## Changes
- **breadcrumb-item.tsx**: 当设置了 max 且使用 renderItem 时,确保渲染的内容被包裹在带有 ref 的 span 中,以便正确检测宽度溢出
- **breadcrumb.tsx**: 修正 renderItem 传递,确保使用 props.renderItem 而非本地的 renderItem 函数
- **changelog.cn.md**: 更新版本日志为 3.8.7-beta.4

## Test plan
- [x] 测试 Breadcrumb 设置 max 属性且设置了自定义 renderItem 时,超宽标题能正常显示 Tooltip
- [x] 测试 Breadcrumb 常规使用场景未受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)