### PR TITLE
feat: 增强 setToken 能力，支持设置 "--xxx" cssvar 格式的变量

### DIFF
--- a/docs/markdown/shineout/changelog-common.md
+++ b/docs/markdown/shineout/changelog-common.md
@@ -1,3 +1,9 @@
+## 3.9.0-beta.9
+2025-10-24
+
+### 💎 Enhancement
+- 增强 `setToken` 能力，支持设置 "--xxx" cssvar 格式的变量 ([#1421](https://github.com/sheinsight/shineout-next/pull/1421))
+
 ## 3.8.0-beta.16
 2025-07-08
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.0-beta.8",
+  "version": "3.9.0-beta.9",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/theme/src/utils/token-setter.ts
+++ b/packages/theme/src/utils/token-setter.ts
@@ -89,6 +89,11 @@ const replaceCssVarValue = (innerHTML: string, cssvar: string, targetValue?: str
   return innerHTML.replace(regex, `${cssvar}: ${targetValue};`);
 };
 
+const isCustomToken = (key: string) => {
+  if (key.startsWith('--')) return true;
+  return false;
+};
+
 const setToken = (options?: Options) => {
   const {
     tagName = 'style',
@@ -116,7 +121,7 @@ const setToken = (options?: Options) => {
 
   if (update && token) {
     Object.keys(token).forEach((key: string) => {
-      const cssvar = `--${prefix}-${camelCaseToDash(key)}`;
+      const cssvar = isCustomToken(key) ? key : `--${prefix}-${camelCaseToDash(key)}`;
       const targetValue = token[key as keyof Tokens];
       tag.innerHTML = replaceCssVarValue(tag.innerHTML, cssvar, targetValue);
     });
@@ -128,12 +133,14 @@ const setToken = (options?: Options) => {
     Object.keys(defaultToken)
       .filter((item) => (customExtraToken || ['Brand-6', 'Neutral-6']).includes(item))
       .forEach((key: string) => {
-        const token = `--${prefix}-${camelCaseToDash(key)}:${defaultToken[key as keyof Tokens]}`;
+        const cssvar = isCustomToken(key) ? key : `--${prefix}-${camelCaseToDash(key)}`;
+        const token = `${cssvar}:${defaultToken[key as keyof Tokens]}`;
         tokens.push(token);
       });
   } else {
     Object.keys(defaultToken).forEach((key: string) => {
-      const token = `--${prefix}-${camelCaseToDash(key)}:${defaultToken[key as keyof Tokens]}`;
+      const cssvar = isCustomToken(key) ? key : `--${prefix}-${camelCaseToDash(key)}`;
+      const token = `${cssvar}:${defaultToken[key as keyof Tokens]}`;
       tokens.push(token);
     });
   }
@@ -147,7 +154,7 @@ const setToken = (options?: Options) => {
   tag.setAttribute('data-token', tokenName || '');
   tag.setAttribute('data-token-id', id);
   tag.setAttribute('data-token-selector', selector);
-  
+
   tag.innerHTML = ignoreExtra
     ? `${selector} {${tokens.join(';')}}`
     : `${selector} {${tokens.concat(extraToken).join(';')}}`;


### PR DESCRIPTION
## Summary
- 新增 `isCustomToken` 函数识别自定义 CSS 变量格式（以 "--" 开头）
- 优化 `setToken` 逻辑，支持直接使用 "--xxx" 格式的 token key
- 更新版本至 3.9.0-beta.9
- 更新 changelog

## Test plan
- [x] 测试使用普通 token key（如 `brandColor`）的场景
- [x] 测试使用自定义 CSS 变量格式（如 `--my-custom-var`）的场景
- [x] 测试 `update` 模式下自定义 CSS 变量的更新
- [x] 测试 `onlyExtra` 模式
- [x] 验证构建和类型检查通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)