### PR TITLE
fix: 修复 Breadcrumb 设置 max 大于或等于 data 长度时，末尾多了个斜线的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.7-beta.4",
+  "version": "3.8.7-beta.5",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/breadcrumb/breadcrumb.tsx
+++ b/packages/base/src/breadcrumb/breadcrumb.tsx
@@ -43,12 +43,13 @@ const Breadcrumb = <Item = BreadcrumbDataType,>(props: BreadcrumbProps<Item>) =>
     return [first, more, ...reset];
   };
 
+  const lastIndex = Math.min(data.length - 1, (maxCount !== undefined ? maxCount : data.length - 1));
   return (
     <div className={className} style={props.style}>
       {data &&
         getRenderData().map((d, index) => {
           const itemFirst = Array.isArray(d) ? d[0] : d;
-          const isLastItem = index === (maxCount !== undefined ? maxCount : data.length - 1);
+          const isLastItem = index === lastIndex;
           return (
             <div
               className={breadcrumbClasses?.item}

--- a/packages/shineout/src/breadcrumb/__doc__/changelog.cn.md
+++ b/packages/shineout/src/breadcrumb/__doc__/changelog.cn.md
@@ -1,3 +1,11 @@
+## 3.8.7-beta.5
+2025-10-24
+
+### 🐞 BugFix
+
+- 修复 `Breadcrumb` 设置 `max` 大于或等于 `data` 长度时，末尾多了个斜线的问题 ([#1424](https://github.com/sheinsight/shineout-next/pull/1424))
+
+
 ## 3.8.7-beta.4
 2025-10-17
 


### PR DESCRIPTION
## Summary
- 修复 `Breadcrumb` 设置 `max` 大于或等于 `data` 长度时，末尾多了个斜线的问题
- 将 `isLastItem` 的判断逻辑提取为 `lastIndex` 变量，统一计算最后一项的索引
- 修复当 `max >= data.length` 时，`lastIndex` 计算错误导致多渲染分隔符的问题

## Test plan
- [x] 验证 `Breadcrumb` 设置 `max` 等于 `data.length` 时，末尾没有多余的分隔符
- [x] 验证 `Breadcrumb` 设置 `max` 大于 `data.length` 时，末尾没有多余的分隔符
- [x] 验证 `Breadcrumb` 设置 `max` 小于 `data.length` 时，省略功能正常工作且末尾无分隔符
- [x] 验证 `Breadcrumb` 未设置 `max` 时，正常显示且末尾无分隔符

🤖 Generated with [Claude Code](https://claude.com/claude-code)