### PR TITLE
enhancement: 支持自定义 data 属性透传至对应 DOM 节点

### DIFF
--- a/docs/markdown/shineout/changelog-common.md
+++ b/docs/markdown/shineout/changelog-common.md
@@ -1,3 +1,11 @@
+## 3.8.8-beta.1
+2025-10-27
+
+### 💎 Enhancement
+
+- 支持自定义 data 属性透传至对应 DOM 节点 ([#1429](https://github.com/sheinsight/shineout-next/pull/1429))
+
+
 ## 3.8.0-beta.16
 2025-07-08
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.7",
+  "version": "3.8.8-beta.1",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/carousel/carousel.tsx
+++ b/packages/base/src/carousel/carousel.tsx
@@ -1,4 +1,4 @@
-import { useCarousel } from '@sheinx/hooks';
+import { getDataset, useCarousel } from '@sheinx/hooks';
 import classNames from 'classnames';
 import React from 'react';
 import { CarouselProps } from './carousel.type';
@@ -159,6 +159,7 @@ const Carousel = (props: CarouselProps) => {
       style={{ ...props.style, height: 'auto' }}
       onMouseEnter={func.stop}
       onMouseLeave={func.start}
+      {...getDataset(props)}
     >
       {renderItems()}
       {renderIndicator()}

--- a/packages/base/src/cascader/cascader.tsx
+++ b/packages/base/src/cascader/cascader.tsx
@@ -10,6 +10,7 @@ import {
   UnMatchedData,
   ObjectKey,
   usePrevious,
+  getDataset,
 } from '@sheinx/hooks';
 import { Spin } from '../spin';
 import { AbsoluteList } from '../absolute-list';
@@ -778,6 +779,7 @@ const Cascader = <DataItem, Value extends KeygenResult[]>(
         id={fieldId}
         tabIndex={disabled === true || showInput ? undefined : 0}
         {...util.getDataAttribute({ ['input-border']: 'true' })}
+        {...getDataset(props)}
         className={rootClass}
         style={rootStyle}
         onBlur={handleBlur}

--- a/packages/base/src/checkbox/simple-checkbox.tsx
+++ b/packages/base/src/checkbox/simple-checkbox.tsx
@@ -1,4 +1,4 @@
-import { useCheck, util } from '@sheinx/hooks';
+import { getDataset, useCheck, util } from '@sheinx/hooks';
 import classNames from 'classnames';
 import React, { useContext } from 'react';
 import { SimpleCheckboxProps } from './checkbox.type';
@@ -42,6 +42,7 @@ const Checkbox = (props: SimpleCheckboxProps) => {
         style,
         needStopPropagation: props.needStopPropagation,
       })}
+      {...getDataset(props)}
     >
       <input {...inputProps} type='checkbox' />
       <span className={indicatorClass}>

--- a/packages/base/src/date-picker/date-picker.tsx
+++ b/packages/base/src/date-picker/date-picker.tsx
@@ -1,4 +1,4 @@
-import { useDatePickerFormat, useInputAble, usePersistFn, usePopup, util } from '@sheinx/hooks';
+import { getDataset, useDatePickerFormat, useInputAble, usePersistFn, usePopup, util } from '@sheinx/hooks';
 import classNames from 'classnames';
 import { AbsoluteList } from '../absolute-list';
 import React, { useEffect, useRef } from 'react';
@@ -288,6 +288,7 @@ const DatePicker = <Value extends DatePickerValueType>(props0: DatePickerProps<V
   return (
     <div
       {...util.getDataAttribute({ ['input-border']: 'true', type })}
+      {...getDataset(props)}
       className={classNames(
         props.className,
         styles?.rootClass,

--- a/packages/base/src/dropdown/dropdownIn.tsx
+++ b/packages/base/src/dropdown/dropdownIn.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Button from '../button';
 import { DropdownNode, MenuPosition, SimpleDropdownProps } from './dropdown.type';
-import { usePopup, util } from '@sheinx/hooks';
+import { getDataset, usePopup, util } from '@sheinx/hooks';
 import AnimationList from '../animation-list';
 import AbsoluteList from '../absolute-list';
 import Icons from '../icons';
@@ -206,6 +206,7 @@ const Dropdown = (props: SimpleDropdownProps) => {
       data-role='dropdown'
       ref={targetRef}
       {...targetProps}
+      {...getDataset(props)}
       onClick={isSub ? openPop : targetProps.onClick}
     >
       {renderButton()}

--- a/packages/base/src/input/input.tsx
+++ b/packages/base/src/input/input.tsx
@@ -6,6 +6,7 @@ import { useConfig } from '../config';
 import React from 'react';
 
 const Input = (props: InputProps) => {
+
   const commonProps = useInputCommon<InputProps['value'], InputProps>(props);
   const config = useConfig();
   const inputFormatParams = {

--- a/packages/base/src/input/simple-input.tsx
+++ b/packages/base/src/input/simple-input.tsx
@@ -1,4 +1,4 @@
-import { useInput, useKeyEvent, usePersistFn, util } from '@sheinx/hooks';
+import { getDataset, useInput, useKeyEvent, usePersistFn, util } from '@sheinx/hooks';
 import classNames from 'classnames';
 import React, { KeyboardEvent, useContext, useRef } from 'react';
 import { SimpleInputProps } from './input.type';
@@ -73,7 +73,8 @@ const Input = (props: SimpleInputProps) => {
     onKeyUp,
   });
 
-  const inputElProps = util.removeProps(inputProps, { formName: undefined })
+  const datasetProps = getDataset(props);
+  const inputElProps = util.removeProps(inputProps, { formName: undefined, ...datasetProps })
   let inputEl = <input type='text' {...inputElProps} />;
 
   if (typeof renderInput === 'function') {
@@ -100,6 +101,7 @@ const Input = (props: SimpleInputProps) => {
     <div
       id={fieldId}
       {...util.getDataAttribute({ ['input-border']: 'true' })}
+      {...datasetProps}
       {...getRootProps({
         className: rootClass,
         style,

--- a/packages/base/src/pagination/pagination.tsx
+++ b/packages/base/src/pagination/pagination.tsx
@@ -3,7 +3,7 @@ import List from './pagination-size-list';
 import Jumper from './pagination-jumper';
 import Buttons from './pagination-buttons';
 import Simple from './pagination-simple';
-import { usePagination, util } from '@sheinx/hooks';
+import { getDataset, usePagination, util } from '@sheinx/hooks';
 import { PaginationProps } from './pagination.type';
 
 const { devUseWarning } = util;
@@ -82,7 +82,7 @@ const Pagination = (props: PaginationProps) => {
   }
 
   return (
-    <div {...getRootProps()} className={rootClasses}>
+    <div {...getRootProps()} {...getDataset(props)} className={rootClasses}>
       {layout.map((section, i) => {
         switch (section) {
           case 'links':

--- a/packages/base/src/rate/rate.tsx
+++ b/packages/base/src/rate/rate.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import React, { useContext, useState } from 'react';
 import { RateProps } from './rate.type';
 import Icons from '../icons';
-import { useInputAble } from '@sheinx/hooks';
+import { getDataset, useInputAble } from '@sheinx/hooks';
 import useWithFormConfig from '../common/use-with-form-config';
 import { useConfig } from '../config';
 import { FormFieldContext } from '../form/form-field-context';
@@ -125,6 +125,7 @@ const Rate = (props0: RateProps) => {
       onMouseLeave={() => {
         setHoverValue(null);
       }}
+      {...getDataset(props)}
     >
       <div className={rateClasses?.inner}>
         {Array.from({ length: max }).map((_, index) => {

--- a/packages/base/src/select/select.tsx
+++ b/packages/base/src/select/select.tsx
@@ -11,6 +11,7 @@ import {
   ObjectKey,
   useTiled,
   KeygenResult,
+  getDataset,
 } from '@sheinx/hooks';
 import { SelectClasses } from './select.type';
 import { SelectPropsBase, OptionListRefType } from './select.type';
@@ -774,6 +775,7 @@ function Select<DataItem, Value>(props0: SelectPropsBase<DataItem, Value>) {
         ref={targetRef}
         tabIndex={disabled === true || showInput ? undefined : 0}
         {...util.getDataAttribute({ ['input-border']: 'true' })}
+        {...getDataset(props)}
         className={rootClass}
         style={rootStyle}
         onKeyDown={handleKeyDown}

--- a/packages/base/src/tag/tag.tsx
+++ b/packages/base/src/tag/tag.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import Icons from '../icons';
 import { TagClasses, TagProps } from './tag.type';
 import useTag from './use-tag';
-import { util } from '@sheinx/hooks';
+import { getDataset, util } from '@sheinx/hooks';
 import TagInput from './tag-input';
 
 const { devUseWarning } = util;
@@ -138,7 +138,7 @@ const Tag = (props: TagProps) => {
   }
 
   return (
-    <div {...getTagRootProps()}>
+    <div {...getTagRootProps()} {...getDataset(props)}>
       {renderChildren()}
       {renderClose()}
     </div>

--- a/packages/base/src/textarea/simple-textarea.tsx
+++ b/packages/base/src/textarea/simple-textarea.tsx
@@ -1,4 +1,4 @@
-import { useKeyEvent, usePersistFn, useTextarea, util } from '@sheinx/hooks';
+import { getDataset, useKeyEvent, usePersistFn, useTextarea, util } from '@sheinx/hooks';
 import classNames from 'classnames';
 import React, { KeyboardEvent, useContext, useEffect } from 'react';
 import { SimpleTextareaProps } from './textarea.type';
@@ -105,6 +105,7 @@ const Textarea = (props: SimpleTextareaProps) => {
     <div
       id={fieldId}
       {...util.getDataAttribute({ ['input-border']: 'true' })}
+      {...getDataset(props)}
       {...getRootProps({
         className: rootClass,
         style,

--- a/packages/base/src/transfer/transfer.tsx
+++ b/packages/base/src/transfer/transfer.tsx
@@ -2,7 +2,7 @@ import { useContext, useMemo } from 'react';
 import classNames from 'classnames';
 import { TransferProps } from './transfer.type';
 import { TransferClasses } from './transfer.type';
-import { TransferContext, useTransfer, TransferListType, KeygenResult, util } from '@sheinx/hooks';
+import { TransferContext, useTransfer, TransferListType, KeygenResult, util, getDataset } from '@sheinx/hooks';
 import TransferList from './transfer-list';
 import TransferOperate from './transfer-operate';
 import Icon from '../icons';
@@ -199,7 +199,7 @@ const Transfer = <DataItem, Value extends KeygenResult[]>(
 
   return (
     <TransferContext.Provider value={{ filterSourceText, filterTargetText, highlight: props.highlight }}>
-      <div className={rootClass} style={style} id={fieldId}>
+      <div className={rootClass} style={style} id={fieldId} {...getDataset(props)}>
         {renderSourceList}
         {!simple && renderOperations()}
         {renderTargetList}

--- a/packages/base/src/tree-select/tree-select.tsx
+++ b/packages/base/src/tree-select/tree-select.tsx
@@ -9,6 +9,7 @@ import {
   UnMatchedData,
   KeygenResult,
   useTree,
+  getDataset,
 } from '@sheinx/hooks';
 import classNames from 'classnames';
 import { TreeSelectProps, ResultItem } from './tree-select.type';
@@ -733,6 +734,7 @@ const TreeSelect = <DataItem, Value extends TreeSelectValueType>(
         ref={targetRef}
         tabIndex={disabled === true || showInput ? undefined : 0}
         {...util.getDataAttribute({ ['input-border']: 'true' })}
+        {...getDataset(props)}
         className={rootClass}
         style={rootStyle}
         onBlur={handleBlur}

--- a/packages/base/src/upload/upload.tsx
+++ b/packages/base/src/upload/upload.tsx
@@ -1,4 +1,4 @@
-import { useInputAble, usePersistFn, useUpload, util } from '@sheinx/hooks';
+import { getDataset, useInputAble, usePersistFn, useUpload, util } from '@sheinx/hooks';
 import React, { useContext, useEffect } from 'react';
 import { UploadProps } from './upload.type';
 import Drop from './drop';
@@ -247,6 +247,7 @@ const Upload = <T,>(props0: UploadProps<T>) => {
         props.disabled && uploadClasses?.wrapperDisabled,
         props.className,
       )}
+      {...getDataset(props)}
     >
       {renderCustomResult ? (
         <>

--- a/packages/hooks/src/utils/dom/get-dataset.ts
+++ b/packages/hooks/src/utils/dom/get-dataset.ts
@@ -1,0 +1,12 @@
+export const getDataset = <T extends {}>(props?: T) => {
+  if (!props) return {}
+  const dataset: { [key: string]: T[keyof T] } = {}
+  const keys = Object.keys(props) as Array<keyof T>
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i] as string
+    if (key.startsWith('data-')) {
+      dataset[key] = props[keys[i]]
+    }
+  }
+  return dataset
+}

--- a/packages/hooks/src/utils/dom/index.ts
+++ b/packages/hooks/src/utils/dom/index.ts
@@ -4,6 +4,7 @@ export type { OldWheelEvent } from './normalize-wheel.type';
 export * from './ready';
 export * from './element';
 export * from './document';
+export * from './get-dataset';
 
 export { default as ResponsiveObserve } from './responsiveObserve';
 export type { Breakpoint, ScreenMap } from './responsiveObserve.type';


### PR DESCRIPTION
## Summary
支持自定义 data 属性透传至对应 DOM 节点，提升组件的可扩展性和可测试性。

## Changes
- 新增 `getDataset` 工具函数，用于从 props 中提取所有 `data-*` 属性
- 优化 `getDataset` 性能，使用 `Object.keys` 和 `startsWith` 替代 `for-in` 和 `indexOf`
- 为以下组件添加 data 属性透传支持：
  - Carousel
  - Cascader
  - Checkbox
  - DatePicker
  - Dropdown
  - Input
  - Pagination
  - Rate
  - Select
  - Tag
  - Textarea
  - Transfer
  - TreeSelect
  - Upload

## Test plan
- [x] 验证各组件能够正确透传 `data-*` 属性到根 DOM 节点
- [x] 测试性能优化后的 `getDataset` 函数运行正常
- [x] 确保现有功能不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)