### PR TITLE
fix(rule): 修复内置校验规则的 Error.message 未跟随国际化显示的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.8-beta.2",
+  "version": "3.8.8-beta.3",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/utils/rule/required.ts
+++ b/packages/hooks/src/utils/rule/required.ts
@@ -1,12 +1,14 @@
+import { getLocale, config } from '@sheinx/base';
 import { deepMerge } from '../object';
 import { ObjectType } from '../../common/type';
 import { MessageType } from './rule.type';
+import { substitute } from '../string';
 
 const options = { skipUndefined: true };
 
 export const requiredMessage = (props: ObjectType) => {
   const type = props.type === 'array' ? 'array' : 'string';
-  return `$rules.required.${type}`;
+  return substitute(getLocale(config.locale, `rules.required.${type}`), props)
 };
 export default ({ message }: { message?: MessageType } = {}) =>
   (msg: MessageType) =>

--- a/packages/hooks/tsconfig.json
+++ b/packages/hooks/tsconfig.json
@@ -7,6 +7,7 @@
     "sourceMap": true,
     "baseUrl": "./",
     "paths": {
+      "@sheinx/base": ["../base/src/index"],
       "@sheinx/hooks": ["./src/index"],
     }
   }

--- a/packages/shineout/src/rule/__doc__/changelog.cn.md
+++ b/packages/shineout/src/rule/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.8.8-beta.3
+2025-10-29
+
+### 🐞 BugFix
+
+- 修复 `Rule` 内置校验规则的Error.message 未跟随国际化显示的问题 ([#1433](https://github.com/sheinsight/shineout-next/pull/1433))
+
 ## 3.7.0-beta.43
 2025-06-04
 


### PR DESCRIPTION
## Summary

- 修复了 `Rule` 组件中内置校验规则的 `Error.message` 未能正确跟随国际化配置显示的问题
- 更新了 `required` 规则以使用 `getLocale` 和 `substitute` 函数来生成国际化的错误消息
- 在 `packages/hooks/tsconfig.json` 中添加了 `@sheinx/base` 路径映射
- 更新版本号至 `3.8.8-beta.3`
- 更新了 changelog 文档

## Test plan

- [x] 验证必填项校验在不同语言环境下显示正确的错误消息
- [x] 确认数组类型和字符串类型的必填校验都正常工作
- [x] 检查国际化切换时错误消息能够正确更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)