### PR TITLE
fix(table): 修复设置的 rowsInView 偏小时容器底部有空白的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.8-beta.4",
+  "version": "3.8.8-beta.5",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-table/use-table-virtual.tsx
+++ b/packages/hooks/src/components/use-table/use-table-virtual.tsx
@@ -313,7 +313,7 @@ const useTableVirtual = (props: UseTableVirtualProps) => {
         context.autoAddRows = addonCount;
       }
     }
-  }, []);
+  }, [props.data.length]);
 
   useEffect(() => {
     // 记录preIndex

--- a/packages/shineout/src/table/__doc__/changelog.cn.md
+++ b/packages/shineout/src/table/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.8.8-beta.5
+2025-10-29
+
+### 🐞 BugFix
+- 修复 `Table` 设置的 `rowsInView` 偏小时容器底部有空白的问题 ([#1435](https://github.com/sheinsight/shineout-next/pull/1435))
+
+
 ## 3.8.7-beta.2
 2025-10-15
 


### PR DESCRIPTION
## Summary

- 修复了 `Table` 组件在设置较小的 `rowsInView` 值时,容器底部出现空白的问题
- 将 `useTableVirtual` 中计算 `autoAddRows` 的 `useEffect` 依赖从空数组 `[]` 改为 `[props.data.length]`
- 确保在数据长度变化时能够正确重新计算需要额外添加的行数
- 更新版本号至 `3.8.8-beta.5`
- 更新了 changelog 文档

## Test plan

- [x] 验证 Table 组件设置较小的 rowsInView 值时底部没有空白
- [x] 确认数据动态变化时表格能够正确重新渲染
- [x] 检查虚拟滚动功能正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)