### PR TITLE
fix(form): add type assertion for defaultValue parameter

### DIFF
--- a/packages/base/src/form/form.tsx
+++ b/packages/base/src/form/form.tsx
@@ -17,7 +17,7 @@ const Form = <V extends ObjectType>(props: FormProps<V>) => {
   const inputAbleParams = {
     value: props.value,
     onChange: props.onChange,
-    defaultValue: props.defaultValue,
+    defaultValue: props.defaultValue as V | undefined,
     control: isControl,
     beforeChange: undefined,
     reserveAble: false,


### PR DESCRIPTION
## Summary
- Fixed TypeScript build error in Form component by adding explicit type assertion for `defaultValue` parameter
- Changed `defaultValue: props.defaultValue` to `defaultValue: props.defaultValue as V | undefined`

## Related Issue
Resolves TypeScript compilation error when passing defaultValue to inputAbleParams

## Test Plan
- [x] Verify TypeScript build passes without errors
- [x] Ensure Form component functionality remains unchanged
- [x] Test Form with defaultValue prop to confirm type safety

🤖 Generated with [Claude Code](https://claude.com/claude-code)