### PR TITLE
fix(tabs): 修复垂直方向上由 --soui-tabs-badge-margin 引入的 marginTop 样式冲突

### DIFF
--- a/packages/shineout-style/src/tabs/tabs.ts
+++ b/packages/shineout-style/src/tabs/tabs.ts
@@ -346,10 +346,12 @@ const tabsStyle: JsStyles<keyof TabsClasses> = {
       '& $tab': {
         display: 'block',
       },
-      '& $tab + $tab': {
+      '&& $tab + $tab': {
         marginTop: Token.tabsNearlyMargin,
       },
       '& $next,& $prev': {
+        // 考虑垂直方向可滚动功能时一并修复zIndex
+        // zIndex: 1,
         padding: `${Token.tabsActionVerticalPaddingY} ${Token.tabsActionVerticalPaddingX}`,
         '&:after': {
           display: 'none',


### PR DESCRIPTION
## Summary
- 修复了垂直方向（left/right）tabs 在使用 `--soui-tabs-badge-margin` feature 时引入的 marginTop 样式冲突问题
- 通过增加选择器权重（`&& $tab + $tab`）来确保垂直方向上的 tab 间距样式能够正确应用

## Changes
- 将 `& $tab + $tab` 选择器修改为 `&& $tab + $tab`，增加选择器权重以避免与其他样式规则冲突

## Test plan
- [x] 验证垂直方向（position="left" 和 position="right"）tabs 的 marginTop 样式是否正确应用
- [x] 确认不同 shape 类型（line、card、fill、button、dash）下的垂直 tabs 样式正常
- [x] 检查水平方向 tabs 未受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)