### PR TITLE
fix(input): show error border color when disabled and validation fails

### DIFF
--- a/packages/shineout-style/src/input/input-border.ts
+++ b/packages/shineout-style/src/input/input-border.ts
@@ -178,8 +178,10 @@ export default <T extends string>(name: T, token: Token = {} as any) => {
       },
     } as CSSProperties,
     [`${name}Error`]: {
-      [`&:not($${name}Disabled)`]: {
+      '&&': {
         borderColor: token.errorBorderColor,
+      },
+      [`&:not($${name}Disabled)`]: {
         background: token.errorBackgroundColor,
         '&:hover': {
           borderColor: token.errorHoverBorderColor,
@@ -201,7 +203,7 @@ export default <T extends string>(name: T, token: Token = {} as any) => {
       borderColor: token.disabledBorderColor,
       boxShadow: 'none',
       cursor: 'not-allowed',
-      '&:hover': {
+      [`&:not($${name}Error):hover`]: {
         borderColor: token.disabledBorderColor,
       },
       '& *': {


### PR DESCRIPTION
## Summary
- Fix input border color priority when form item is both disabled and has validation errors
- Error border color now takes precedence over disabled border color for better visual feedback
- Error background color remains only for enabled state

## Changes
- Apply error border color (`borderColor: token.errorBorderColor`) to both disabled and enabled states using `&&` selector
- Keep error background color only for non-disabled state
- Update disabled hover style to not override error border color using `:not($${name}Error)` selector

## Test plan
- [x] Test input with validation error in enabled state - should show red border and background
- [x] Test input with validation error in disabled state - should show red border but no error background
- [x] Test disabled input without validation error - should show normal disabled gray border
- [x] Test hover behavior on disabled inputs with and without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)