### PR TITLE
fix: 修复getDefaultContainer中config在某些情况下获取不到

### DIFF
--- a/packages/base/src/config/index.ts
+++ b/packages/base/src/config/index.ts
@@ -73,6 +73,8 @@ state.subscribe(() => {
 });
 
 export function getDefaultContainer() {
+  const config = state.mutate;
+
   if (util.isFunc(config.popupContainer)) {
     const container = config.popupContainer();
     if (util.isDomElement(container)) {


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information       | Descriptions|
| -------------- | -------------------- |
| Browser   | Chrome / Safari / |
| Version   | Chrome 49 ... |
| OS       | MacOS / Windows ... |

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### Changelog

<!-- - Fix `Component` ... -->

### Playground id

### Other information

使用plasmo框架开发浏览器插件的时候，出现设置了setConfig导致 getDefaultContainer获取全局config时为undefined
复现demo：https://github.com/GaryHjy/plasmo-shineout