### PR TITLE
feat(table): 增强筛选功能，支持树形数据

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.0-beta.19",
+  "version": "3.9.0-beta.20",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/table/table.tsx
+++ b/packages/base/src/table/table.tsx
@@ -147,6 +147,7 @@ export default function Table<Item, Value>(props: TableProps<Item, Value>) {
   });
 
   const { filteredData, filterInfo, onFilterChange } = useTableFilter<Item>({
+    keygen: props.keygen,
     data: props.data,
     columns: props.columns,
   });

--- a/packages/shineout/src/table/__doc__/changelog.cn.md
+++ b/packages/shineout/src/table/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.9.0-beta.20
+2025-11-06
+
+### 💎 Enhancement
+- 增强 `Table` 的筛选功能：支持树形数据 ([#1452](https://github.com/sheinsight/shineout-next/pull/1452))
+
 ## 3.9.0-beta.16
 2025-10-31
 


### PR DESCRIPTION
## Summary
- 增强 `Table` 组件的筛选功能，支持树形数据结构
- 使用 `getFilterTree` 方法替代原有的数组 `filter`，实现树形数据的递归过滤
- 添加 `keygen` 属性传递，确保树形节点的唯一标识
- 支持 `treeColumnsName` 配置的树形列筛选场景

## 技术细节
1. **更新 `useTableFilter` hook**：
   - 引入 `getFilterTree` 和 `getKey` 工具函数
   - 添加 `keygen` 到接口类型定义
   - 检测列配置中是否存在 `treeColumnsName`
   - 使用 `getFilterTree` 进行树形数据的递归过滤

2. **更新 `Table` 组件**：
   - 传递 `keygen` 属性到 `useTableFilter` hook

3. **版本更新**：
   - 版本号升级至 `3.9.0-beta.20`
   - 更新 changelog 文档

## Test plan
- [ ] 测试普通平铺数据的筛选功能是否正常
- [ ] 测试树形数据的筛选功能，验证父子节点的过滤逻辑
- [ ] 测试多个筛选条件同时激活的场景
- [ ] 验证筛选后的数据结构完整性

🤖 Generated with [Claude Code](https://claude.com/claude-code)