### PR TITLE
fix(select): fix issue where renderItem returning 0 does not display in multiple mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.10-beta.1",
+  "version": "3.8.10-beta.2",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/select/list.tsx
+++ b/packages/base/src/select/list.tsx
@@ -6,6 +6,7 @@ import { VirtualScrollList } from '../virtual-scroll';
 import ListOption from './list-option';
 import { VirtualListType } from '../virtual-scroll/virtual-scroll-list.type';
 
+export const defaultRenderItem = <DataItem,>(d: DataItem) => d as unknown as React.ReactNode;
 const List = <DataItem, Value>(props: BaseListProps<DataItem, Value>) => {
   const {
     jssStyle,
@@ -23,7 +24,7 @@ const List = <DataItem, Value>(props: BaseListProps<DataItem, Value>) => {
     hideCreateOption,
     optionListRef,
     isAnimationFinish,
-    renderItem: renderItemProp = (d) => d as React.ReactNode,
+    renderItem: renderItemProp = defaultRenderItem,
     closePop,
     onControlTypeChange,
     onOptionClick,

--- a/packages/base/src/select/result.tsx
+++ b/packages/base/src/select/result.tsx
@@ -201,7 +201,7 @@ const Result = <DataItem, Value>(props: ResultProps<DataItem, Value>) => {
 
     const content = renderResultContent(item, index, nodes);
 
-    if (!content) return null;
+    if (!content && content !== 0) return null;
 
     if (renderResultContentProp) {
       // cascader 不渲染tag

--- a/packages/base/src/select/select.tsx
+++ b/packages/base/src/select/select.tsx
@@ -20,7 +20,7 @@ import useInnerTitle from '../common/use-inner-title';
 import AnimationList from '../animation-list';
 import Spin from '../spin';
 import Result from './result';
-import List from './list';
+import List, { defaultRenderItem } from './list';
 import TreeList from './list-tree';
 import Icons from '../icons';
 import ColumnsList from './list-columns';
@@ -79,7 +79,7 @@ function Select<DataItem, Value>(props0: SelectPropsBase<DataItem, Value>) {
     emptyAfterSelect,
     autoAdapt,
     groupBy,
-    renderItem: renderItemProp = (d) => d as ReactNode,
+    renderItem: renderItemProp = defaultRenderItem,
     renderResult: renderResultProp,
     renderUnmatched,
     resultClassName,
@@ -329,7 +329,7 @@ function Select<DataItem, Value>(props0: SelectPropsBase<DataItem, Value>) {
   const getRenderItem = (data: DataItem, index?: number): ReactNode => {
     return typeof renderItemProp === 'function'
       ? renderItemProp(data, index)
-      : ((data?.[renderItemProp] || '') as ReactNode);
+      : ((data?.[renderItemProp] ?? '') as ReactNode);
   };
 
   const renderItem = getRenderItem;

--- a/packages/shineout/src/select/__doc__/changelog.cn.md
+++ b/packages/shineout/src/select/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.8.10-beta.2
+2025-11-13
+
+### 🐞 BugFix
+
+- 修复 `Select` 多选模式下，`renderItem` 返回的是数字0时不回显的问题 ([#1460](https://github.com/sheinsight/shineout-next/pull/1460))
+
 ## 3.8.9-beta.3
 2025-11-05
 


### PR DESCRIPTION
## Summary

修复 Select 多选模式下，renderItem 返回数字 0 时不回显的问题

## Root Cause

数字 0 是 JavaScript 中的 falsy 值，在以下两个地方被错误处理：

1. **result.tsx:204** - 使用 `if (!content)` 判断时，数字 0 被错误地当作空值过滤掉
2. **select.tsx:332** - 使用 `||` 运算符时，数字 0 被错误地替换为默认值 `''`

## Changes

### 核心修复

1. **packages/base/src/select/result.tsx**
   - 修改空值判断逻辑: `if (!content && content !== 0)` 
   - 显式排除数字 0，确保其能够正常渲染

2. **packages/base/src/select/select.tsx**
   - 使用空值合并运算符 `??` 替代 `||`
   - 确保 0、false 等有效值不被错误替换为默认值

### 代码优化

3. **packages/base/src/select/list.tsx & select.tsx**
   - 提取 `defaultRenderItem` 函数，避免每次渲染时重新创建
   - 提高代码复用性和性能

## Test Case

```tsx
<Select
  multiple
  data={[{value: 0}, {value: 1}]}
  keygen="value"
  format="value"
  renderItem="value"
  value={[0]}  // 现在可以正确显示 '0'
/>
```

## Impact

- ✅ 修复了数字 0 无法回显的 bug
- ✅ 同时修复了其他 falsy 值（如 false）的潜在问题
- ✅ 提升了代码质量和性能

## Playground ID
0e80a559-4153-4614-a34b-7895014ba1ce

🤖 Generated with [Claude Code](https://claude.com/claude-code)