### PR TITLE
fix(cascader): fix issue where parent nodes cannot be checked with loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.10-beta.2",
+  "version": "3.8.10-beta.3",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/cascader/node.tsx
+++ b/packages/base/src/cascader/node.tsx
@@ -107,6 +107,8 @@ const CascaderNode = <DataItem, Value extends KeygenResult[]>(
         handleSelect(e);
       }
       hasHandleSelectRef.current = true;
+    } else {
+      hasHandleSelectRef.current = false;
     }
     return events;
   };

--- a/packages/shineout/src/cascader/__doc__/changelog.cn.md
+++ b/packages/shineout/src/cascader/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.8.10-beta.3
+2025-11-13
+
+### 🐞 BugFix
+- 修复 `Cascader` 动态加载场景父级节点无法勾选的问题 （Regression: since v3.7.5）([#1461](https://github.com/sheinsight/shineout-next/pull/1461))
+
 ## 3.8.6-beta.7
 2025-10-13
 


### PR DESCRIPTION
## Summary
- 修复 Cascader 动态加载场景下父级节点无法勾选的问题
- 回归版本: since v3.7.5

## Root Cause
在 `getEvents` 函数中，`hasHandleSelectRef.current` 标志位在某些条件分支中被设置为 `true`，但当条件不满足时没有被重置为 `false`，导致在动态加载场景中父级节点的状态不正确。

## Changes
在 `packages/base/src/cascader/node.tsx` 的 `getEvents` 函数中添加 `else` 分支，显式将 `hasHandleSelectRef.current` 重置为 `false`。

## Test Plan
- [x] 测试动态加载场景下父级节点可以正常勾选
- [x] 测试非动态加载场景功能正常
- [x] 手动验证多个场景无问题
- [x] 更新 changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)