### PR TITLE
fix(table): 修复祖先元素 display 切换导致滚动位置丢失的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.0-beta.25",
+  "version": "3.9.0-beta.26",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout/src/table/__doc__/changelog.cn.md
+++ b/packages/shineout/src/table/__doc__/changelog.cn.md
@@ -1,8 +1,8 @@
-## 3.9.0-beta.22
-2025-11-10
+## 3.9.0-beta.26
+2025-11-14
 
 ### 🐞 BugFix
-- 修复 `Table` 父容器从display:none切换回来时，之前的滚动条位置没有保持住的问题 ([#1455](https://github.com/sheinsight/shineout-next/pull/1455))
+- 修复 `Table` 的祖先元素从display:none切换回来时，之前的滚动条位置没有保持住的问题 ([#1455](https://github.com/sheinsight/shineout-next/pull/1455))([#1463](https://github.com/sheinsight/shineout-next/pull/1463))
 
 ## 3.9.0-beta.20
 2025-11-06


### PR DESCRIPTION
## Summary
修复 Table 组件在祖先元素 `display` 在 `none` 和 `block` 之间切换时,滚动条位置丢失的问题。

## 问题描述
当 Table 的祖先容器(可能嵌套多层 flex)的 `display` 从 `none` 切换回 `block` 时,滚动容器的滚动位置会被重置,导致用户体验不佳。

## 解决方案
- 使用 `useEffect` 监听容器的可见性变化
- 当容器从可见变为不可见时,将容器的 `height` 从 `100%` 设置为固定的像素值(如 `400px`)
- 当容器从不可见变为可见时,恢复 `height` 为 `100%`
- 通过保持容器的固定高度,防止滚动位置被浏览器重置

## 技术细节
- 改用 `useEffect` 替代 `useLayoutEffect`,避免阻塞渲染,提升性能
- 使用 `data-was-hidden` 属性标记容器的隐藏状态
- 只对 `height: 100%` 的场景生效,避免影响其他布局方式

## Test plan
- [x] 测试 Table 在多层 flex 嵌套场景下的显示/隐藏切换
- [x] 验证滚动位置在切换后保持不变
- [x] 确认性能没有明显下降

🤖 Generated with [Claude Code](https://claude.com/claude-code)