### PR TITLE
fix(descriptions): fix layout issue when all values are empty in horizontal mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.10-beta.3",
+  "version": "3.8.10-beta.4",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/descriptions/descriptions.ts
+++ b/packages/shineout-style/src/descriptions/descriptions.ts
@@ -102,6 +102,9 @@ const descriptionsStyle: JsStyles<DescriptionsClassType> = {
     '& $label': {
       width: '1px',
     },
+    '& $value:empty': {
+      width: '1px',
+    },
   },
   vertical: {
     '& $label': {

--- a/packages/shineout/src/descriptions/__doc__/changelog.cn.md
+++ b/packages/shineout/src/descriptions/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.8.10-beta.4
+2025-11-14
+
+### 🐞 BugFix
+- 修复 `Descriptions` 的 horizontal 排列方式时所有子项的value都为空时的布局样式问题 ([#1464](https://github.com/sheinsight/shineout-next/pull/1464))
+
+
 ## 3.8.10-beta.1
 2025-11-12
 


### PR DESCRIPTION
## Summary
- Fixed layout style issue in Descriptions component when all child item values are empty in horizontal arrangement mode
- Added width constraint for empty value cells to prevent layout breaking

## Changes
- Updated `packages/shineout-style/src/descriptions/descriptions.ts` to add `width: '1px'` style for empty value cells in horizontal mode
- Bumped version to 3.8.10-beta.4
- Updated changelog

## Test plan
- [x] Verify Descriptions component layout when all values are empty in horizontal mode
- [x] Check that normal Descriptions with values still render correctly
- [x] Ensure no regression in vertical mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)