### PR TITLE
修复 DatePicker 的 selNow 在异步 onChange 场景下触发两次的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.8.10-beta.4",
+  "version": "3.8.10-beta.5",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/date-picker/day.tsx
+++ b/packages/base/src/date-picker/day.tsx
@@ -53,7 +53,7 @@ const Day = (props: DayProps) => {
     props.setCurrent(new Date(), areaType);
     props.onChange(new Date(), props.needConfirm || props.type === 'datetime');
     setTimeout(() => {
-      if (props.closeByConfirm && !props.range) props.closeByConfirm();
+      if (props.needConfirm && props.closeByConfirm && !props.range) props.closeByConfirm();
     }, 0);
   };
 

--- a/packages/shineout/src/date-picker/__doc__/changelog.cn.md
+++ b/packages/shineout/src/date-picker/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.8.10-beta.5
+2025-11-17
+
+### 🐞 BugFix
+- 修复 `DatePicker` 的 `selNow` 在异步的 `onChange` 赋值场景下触发两次的问题 ([#1466](https://github.com/sheinsight/shineout-next/pull/1466))
+
+
 ## 3.8.5-beta.5
 2025-09-30
 


### PR DESCRIPTION
## Summary
- 修复 DatePicker 的 `selNow` 按钮在异步 onChange 赋值场景下触发两次回调的问题
- 添加条件判断,仅在 `needConfirm` 为 true 时才调用 `closeByConfirm`
- 更新版本号至 3.8.10-beta.5

## Test plan
- [x] 测试 DatePicker 在异步 onChange 场景下点击"此刻"按钮
- [x] 验证点击"此刻"按钮时 onChange 只触发一次
- [x] 确保 DatePicker 正常功能不受影响
- [x] 验证修复对 datetime 和 date 类型都有效

## Playground ID
c72f76b7-c514-42f1-bcd9-d8e0c512f5ed

🤖 Generated with [Claude Code](https://claude.com/claude-code)