### PR TITLE
fix(input): resolve onChange trigger issue when delay is set to 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.1-beta.3",
+  "version": "3.9.1-beta.4",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/common/use-input-able/use-Input-able.ts
+++ b/packages/hooks/src/common/use-input-able/use-Input-able.ts
@@ -69,15 +69,15 @@ export default function useInputAble<T, V extends ChangeType<T>>(props: InputAbl
 
     if (!isFunc(onChange)) return;
 
-    context.delayChange = () => {
-      context.timer = null;
-      context.delayChange = null;
-      onChange(vv, ...other);
-      render();
-    };
     if (!delay) {
       onChange(vv, ...other);
     } else {
+      context.delayChange = () => {
+        context.timer = null;
+        context.delayChange = null;
+        onChange(vv, ...other);
+        render();
+      };
       if (context.timer) clearTimeout(context.timer);
       context.timer = setTimeout(context.delayChange, delay);
     }

--- a/packages/shineout/src/input/__doc__/changelog.cn.md
+++ b/packages/shineout/src/input/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.9.1-beta.4
+2025-11-26
+
+### 🐞 BugFix
+- 修复 `Input` 设置了 `delay` 为0后，失焦时触发了 `onChange` 的问题 ([#1487](https://github.com/sheinsight/shineout-next/pull/1487))
+
+
 ## 3.9.0-beta.4
 2025-10-14
 


### PR DESCRIPTION
## Summary
- Fixed a bug where Input component with `delay=0` would still trigger `onChange` on blur
- The `delayChange` function is now only initialized when delay is actually set

## Changes
- Modified `use-Input-able.ts` to only create `delayChange` function when delay is set
- Updated version to 3.9.1-beta.4
- Added changelog entry

## Test plan
- [x] Verify that Input with `delay=0` does not trigger onChange on blur
- [x] Verify that Input with `delay > 0` still works correctly with delayed onChange
- [x] Verify that Input without delay prop works as expected

## Playground ID
fb9dedbd-0b28-4a73-9c4f-415c26d6a786

🤖 Generated with [Claude Code](https://claude.com/claude-code)