### PR TITLE
fix(hooks): 将 @sheinx/base 移至 peerDependencies

### DIFF
--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -24,6 +24,7 @@
     "immer": "10.0.2"
   },
   "peerDependencies": {
+    "@sheinx/base": ">=3.0.0",
     "react": ">=16.14.0",
     "react-dom": ">=16.14.0",
     "core-js": ">=3"


### PR DESCRIPTION
## Summary
- 修复用户反馈的 "Can't resolve '@sheinx/base'" 问题
- `@sheinx/hooks` 的 `required.ts` 引用了 `@sheinx/base`,但未在 package.json 中声明依赖

## Changes
- 将 `@sheinx/base` 声明为 peerDependencies
- 避免作为 dependencies 时与 base 包形成循环依赖
- 用户使用 `@sheinx/hooks` 时需要同时安装 `@sheinx/base`

## Technical Details
**循环依赖情况:**
- `@sheinx/hooks` 引用 `@sheinx/base` (在 required.ts 中使用 getLocale/config)
- `@sheinx/base` 依赖 `@sheinx/hooks` (在 package.json 中)

**为什么使用 peerDependencies:**
- 作为 peerDependencies 不会被打包,由宿主环境提供
- 解决用户安装时的模块解析问题
- 避免循环依赖导致的构建问题

## Test plan
- [x] 验证分支的提交干净,只包含 hooks 相关修改
- [ ] 用户环境测试 (需要发布后验证)

## Note
这是临时解决方案,后续可以考虑重构 locale 逻辑以彻底解决循环依赖问题。

🤖 Generated with [Claude Code](https://claude.ai/code)