### PR TITLE
fix(hooks): 修复 useCollapseAnimation classList 多 class 支持

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.2-beta.5",
+  "version": "3.9.2-beta.6",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/common/use-collapse-animation/use-collapse-animation.ts
+++ b/packages/hooks/src/common/use-collapse-animation/use-collapse-animation.ts
@@ -135,7 +135,9 @@ export function useCollapseAnimation<T extends HTMLElement = HTMLElement>(
       const needTempClass = parentOpenClassName && parentElement;
 
       if (needTempClass) {
-        parentElement.classList.add(parentOpenClassName);
+        // 处理可能包含多个 class 的情况（用空格分隔）
+        const classNames = parentOpenClassName.split(/\s+/).filter(Boolean);
+        parentElement.classList.add(...classNames);
       }
 
       // 强制重绘,确保临时 class 生效
@@ -158,7 +160,8 @@ export function useCollapseAnimation<T extends HTMLElement = HTMLElement>(
         timer = setTimeout(() => {
           // 移除临时 class
           if (needTempClass) {
-            parentElement.classList.remove(parentOpenClassName);
+            const classNames = parentOpenClassName.split(/\s+/).filter(Boolean);
+            parentElement.classList.remove(...classNames);
           }
           setShouldHide(true);
           setIsAnimating(false);


### PR DESCRIPTION
## Summary
修复 `useCollapseAnimation` hook 中 `parentOpenClassName` 参数不支持多个 class 名称（空格分隔）的问题。

这是对 #1495 PR 的进一步修复，解决生产环境中报错的问题。

## 问题描述
生产环境报错：
```
Uncaught InvalidCharacterError: Failed to execute 'add' on 'DOMTokenList': 
The token provided ('c-bo4qic soui-menu-item-open') contains HTML space characters, 
which are not valid in tokens.
```

当 `parentOpenClassName` 传入包含空格的字符串时（如 `'c-bo4qic soui-menu-item-open'`），`classList.add()` 和 `classList.remove()` 会抛出 `InvalidCharacterError`，因为这些 DOM API 不接受包含空格的 token。

## 解决方案
将 `parentOpenClassName` 按空格分割成多个独立的 class 名称，然后使用展开运算符传入：
```typescript
// 修改前
parentElement.classList.add(parentOpenClassName);

// 修改后
const classNames = parentOpenClassName.split(/\s+/).filter(Boolean);
parentElement.classList.add(...classNames);
```

## 改动文件
- `packages/hooks/src/common/use-collapse-animation/use-collapse-animation.ts:138-140`
- `packages/hooks/src/common/use-collapse-animation/use-collapse-animation.ts:163-164`

## Test plan
- [x] 修复 classList 操作支持多个 class 名称
- [x] 保持单个 class 名称的兼容性
- [x] 验证空字符串过滤逻辑

## 相关 PR
- #1495 (原始功能 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)