### PR TITLE
fix(image): 修复 inViewOnly 和 container 属性导致的 React DOM 警告

### DIFF
--- a/packages/base/src/image/image.tsx
+++ b/packages/base/src/image/image.tsx
@@ -36,6 +36,7 @@ const Image = (props: ImageProps) => {
     onClick,
     componentRef,
     renderHoverMask,
+    inViewOnly,
     ...rest
   } = props;
 
@@ -48,6 +49,7 @@ const Image = (props: ImageProps) => {
     autoSSL,
     noImgDrag,
     fit,
+    inViewOnly,
     ...rest,
   });
 


### PR DESCRIPTION
## Summary
- 修复 Image 组件在开发模式下出现的 React DOM 警告: `React does not recognize the inViewOnly prop on a DOM element`

## Root Cause
在 `packages/base/src/image/image.tsx` 中，`inViewOnly` 属性没有从 props 中显式提取，导致它通过 `...rest` 被传递到 DOM 元素上。

```tsx
// 问题代码
const { fit, alt, src, ..., ...rest } = props;

useImage({ ..., ...rest });  // rest 包含 inViewOnly ✅ 这里是对的

const rootProps = getRootProps({ ...rest }); // ❌ rest 传递到 DOM，包含 inViewOnly
```

虽然 `inViewOnly` 通过 `...rest` 传递给 `useImage` 是正确的，但它也被传递到了 `getRootProps`，最终出现在 DOM 元素上。

## Changes
**修改文件:** `packages/base/src/image/image.tsx`

**修改策略:**
- **只提取 `inViewOnly`**，其他保持不变
- **保留 `...rest` 传递给 `useImage`**，维持原有的属性覆盖逻辑
- 最小化改动，避免引入新问题

**修改前:**
```tsx
const { fit, alt, src, ..., ...rest } = props;

useImage({
  container: getDefaultContainer()!,
  alt, src, ...,
  ...rest,  // rest 包含 inViewOnly
});

const rootProps = getRootProps({ ...rest }); // ❌ inViewOnly 传到 DOM
```

**修改后:**
```tsx
const {
  fit, alt, src, ...,
  inViewOnly,  // ✅ 显式提取
  ...rest      // ✅ rest 不再包含 inViewOnly
} = props;

useImage({
  container: getDefaultContainer()!,
  alt, src, ...,
  inViewOnly,  // ✅ 显式传递
  ...rest,     // ✅ 保持原有逻辑
});

const rootProps = getRootProps({ ...rest }); // ✅ rest 不包含 inViewOnly
```

## Impact
**开发模式:**
- ✅ 移除控制台警告，改善开发体验
- ✅ 避免非标准属性污染 HTML DOM

**生产模式:**
- ✅ 无影响 (React 生产模式不检查非标准 DOM 属性)

**功能:**
- ✅ 功能完全一致
- ✅ 保持原有的 `...rest` 逻辑，降低风险

🤖 Generated with [Claude Code](https://claude.com/claude-code)