### PR TITLE
fix(menu): 修复折叠菜单时 popover 内容不可见的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.2-beta.6",
+  "version": "3.9.2-beta.7",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/menu/item.tsx
+++ b/packages/base/src/menu/item.tsx
@@ -87,7 +87,8 @@ const MenuItem = (props: OptionalToRequired<MenuItemProps>) => {
           classes?.children,
           isUp && classes?.childrenUp,
           hasExpandAbleChildren && classes?.childrenHasExpand,
-          shouldHideChildren && classes?.childrenHidden,
+          // 有close函数的是popover弹出的菜单，不需要childrenHidden类名
+          shouldHideChildren && !close && classes?.childrenHidden,
         )}
         // 子菜单点击弹出
         onClick={close}

--- a/packages/base/src/menu/menu.tsx
+++ b/packages/base/src/menu/menu.tsx
@@ -91,6 +91,8 @@ const Menu = <DataItem, Key extends KeygenResult>(props: MenuProps<DataItem, Key
           render();
         }
       }}
+      // todo: 其实可以把scrollRef指向到这里，后续验证相关功能后重构
+      // ref={scrollRef}
     >
       {renderHeader()}
       <div className={classes?.scrollbox} ref={scrollRef}>


### PR DESCRIPTION
## Summary
- 修复折叠菜单时 popover 弹出内容不可见的问题
- 版本更新至 3.9.2-beta.7

## 详细说明
这是对 #1495 PR 引入问题的修复。在有 close 函数的 popover 弹出菜单中，不应该添加 childrenHidden 类名，以确保弹出内容正常显示。

🤖 Generated with [Claude Code](https://claude.ai/code)