### PR TITLE
perf(table): 优化 Table 同时设置 virtualColumn 虚拟列和 virtual=lazy 虚拟行后的滚动表现

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.3-beta.3",
+  "version": "3.9.3-beta.4",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/table/table.tsx
+++ b/packages/base/src/table/table.tsx
@@ -117,7 +117,7 @@ export default function Table<Item, Value>(props: TableProps<Item, Value>) {
     beforeChange: undefined,
   });
 
-  const { columns, expandHideCol, columnInfo } = useTableColumns({
+  const { columns, expandHideCol, columnInfo, currentColIndex } = useTableColumns({
     columns: props.columns,
     virtualColumn: props.virtualColumn,
     scrollRef: scrollRef,
@@ -600,7 +600,8 @@ export default function Table<Item, Value>(props: TableProps<Item, Value>) {
                 {Group}
                 <Tbody
                   {...bodyCommonProps}
-                  currentIndex={virtualInfo.startIndex}
+                  currentRowIndex={virtualInfo.startIndex}
+                  currentColIndex={currentColIndex}
                   data={virtualInfo.data}
                   setRowHeight={virtualInfo.setRowHeight}
                   scrolling={scrolling}

--- a/packages/base/src/table/tbody.tsx
+++ b/packages/base/src/table/tbody.tsx
@@ -4,7 +4,7 @@ import Tr from './tr';
 import { TbodyProps } from './tbody.type';
 
 export default (props: TbodyProps) => {
-  const { columns = [], currentIndex = 0, hover = true } = props;
+  const { columns = [], currentRowIndex = 0, currentColIndex, hover = true } = props;
   const { isRowExpand, handleExpandClick } = useTableExpand({
     columns: props.columns,
     expandKeys: props.expandKeys,
@@ -14,7 +14,7 @@ export default (props: TbodyProps) => {
   const { rowData, handleCellHover, hoverIndex, rowSelectMergeStartData } = useTableRow({
     columns: props.columns,
     data: props.data,
-    currentIndex,
+    currentIndex: currentRowIndex,
     hover,
   });
 
@@ -24,7 +24,7 @@ export default (props: TbodyProps) => {
     )) as typeof props.expandHideCol;
 
   const renderRow = (item: any, index: number) => {
-    const rowIndex = index + currentIndex;
+    const rowIndex = index + currentRowIndex;
     const originKey = util.getKey(props.keygen, item, rowIndex);
     const trRenderKey =
       props.loader || props.rowEvents?.draggable ? originKey : `${originKey}-${rowIndex}`;
@@ -94,7 +94,7 @@ export default (props: TbodyProps) => {
   if (props.virtual === 'lazy') {
     return useComponentMemo(
       () => $tbody,
-      [props.data, currentIndex],
+      [currentRowIndex, currentColIndex, props.data],
       (prev: any, next: any) => {
         return (
           prev.some((_: any, index: number) => {

--- a/packages/base/src/table/tbody.type.ts
+++ b/packages/base/src/table/tbody.type.ts
@@ -33,7 +33,8 @@ export interface TbodyProps
   data: any[];
   colgroup: (number | string | undefined)[];
   isScrollX: boolean;
-  currentIndex?: number;
+  currentRowIndex?: number;
+  currentColIndex?: number;
   expandHideCol: UseColumnsResult['expandHideCol'];
   datum: ListDatum;
   treeFunc: UseTreeResult['func'];

--- a/packages/base/src/table/td.tsx
+++ b/packages/base/src/table/td.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useComponentMemo, util } from '@sheinx/hooks';
 import type { TableFormatColumn } from '@sheinx/hooks';
 import { TbodyProps } from './tbody.type';
 
@@ -27,14 +26,13 @@ export default function Td(props: TdProps): JSX.Element {
     className,
     direction,
     role,
-    data,
     onClick,
     onMouseEnter,
     onMouseLeave,
     renderContent,
   } = props;
 
-  const $td = (
+  return (
     <td
       key={col.key}
       colSpan={colSpan}
@@ -50,22 +48,4 @@ export default function Td(props: TdProps): JSX.Element {
       {renderContent(props.col, props.data)}
     </td>
   );
-
-  if (props.virtual === 'lazy') {
-    return useComponentMemo(
-      () => $td,
-      [data, className, props.style?.left, props.style?.right, col.type, col.treeColumnsName],
-      (prev: any, next: any) => {
-        if (col.type || col.treeColumnsName) {
-          return true;
-        }
-        return (
-          prev.some((_: any, index: any) => {
-            return !util.shallowEqual(prev?.[index], next?.[index]);
-          }) || !props.scrolling
-        );
-      },
-    ) as JSX.Element;
-  }
-  return $td;
 }

--- a/packages/hooks/src/components/use-table/use-table-columns.tsx
+++ b/packages/hooks/src/components/use-table/use-table-columns.tsx
@@ -167,6 +167,7 @@ const useColumns = <Data,>(props: UseColumnsProps<Data>) => {
     columnInfo: {
       handleScroll,
     },
+    currentColIndex: startIndex,
     expandHideCol: context.expandHideCol,
   };
 };

--- a/packages/shineout/src/table/__doc__/changelog.cn.md
+++ b/packages/shineout/src/table/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.9.3-beta.4
+2025-12-08
+### 🚀 Performance
+- 优化 `Table` 同时设置 `virtualColumn` 虚拟列和 virtual=lazy 虚拟行后的滚动表现  ([#1508](https://github.com/sheinsight/shineout-next/pull/1508))
+
+
 ## 3.9.3-beta.3
 2025-12-08
 ### 🐞 BugFix


### PR DESCRIPTION
## Summary
- 优化 `Table` 组件在同时开启虚拟列(`virtualColumn`)和虚拟行(`virtual=lazy`)时的滚动性能
- 将虚拟列的当前列索引传递给 Tbody 组件,确保 lazy 模式能够正确响应横向滚动
- 简化了 Td 组件的渲染逻辑,将 lazy 模式的优化统一收拢到 Tbody 层面

## Changes
- 新增 `currentColIndex` 参数从 `useTableColumns` 传递到 `Tbody`
- 优化 `Tbody` 的 `useComponentMemo` 依赖项,同时监听 `currentRowIndex` 和 `currentColIndex`
- 移除 `Td` 组件中冗余的 lazy 模式优化代码
- 重命名 `currentIndex` 为 `currentRowIndex` 提升代码可读性
- 更新版本号至 3.9.3-beta.4

## Test plan
- [x] 测试同时开启 `virtualColumn` 和 `virtual=lazy` 的 Table 组件横向和纵向滚动是否流畅
- [x] 验证滚动时单元格内容渲染是否正确,无闪烁或错位
- [x] 确认优化后性能有所提升

🤖 Generated with [Claude Code](https://claude.com/claude-code)