### PR TITLE
chore: 升级版本到 3.9.3-beta.5 并修复 Switch 阴影样式

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.3-beta.4",
+  "version": "3.9.3-beta.5",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/switch/switch.ts
+++ b/packages/shineout-style/src/switch/switch.ts
@@ -144,6 +144,7 @@ const switchStyle: JsStyles<keyof SwitchClasses> = {
       backgroundColor: token.switchDisabledCircleCheckedFill,
     },
     '$wrapperDisabled &': {
+      boxShadow: 'none',
       backgroundColor: token.switchCheckedDisabledCircleFill,
     },
 
@@ -151,7 +152,7 @@ const switchStyle: JsStyles<keyof SwitchClasses> = {
     position: 'absolute',
 
     backgroundColor: token.switchCircleFill,
-    // boxShadow: token.switchCircleShadow,
+    boxShadow: token.switchCircleShadow,
     transition: `left ${transition}, right ${transition}`,
   },
   content: {


### PR DESCRIPTION
## Summary
- 升级版本到 3.9.3-beta.5
- 修复 Switch 组件圆形按钮的阴影样式
- 正确处理禁用状态下的阴影效果（设置为 none）

## 变更内容
- `package.json`: 版本号从 3.9.3-beta.4 升级到 3.9.3-beta.5
- `packages/shineout-style/src/switch/switch.ts`: 
  - 恢复 Switch 圆形按钮的 boxShadow 样式
  - 为禁用状态添加 `boxShadow: 'none'`

## Test plan
- [x] 测试 Switch 组件在正常状态下的阴影显示
- [x] 测试 Switch 组件在禁用状态下的阴影效果
- [x] 验证版本号更新正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)