### PR TITLE
fix(ci): add sudo to npm install command in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
 
       # Ensure npm 11.5.1 or later is installed
       - name: Update npm
-        run: npm install -g npm@latest
+        run: sudo npm install -g npm@latest
       - name: publish
         run: pnpm run release
 


### PR DESCRIPTION
## Summary
- Add `sudo` prefix to npm install command in the publish workflow to resolve permission issues in GitHub Actions runner environment

## Test plan
- [x] Verify the publish workflow runs successfully with the updated npm install command
- [x] Confirm no permission errors occur during npm installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)