### PR TITLE
fix(ci): add provenance flag to npm publish command

### DIFF
--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -81,7 +81,7 @@ const validateFile = (name) => {
 const publishPackage = (name) => {
   const distPath = path.resolve(__dirname, `../packages/${name}/dist`);
   exec(
-    'npm publish ' + distPath + ' --access public' + (tag ? ` --tag ${tag}` : ''),
+    'npm publish ' + distPath + ' --access public --provenance' + (tag ? ` --tag ${tag}` : ''),
     (error, stdout) => {
       if (error) {
         console.error(error);


### PR DESCRIPTION
## Summary
- 在 npm publish 命令中添加 `--provenance` 参数，以启用包来源证明
- 配合 GitHub Actions 中的 OIDC 认证使用

## Test plan
- [ ] 验证发布工作流是否能成功发布包
- [ ] 确认 npm 包包含 provenance 信息

🤖 Generated with [Claude Code](https://claude.com/claude-code)