### PR TITLE
fix(ci): configure npm authentication with token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,13 +41,15 @@ jobs:
       - name: build
         run: pnpm run build:pkg
 
+      - name: set token
+        run: echo -e //registry.npmjs.org/:_authToken=${NPM_TOKEN} >> .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.SHINEOUT_PUB_TOKEN }}
       # Ensure npm 11.5.1 or later is installed
       - name: Update npm
         run: sudo npm install -g npm@latest
 
       - name: publish
         run: pnpm run release
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
 


### PR DESCRIPTION
## Summary
- 在发布前添加 npm token 配置步骤
- 使用 SHINEOUT_PUB_TOKEN secret 进行认证
- 将 token 写入 .npmrc 文件供 npm publish 命令使用

## Test plan
- [ ] 验证发布工作流是否能成功通过认证
- [ ] 确认包能够成功发布到 npm registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)