### PR TITLE
fix(Tree): revert provider value to inline object creation

### DIFF
--- a/packages/base/src/tree/tree.tsx
+++ b/packages/base/src/tree/tree.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { useContext, useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
 import { KeygenResult, useTree, util, ObjectKey } from '@sheinx/hooks';
 import { TreeClasses } from './tree.type';
@@ -305,13 +305,11 @@ const Tree = <DataItem, Value extends KeygenResult[]>(props: TreeProps<DataItem,
     context.mounted = true;
   }, []);
 
-  const providerValue = useMemo(() => ({ ...datum, size: props.size, leafIcon }), [datum, props.size, leafIcon]);
-
   const { fieldId } = useContext(FormFieldContext);
 
   return (
     <div ref={treeRef} className={rootClass} id={fieldId} {...rest}>
-      <Provider value={providerValue}>{renderList()}</Provider>
+      <Provider value={{ ...datum, size: props.size, leafIcon }}>{renderList()}</Provider>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Reverted the Tree component's provider value from `useMemo` to inline object creation
- Restored the previous behavior of passing provider value directly to the Provider component

## Changes
- Removed `useMemo` wrapper for `providerValue`
- Changed back to inline object creation: `<Provider value={{ ...datum, size: props.size, leafIcon }}>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)