### PR TITLE
fix(Table): revert table-layout to fixed for virtual columns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.3-beta.11",
+  "version": "3.9.3-beta.12",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/table/table.tsx
+++ b/packages/base/src/table/table.tsx
@@ -383,9 +383,9 @@ export default function Table<Item, Value>(props: TableProps<Item, Value>) {
     () => ({
       width,
       borderSpacing: 0,
-      tableLayout: isVirtualColumnEnabled ? 'initial' : 'fixed',
+      tableLayout: 'fixed',
     } as React.CSSProperties),
-    [width, isVirtualColumnEnabled],
+    [width],
   );
   const renderTable = () => {
     const Group = (


### PR DESCRIPTION
## Summary
- Reverted the table-layout property back to 'fixed' for virtual column scenarios
- Removed the conditional logic that set table-layout to 'initial' when virtual columns were enabled

## Test plan
- [x] Verify table rendering with virtual columns enabled
- [x] Check that table layout remains stable

🤖 Generated with [Claude Code](https://claude.ai/code)