### PR TITLE
fix(DatePicker): 修复时间格式匹配和默认时间展示问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.3-beta.13",
+  "version": "3.9.3-beta.14",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-datepicker/use-date.ts
+++ b/packages/hooks/src/components/use-datepicker/use-date.ts
@@ -151,15 +151,26 @@ const useDate = (props: UseDateProps) => {
 
   const getTimeStr = () => {
     let { format, type } = props;
-    if (!props.value) return '';
     if (type !== 'datetime' || !format) return '';
-    if (/^[X|x]$/.test(format)) {
+    if (/^[X|x]$/.test(utils.compatibleFmt(format)!)) {
       format = 'HH:mm:ss';
     } else {
       const match = format.match(/[H|h].*/);
       // eslint-disable-next-line
       if (match) format = match[0];
     }
+
+    // 当不存在 props.value 时,根据 format 格式返回默认时间字符串
+    if (!props.value) {
+      return format
+        .replace(/[Hh]+/g, '00')  // HH/hh -> 00
+        .replace(/m+/g, '00')     // mm -> 00
+        .replace(/s+/g, '00')     // ss -> 00
+        .replace(/S+/g, '0')      // SSS -> 0
+        .replace(/A/g, 'AM')      // A -> AM
+        .replace(/a/g, 'am');     // a -> am
+    }
+
     return dateUtil.format(props.value, format, options);
   };
 

--- a/packages/shineout/src/date-picker/__doc__/changelog.cn.md
+++ b/packages/shineout/src/date-picker/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.9.3-beta.14
+2025-12-11
+
+### 🐞 BugFix
+- 修复 `DatePicker` 时间格式匹配逻辑，正确处理时间戳格式 ([#1526](https://github.com/sheinsight/shineout-next/pull/1526))
+- 修复 `DatePicker` 无值时默认时间字符串未按 `format` 格式展示的问题 ([#1526](https://github.com/sheinsight/shineout-next/pull/1526))
+
 ## 3.9.0-beta.28
 2025-11-17
 


### PR DESCRIPTION
## Summary
- 修复时间格式匹配逻辑，正确处理时间戳格式（使用 `utils.compatibleFmt` 处理格式）
- 修复无值时默认时间字符串未按 `format` 格式展示的问题（根据 format 中的时间部分返回相应的默认值，如 HH→00）

## Test plan
- [x] 测试 `format="YYYY-MM-DD HH"` 时，无值情况下时间面板显示 "00"
- [x] 测试 `format="YYYY-MM-DD HH:mm"` 时，无值情况下时间面板显示 "00:00"
- [x] 测试 `format="YYYY-MM-DD HH:mm:ss"` 时，无值情况下时间面板显示 "00:00"
- [ ] 测试时间戳格式（X/x）能正确匹配处理

🤖 Generated with [Claude Code](https://claude.com/claude-code)