### PR TITLE
fix(Table): 优化虚拟列渲染和宽度计算逻辑

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.3-beta.14",
+  "version": "3.9.3-beta.15",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-table/use-table-columns.tsx
+++ b/packages/hooks/src/components/use-table/use-table-columns.tsx
@@ -146,10 +146,10 @@ const useColumns = <Data,>(props: UseColumnsProps<Data>) => {
   useEffect(() => {
     if (!props.virtualColumn) return;
 
-    if(props.scrollRef.current?.scrollLeft === 0){
-      handleScroll({ scrollLeft: 0 });
+    if (props.scrollRef.current) {
+      handleScroll({ scrollLeft: props.scrollRef.current?.scrollLeft });
     }
-  }, [props.data?.length]);
+  }, [props.data?.length, columns]);
 
   const processedColumns = useMemo(() => {
     if (!props.virtualColumn) return columns;
@@ -160,10 +160,17 @@ const useColumns = <Data,>(props: UseColumnsProps<Data>) => {
       }
       if (index < startIndex || index > startIndex + renderedCount) {
         let colSpan;
+        let colSpanWidth;
         if (index > startIndex + renderedCount && index === startIndex + renderedCount + 1) {
           colSpan = () => middleColumns.length - (startIndex + renderedCount) + 1;
+          colSpanWidth = middleColumns.slice(startIndex + renderedCount).reduce((sum, c) => {
+            return sum + ((c.width as number) || 0);
+          }, 0);
         } else if (index < startIndex && index === leftFixedColumns.length && startIndex > 0) {
           colSpan = () => startIndex;
+          colSpanWidth = middleColumns.slice(0, startIndex).reduce((sum, c) => {
+            return sum + ((c.width as number) || 0);
+          }, 0);
         }
 
         const hiddenTitle = context.groupLevel > 0 ? col.title : null;
@@ -172,11 +179,20 @@ const useColumns = <Data,>(props: UseColumnsProps<Data>) => {
           colSpan,
           render: () => null,
           title: hiddenTitle,
+          style: { width: colSpanWidth },
         };
       }
       return col;
     });
-  }, [columns, startIndex, renderedCount, props.virtualColumn, leftFixedColumns.length, middleColumns.length, context.groupLevel]);
+  }, [
+    columns,
+    startIndex,
+    renderedCount,
+    props.virtualColumn,
+    leftFixedColumns.length,
+    middleColumns.length,
+    context.groupLevel,
+  ]);
 
   return {
     columns: processedColumns,


### PR DESCRIPTION
## Summary
对 #1422, #1508, #1517 PR 的进一步优化，改进虚拟列的渲染逻辑：

- 优化初始化时滚动位置的处理逻辑，支持非零起始位置（原逻辑只处理 scrollLeft === 0 的情况）
- 修复隐藏列的 colSpan 宽度计算，为占位列添加正确的宽度样式，确保布局一致性
- 在 useEffect 依赖项中添加 `columns`，确保列配置变化时重新计算虚拟列渲染范围

## Test plan
- [x] 测试虚拟列表初始化时非零 scrollLeft 位置的渲染是否正确
- [x] 测试隐藏列的占位宽度是否正确，布局是否一致
- [x] 测试动态改变 columns 配置时虚拟列是否正确更新
- [x] 测试横向滚动时列的显示/隐藏切换是否流畅
- [x] 验证数据长度变化时虚拟列渲染是否正常

## Playground ID
ace26cbd-d987-4377-9d31-4fc84efe319e

🤖 Generated with [Claude Code](https://claude.com/claude-code)