### PR TITLE
fix(Form): 修复 FieldSet 嵌套使用时触发整个数组校验的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.4-beta.2",
+  "version": "3.9.4-beta.3",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/form/form-fieldset.tsx
+++ b/packages/base/src/form/form-fieldset.tsx
@@ -5,13 +5,8 @@ const { produce } = util;
 
 const FormFieldSet = <T,>(props: FormFieldSetProps<T>) => {
   const { children, empty } = props;
-  // const { current: context } = React.useRef<{ ids: string[] }>({ ids: [] });
 
   const formFunc = useFormFunc();
-
-  const validateFieldSet = () => {
-    formFunc?.validateFields(props.name, { ignoreChildren: true}).catch((e) => e);
-  };
 
   const getValidateProps = usePersistFn(() => props);
   const { Provider, ProviderValue, error, onChange, name } = useFormFieldSet<T>({
@@ -23,7 +18,7 @@ const FormFieldSet = <T,>(props: FormFieldSetProps<T>) => {
     getValidateProps,
   });
   if (typeof children !== 'function') {
-    return <Provider value={{ ...ProviderValue, validateFieldSet }}>{children}</Provider>;
+    return <Provider value={ProviderValue}>{children}</Provider>;
   }
   let valueArr = formFunc?.getValue(name) || [];
   valueArr = Array.isArray(valueArr) ? valueArr : [valueArr];
@@ -95,7 +90,7 @@ const FormFieldSet = <T,>(props: FormFieldSetProps<T>) => {
     return (
       <Provider
         key={i}
-        value={{ path: `${ProviderValue.path}[${i}]`, validateFieldSet }}
+        value={{ path: `${ProviderValue.path}[${i}]` }}
       >
         {children({
           list: valueArr,

--- a/packages/hooks/src/components/use-form/Provider.tsx
+++ b/packages/hooks/src/components/use-form/Provider.tsx
@@ -6,7 +6,7 @@ import { FormSchemaContext } from './form-schema-context';
 import * as React from 'react';
 import { ProviderProps } from './use-form.type';
 
-const topPath = { path: '', validateFieldSet: () => {} };
+const topPath = { path: '' };
 export const Provider = (props: ProviderProps) => {
   const { children, formConfig, formValue, formFunc, formSchema } = props;
   return (

--- a/packages/hooks/src/components/use-form/use-form-control/use-form-control.ts
+++ b/packages/hooks/src/components/use-form/use-form-control/use-form-control.ts
@@ -46,7 +46,7 @@ export default function useFormControl<T>(props: BaseFormControlProps<T>) {
     getValidateProps,
     clearToUndefined,
   } = props;
-  const { name, bind, validateFieldSet } = useFieldSetConsumer({
+  const { name, bind } = useFieldSetConsumer({
     name: props.name,
     bind: props.bind,
   });
@@ -210,7 +210,6 @@ export default function useFormControl<T>(props: BaseFormControlProps<T>) {
       validateField('', v, undefined);
     }
     if (onChangePo) onChangePo(v, ...other);
-    if (validateFieldSet) validateFieldSet();
   });
 
   const initError = usePersistFn(() => {

--- a/packages/hooks/src/components/use-form/use-form-fieldset/fieldset-context.ts
+++ b/packages/hooks/src/components/use-form/use-form-fieldset/fieldset-context.ts
@@ -1,7 +1,7 @@
 'use client';
 import React, { createContext } from 'react';
 
-export const FieldsetContext = createContext({ path: '', validateFieldSet: () => {} });
+export const FieldsetContext = createContext({ path: '' });
 FieldsetContext.displayName = 'FieldsetContext';
 
 interface BaseFieldProps {
@@ -25,7 +25,7 @@ function extendName(
   return `${path}${path.length > 0 ? '.' : ''}${name}`;
 }
 export const useFieldSetConsumer = <T extends BaseFieldProps>(props: T) => {
-  const { path, validateFieldSet } = React.useContext(FieldsetContext);
+  const { path } = React.useContext(FieldsetContext);
   const bind = React.useMemo(() => {
     const _bind = path ? (props.bind || []).concat(path) : props.bind;
     // 只有当路径中包含超过1个索引时才需要去掉最后一个索引
@@ -42,7 +42,6 @@ export const useFieldSetConsumer = <T extends BaseFieldProps>(props: T) => {
     ...props,
     name,
     bind,
-    validateFieldSet,
   };
 };
 

--- a/packages/hooks/src/components/use-form/use-form-fieldset/use-form-fieldset.ts
+++ b/packages/hooks/src/components/use-form/use-form-fieldset/use-form-fieldset.ts
@@ -22,7 +22,6 @@ export const useFormFieldSet = <T>(props: BaseFormFieldSetProps<T>) => {
 
   const ProviderValue = {
     path: name,
-    validateFieldSet: () => {},
   };
 
   return {

--- a/packages/shineout/src/form/__doc__/changelog.cn.md
+++ b/packages/shineout/src/form/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.9.4-beta.3
+2025-12-15
+### 🐞 BugFix
+- 修复 `Form` 的 `FieldSet` 嵌套使用时，某一项改变时触发了整个数组的校验的问题 (Regression: since v3.5.1) ([#1532](https://github.com/sheinsight/shineout-next/pull/1532))
+
+
 ## 3.9.3-beta.13
 2025-12-11
 ### 🐞 BugFix


### PR DESCRIPTION
## Summary
- 移除了 `validateFieldSet` 函数及相关逻辑
- 修复 `Form` 的 `FieldSet` 嵌套使用时，某一项改变时触发了整个数组的校验的问题
- 更新 changelog (Regression: since v3.5.1)
- 版本号更新至 3.9.4-beta.3

## 背景
此问题由 #796 引入。在 #796 中添加了 `validateFieldSet` 机制来支持 FieldSet 的校验，但这导致在嵌套使用 FieldSet 时，单个字段的改变会触发整个数组的校验，影响了性能和用户体验。

本 PR 移除了该机制，恢复到原有的校验逻辑。

## 修改文件
- `packages/base/src/form/form-fieldset.tsx` - 移除 validateFieldSet 函数和相关调用
- `packages/hooks/src/components/use-form/Provider.tsx` - 移除 topPath 中的 validateFieldSet
- `packages/hooks/src/components/use-form/use-form-control/use-form-control.ts` - 移除 onChange 中的 validateFieldSet 调用
- `packages/hooks/src/components/use-form/use-form-fieldset/fieldset-context.ts` - 移除 FieldsetContext 中的 validateFieldSet
- `packages/hooks/src/components/use-form/use-form-fieldset/use-form-fieldset.ts` - 移除 ProviderValue 中的 validateFieldSet

## Test plan
- [x] 测试 FieldSet 嵌套使用场景
- [x] 验证单项改变时不会触发整个数组校验
- [x] 验证表单校验功能正常工作

## Related PR
- Fixes regression introduced in #796

## Playground ID
07a68adb-bd16-4f48-95d9-9aa752d3271f

🤖 Generated with [Claude Code](https://claude.com/claude-code)