### PR TITLE
fix(Select): 修复设置 onFilter 时非 string 类型的 placeholder 不显示的问题

### DIFF
--- a/docs/markdown/shineout/changelog-common.md
+++ b/docs/markdown/shineout/changelog-common.md
@@ -1,3 +1,10 @@
+## 3.9.4-beta.5
+2025-12-15
+
+### 🐞 BugFix
+-  修复 `Select`、`TreeSelect`、`Cascader` 设置 `onFilter` 时，非 string 类型的 `placeholder` 不显示的问题 ([#1534](https://github.com/sheinsight/shineout-next/pull/1534))
+
+
 ## 3.9.3-beta.9
 2025-12-09
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.4-beta.4",
+  "version": "3.9.4-beta.5",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/select/result-input.tsx
+++ b/packages/base/src/select/result-input.tsx
@@ -74,6 +74,14 @@ const ResultInput = (props: ResultInputProps) => {
   }, []);
 
   const renderResultPlaceholder = () => {
+    if (!inputText && !focus && props.placeholder && typeof props.placeholder !== 'string') {
+      return (
+        <div className={styles.inputPlaceholder}>
+          {props.placeholder}
+        </div>
+      )
+    }
+
     if (inputText || !focus || typeof props.placeholder === 'string') return null;
 
     return (


### PR DESCRIPTION
## Summary
- 修复 `Select`、`TreeSelect`、`Cascader` 组件在设置 `onFilter` 时，非 string 类型的 `placeholder` 不显示的问题
- 在 `renderResultPlaceholder` 函数中添加对非 string 类型 placeholder 的优先处理逻辑

## Test plan
- [x] 验证 Select 组件设置 onFilter 时，ReactNode 类型的 placeholder 能正常显示
- [x] 验证 TreeSelect 组件设置 onFilter 时，ReactNode 类型的 placeholder 能正常显示
- [x] 验证 Cascader 组件设置 onFilter 时，ReactNode 类型的 placeholder 能正常显示
- [x] 验证 string 类型的 placeholder 显示不受影响

## Playground ID
d2cd1520-e5a2-4f6f-aa7c-5d873095a440

🤖 Generated with [Claude Code](https://claude.com/claude-code)