### PR TITLE
fix: 修复 Tag 和 Select 组件样式问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.4-beta.9",
+  "version": "3.9.4-beta.10",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/select/select.ts
+++ b/packages/shineout-style/src/select/select.ts
@@ -91,6 +91,7 @@ const selectStyle: JsStyles<SelectClassType> = {
       '& $tag': {
         marginTop: 1,
         marginBottom: 1,
+        border: 'none',
       },
       '& $placeholder,$ellipsis,$space,input': {
         marginTop: 0,

--- a/packages/shineout-style/src/tag/tag.ts
+++ b/packages/shineout-style/src/tag/tag.ts
@@ -207,8 +207,8 @@ const TagStyle: JsStyles<keyof TagClasses> = {
     padding: `${Token.tagLargePaddingY} ${Token.tagLargePaddingX}`,
     '& $closeIconWrapper': {
       '& svg': {
-        width: 14,
-        height: 14,
+        width: Token.tagLargeFontSize,
+        height: Token.tagLargeFontSize,
       },
     },
     '& $wrapper': {
@@ -235,8 +235,8 @@ const TagStyle: JsStyles<keyof TagClasses> = {
       height: `calc(${Token.tagSmallFontSize} + 6px)`,
       lineHeight: `calc(${Token.tagSmallFontSize} + 6px)`,
       '& svg': {
-        width: 12,
-        height: 12,
+        width: Token.tagSmallFontSize,
+        height: Token.tagSmallFontSize,
       },
     },
   },
@@ -249,7 +249,7 @@ const TagStyle: JsStyles<keyof TagClasses> = {
   },
 
   closeIcon: {
-    marginLeft: 4,
+    marginLeft: 2,
     alignItems: 'center',
     display: 'inline-flex',
     cursor: 'pointer',
@@ -265,8 +265,8 @@ const TagStyle: JsStyles<keyof TagClasses> = {
     width: `calc(1em + 4px)`,
     height: `calc(1em + 4px)`,
     '& svg': {
-      width: 12,
-      height: 12,
+      width: Token.tagFontSize,
+      height: Token.tagFontSize,
     },
   },
 


### PR DESCRIPTION
## Summary
- 移除 Select 组件中 tag 的边框
- 统一 Tag 组件不同尺寸下关闭图标的字号设置，使用 token 替代硬编码值
- 调整 Tag 组件关闭图标的左边距从 4px 到 2px
- 版本号升级到 3.9.4-beta.10

## 修改文件
- `packages/shineout-style/src/select/select.ts`: 为 tag 添加 `border: 'none'`
- `packages/shineout-style/src/tag/tag.ts`: 使用 token 设置关闭图标尺寸，调整左边距
- `package.json`: 版本号升级

## Test plan
- [x] 验证 Select 组件中的 tag 样式正确
- [x] 验证 Tag 组件在不同尺寸下关闭图标的显示正确
- [x] 验证关闭图标的左边距调整后视觉效果良好

🤖 Generated with [Claude Code](https://claude.com/claude-code)