### PR TITLE
fix: 修复 Pagination 在非受控模式下切换 pageSize 后点击页码导致 pageSize 重置的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.4",
+  "version": "3.9.5-beta.1",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-pagination/use-pagination.tsx
+++ b/packages/hooks/src/components/use-pagination/use-pagination.tsx
@@ -28,7 +28,7 @@ const usePagination = (props: BasePaginationProps) => {
   const handleChange = usePersistFn((c: number, size?: number) => {
     if (c === current && size === undefined) return;
     setCurrent(c);
-    setPageSize(size || pageSizeProp);
+    setPageSize(size || pageSize);
     if (onChange) {
       const sizeChange = size !== undefined && pageSize !== size;
       onChange(c, size || pageSize, sizeChange);

--- a/packages/shineout/src/pagination/__doc__/changelog.cn.md
+++ b/packages/shineout/src/pagination/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.9.5-beta.1
+2025-12-22
+### 🐞 BugFix
+- 修复 `Pagination` 在非受控模式下切换 pageSize 后点击页码会导致 pageSize 重置的问题 ([#1544](https://github.com/sheinsight/shineout-next/pull/1544))
+
+
 ## 3.9.2-beta.9
 2025-12-05
 


### PR DESCRIPTION
## 问题描述
修复了一个 Pagination 组件在非受控模式下的 bug：
- 当用户将分页器从 10/page 修改为 20/page 后
- 再点击第 2 页（或其他页码）
- 分页器的 pageSize 会意外重置回 10/page

## 根本原因
位置：`packages/hooks/src/components/use-pagination/use-pagination.tsx:31`

在 `handleChange` 函数中，当点击页码进行翻页时（不传入 size 参数），代码错误地回退到初始的 `pageSizeProp` 而不是当前的 `pageSize` 状态：

```typescript
// 修复前
setPageSize(size || pageSizeProp);  // 回退到初始 prop

// 修复后
setPageSize(size || pageSize);     // 保持当前状态
```

## 解决方案
将回退逻辑从使用初始 prop 改为使用当前 state，确保在翻页时保持用户选择的 pageSize。

## 测试步骤
1. 打开示例：`packages/shineout/src/pagination/__example__/009-text.tsx`
2. 将分页器从默认的 10/page 修改为 20/page
3. 点击第 2 页
4. ✅ 验证 pageSize 保持为 20/page（修复后）
5. ❌ 之前会重置为 10/page（修复前）

## Breaking Change
无。这是一个纯粹的 bug 修复，修复了违背用户预期的错误行为。

## 相关文件
- `packages/hooks/src/components/use-pagination/use-pagination.tsx` - 修复核心逻辑
- `packages/shineout/src/pagination/__doc__/changelog.cn.md` - 更新 changelog
- `package.json` - 版本号更新为 3.9.5-beta.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)