### PR TITLE
fix: 修复弹出层在 CSS zoom 嵌套环境下使用 absolute 时位置偏移的问题

### DIFF
--- a/docs/markdown/shineout/changelog-common.md
+++ b/docs/markdown/shineout/changelog-common.md
@@ -1,3 +1,10 @@
+## 3.9.5-beta.2
+2025-12-23
+
+### 🐞 BugFix
+- 修复弹出层类组件在 CSS zoom 嵌套环境下使用 `absolute` 属性时位置偏移的问题 ([#1545](https://github.com/sheinsight/shineout-next/pull/1545))
+
+
 ## 3.9.4-beta.7
 2025-12-17
 ### 💅 Style

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.5-beta.1",
+  "version": "3.9.5-beta.2",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/common/use-position-style/index.ts
+++ b/packages/hooks/src/common/use-position-style/index.ts
@@ -6,7 +6,7 @@ import { useCheckElementBorderWidth } from './check-border';
 import { useCheckElementSize } from './check-element-size'
 import shallowEqual from '../../utils/shallow-equal';
 import usePersistFn from '../use-persist-fn';
-import { getCurrentCSSZoom, getScrollPosition } from '../../utils';
+import { getScrollPosition, getRelativeZoom } from '../../utils';
 import { docSize } from '../../utils';
 
 export type HorizontalPosition =
@@ -353,19 +353,23 @@ export const usePositionStyle = (config: PositionStyleConfig) => {
     }
     const { style } = getAbsolutePositionStyle(rect, position);
 
-    const currentCSSZoom = getCurrentCSSZoom()
-    if (currentCSSZoom && currentCSSZoom !== 1) {
+    // 计算从触发元素到挂载容器之间的相对 zoom 值
+    const rootContainer = getContainer() || document.body;
+    const relativeZoom = getRelativeZoom(parentElRef.current, rootContainer);
+
+    if (relativeZoom && relativeZoom !== 1) {
+      const zoomRatio = 1 / relativeZoom;
       if (style.left && typeof style.left === 'number') {
-        style.left = style.left * (1 / currentCSSZoom);
+        style.left = style.left * zoomRatio;
       }
       if (style.top && typeof style.top === 'number') {
-        style.top = style.top * (1 / currentCSSZoom);
+        style.top = style.top * zoomRatio;
       }
       if (style.right && typeof style.right === 'number') {
-        style.right = style.right * (1 / currentCSSZoom);
+        style.right = style.right * zoomRatio;
       }
       if (style.bottom && typeof style.bottom === 'number') {
-        style.bottom = style.bottom * (1 / currentCSSZoom);
+        style.bottom = style.bottom * zoomRatio;
       }
     }
     return { style };

--- a/packages/hooks/src/utils/dom/document.ts
+++ b/packages/hooks/src/utils/dom/document.ts
@@ -1,54 +1,46 @@
+// 缓存容器的 zoom 值，避免重复计算
+// 使用 WeakMap 确保容器元素被销毁时缓存也会被清理
+const zoomCache = new WeakMap<HTMLElement, number>();
 
-let cachedZoom = 0
-export const getCurrentCSSZoom = (): number => {
-  if (cachedZoom) return cachedZoom
+/**
+ * 计算容器的累积 zoom 值
+ * 当弹出层通过 position: absolute 定位在容器内时，需要用容器的 zoom 值来修正坐标
+ * 因为 getBoundingClientRect() 返回的是应用 zoom 后的视口坐标，
+ * 但 CSS 的 left/top 值会在容器的 zoom 坐标系中解释
+ * @param container - 容器元素，默认为 document.body
+ * @returns 容器的累积 zoom 值
+ */
+export const getRelativeZoom = (_element: HTMLElement | null, container: HTMLElement | null = document.body): number => {
+  if (!container || typeof window === 'undefined') return 1;
 
-  if (typeof window === 'undefined' || typeof navigator === 'undefined' || !document.body) {
-    return 1
+  // 检查缓存
+  const cached = zoomCache.get(container);
+  if (cached !== undefined) {
+    return cached;
   }
 
-  const currentCSSZoom = Math.round(document.body.getBoundingClientRect().width) / document.body.clientWidth
+  let zoom = 1;
+  let current: HTMLElement | null = container;
 
-  if (window.ResizeObserver) {
-    // 监听document.body的变化，更新缓存的zoom
-    const resizeObserver = new ResizeObserver(() => {
-      cachedZoom = Math.round(document.body.getBoundingClientRect().width) / document.body.clientWidth
-    })
+  // 从容器向上遍历到 document，累积所有的 zoom 值
+  while (current && current !== document.documentElement) {
+    const computedStyle = window.getComputedStyle(current);
+    // zoom 不是标准 CSS 属性，需要通过索引访问
+    const zoomValue = (computedStyle as any).zoom || '1';
+    const currentZoom = parseFloat(zoomValue);
 
-    resizeObserver.observe(document.body)
+    if (!isNaN(currentZoom) && currentZoom !== 0) {
+      zoom *= currentZoom;
+    }
+
+    current = current.parentElement;
   }
 
-  cachedZoom = currentCSSZoom
+  // 缓存计算结果
+  zoomCache.set(container, zoom);
 
-  return currentCSSZoom
-}
-
-
-// export const getZoomBoundingClientRect = (element: HTMLElement) => {
-//   const currentCSSZoom = getCurrentCSSZoom()
-//   if (currentCSSZoom === 1 || !currentCSSZoom) {
-//     return element.getBoundingClientRect()
-//   }
-//   const isNotZoom = currentCSSZoom === 1 || !currentCSSZoom
-
-//   if (isNotZoom) {
-//     return element.getBoundingClientRect()
-//   }
-
-//   const zoomRatio = 1 / currentCSSZoom
-//   const rect = element.getBoundingClientRect()
-
-//   return {
-//     x: rect.x * zoomRatio,
-//     y: rect.y * zoomRatio,
-//     top: rect.top * zoomRatio,
-//     right: rect.right * zoomRatio,
-//     bottom: rect.bottom * zoomRatio,
-//     left: rect.left * zoomRatio,
-//     width: rect.width * zoomRatio,
-//     height: rect.height * zoomRatio,
-//   }
-// }
+  return zoom;
+};
 
 export const getScrollPosition = (element?: HTMLElement | null) => {
   if (!element) return { scrollTop: 0, scrollLeft: 0 };

--- a/packages/shineout/src/select/__example__/test-03-multi-zoom.tsx
+++ b/packages/shineout/src/select/__example__/test-03-multi-zoom.tsx
@@ -1,0 +1,43 @@
+/**
+ * cn - multi-zoom
+ *    -- 多个css zoom叠加作用下的弹出层位置问题
+ * en - multi-zoom
+ *    --
+ */
+import React from 'react';
+import { Select } from 'shineout';
+
+// document.body.style.zoom = '1.125'
+
+export default () => {
+  const data = ['red', 'orange', 'yellow', 'green'];
+  return (
+    <div>
+      <p>
+        Integer et enim sit amet massa sollicitudin dignissim vel sit amet mauris. Maecenas volutpat
+        dui nec lobortis lacinia. Sed pretium, lorem in scelerisque fringilla, metus nulla lacinia
+        lorem, sit amet fringilla ipsum justo non ipsum. Cras ut magna quis ipsum porttitor blandit
+        eget ut dui.
+      </p>
+
+      <div
+        className='inner'
+        style={{
+          marginLeft: 100,
+          zoom: 0.88888889,
+        }}
+      >
+        <div style={{ padding: 10 }} id='aaa'>
+          <Select
+            data={data}
+            keygen
+            placeholder='Select Color'
+            absolute={() => {
+              return document.querySelector('#aaa');
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## 问题描述
当页面存在嵌套的 CSS zoom 设置时（例如 `body { zoom: 1.25 }` + `inner { zoom: 0.8 }`），弹出层组件使用 `absolute` 属性挂载到指定容器时，会出现位置偏移的问题。

## 根本原因
之前的 `getCurrentCSSZoom()` 函数只计算了 `body` 元素的 zoom 值，没有考虑挂载容器及其父元素链上的 zoom 值。

在嵌套 zoom 场景下：
- `body` 的 zoom = 1.25
- `inner` 的 zoom = 0.8  
- 实际挂载容器的累积 zoom = 1.25 × 0.8 = 1.0

但代码只使用了 `body` 的 zoom (1.25) 来调整位置，导致偏移。

## 解决方案

### 1. 新增 `getRelativeZoom` 函数
- 计算容器到 document 的累积 zoom 值
- 使用 WeakMap 实现轻量级缓存
- 自动处理容器元素销毁时的缓存清理

### 2. 修改位置计算逻辑
- 将 `use-position-style` 中的 zoom 计算从 `getCurrentCSSZoom()` 改为 `getRelativeZoom()`
- 正确处理挂载容器的累积 zoom 效果

### 3. 清理冗余代码
- 删除已无使用的 `getCurrentCSSZoom()` 函数

## 影响范围
所有使用 `absolute` 属性的弹出层组件：
- Select
- TreeSelect
- DatePicker  
- Cascader
- Dropdown
- Popover
- Table
- 等

## 兼容性
✅ **完全向后兼容**
- 无 zoom 场景：无影响
- 仅 body zoom 场景：行为一致
- 嵌套 zoom 场景：修复了之前的 bug

## 测试
- ✅ 已在本地验证通过
- ✅ 新增测试用例 `test-03-multi-zoom.tsx`
- ✅ 构建通过

## Changelog
已更新到 `docs/markdown/shineout/changelog-common.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)