### PR TITLE
fix: 修复弹出层在 body zoom 环境下 adjust 逻辑判断错误的问题

### DIFF
--- a/docs/markdown/shineout/changelog-common.md
+++ b/docs/markdown/shineout/changelog-common.md
@@ -2,7 +2,7 @@
 2025-12-23
 
 ### 🐞 BugFix
-- 修复弹出层类组件在 CSS zoom 嵌套环境下使用 `absolute` 属性时位置偏移的问题 ([#1545](https://github.com/sheinsight/shineout-next/pull/1545))
+- 修复弹出层类组件在 CSS zoom 嵌套环境下使用 `absolute` 属性时位置偏移的问题 ([#1545](https://github.com/sheinsight/shineout-next/pull/1545))([#1546](https://github.com/sheinsight/shineout-next/pull/1546))
 
 
 ## 3.9.4-beta.7

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.5-beta.2",
+  "version": "3.9.5-beta.3",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/common/use-position-style/index.ts
+++ b/packages/hooks/src/common/use-position-style/index.ts
@@ -199,7 +199,8 @@ export const usePositionStyle = (config: PositionStyleConfig) => {
     } else {
       // absolute 场景下，右侧溢出判断需要考虑弹出层元素的尺寸
       const [, horizontalPosition] = position.split('-');
-      if (horizontalPosition === 'left' && context.parentRect.left + (popupElWidth || context.popUpWidth) > docSize.width) {
+      const bodyZoom = getRelativeZoom(document.body);
+      if (horizontalPosition === 'left' && context.parentRect.left + (popupElWidth || context.popUpWidth) > docSize.width * bodyZoom) {
         newPosition = newPosition.replace('left', 'right') as VerticalPosition;
       }
     }

--- a/packages/shineout/src/select/__example__/test-03-multi-zoom.tsx
+++ b/packages/shineout/src/select/__example__/test-03-multi-zoom.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { Select } from 'shineout';
 
-// document.body.style.zoom = '1.125'
+// document.body.style.zoom = '2';
 
 export default () => {
   const data = ['red', 'orange', 'yellow', 'green'];
@@ -24,9 +24,16 @@ export default () => {
         className='inner'
         style={{
           marginLeft: 100,
-          zoom: 0.88888889,
+          zoom: 0.5,
         }}
       >
+        <Select
+          data={data}
+          keygen
+          placeholder='Select Color'
+          absolute
+        />
+
         <div style={{ padding: 10 }} id='aaa'>
           <Select
             data={data}


### PR DESCRIPTION
## 问题描述
本 PR 是对 #1545 的进一步优化。

在 #1545 中修复了嵌套 zoom 环境下的位置计算问题后，发现在 `document.body` 设置了 CSS zoom 时，弹出层的 adjust 逻辑仍然存在问题，会错误地将 `bottom-left` 调整为 `bottom-right`，导致位置异常。

## 根本原因

在 adjust 逻辑判断弹出层是否溢出视口时，使用了**不同坐标系**的值进行比较：

```javascript
// 错误的比较
context.parentRect.left + context.popUpWidth > docSize.width
//      ↑ 物理像素(已应用zoom)              ↑ 逻辑像素(未应用zoom)
```

当 `body zoom = 2` 时：
- `parentRect.left`: 通过 `getBoundingClientRect()` 获取，返回**物理像素**（已应用 zoom）
- `docSize.width`: 通过 `clientWidth` 获取，返回**逻辑像素**（未应用 zoom）

例如：
- 视口宽度: 960 逻辑像素
- `docSize.width`: 960
- `parentRect.left`: 200（实际是 100 逻辑像素 × 2）
- `popUpWidth`: 1208（实际是 604 逻辑像素 × 2）
- 错误判断: `200 + 1208 = 1408 > 960`，认为溢出 ❌
- 正确应该: `100 + 604 = 704 < 960`，不溢出 ✅

## 解决方案

在 absolute 模式下的溢出判断中，统一使用**物理像素坐标系**：

```javascript
// 修复后：统一坐标系
const bodyZoom = getRelativeZoom(document.body);
if (context.parentRect.left + context.popUpWidth > docSize.width * bodyZoom) {
  // 判断是否溢出
}
```

这样确保了所有值都在物理像素坐标系中，比较才是准确的。

## 影响范围

- 仅影响在 `document.body` 设置了 CSS zoom 时使用 `absolute` 属性的弹出层组件
- 修复了 adjust 逻辑在 zoom 环境下的边界问题
- 与 #1545 配合，完整解决了 zoom 环境下的定位问题

## 测试

- ✅ 已在本地验证通过
- ✅ 更新了测试用例 `test-03-multi-zoom.tsx` 覆盖 body zoom 场景
- ✅ 第一次和第二次打开弹出层位置保持一致

## 关联 PR

- 基于 #1545 的进一步优化
- 两个 PR 配合完整解决 zoom 环境下的定位问题

🤖 Generated with [Claude Code](https://claude.com/claude-code)