### PR TITLE
fix: 修复 Descriptions 非 border 模式在 Table 内显示多余边框的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.5-beta.3",
+  "version": "3.9.5-beta.4",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/descriptions/descriptions.ts
+++ b/packages/shineout-style/src/descriptions/descriptions.ts
@@ -65,6 +65,9 @@ const descriptionsStyle: JsStyles<DescriptionsClassType> = {
     boxSizing: 'border-box',
     color: token.descriptionsLabelColor,
     whiteSpace: 'nowrap',
+    '$wrapper $body:not($border) table &': {
+      border: 'none',
+    },
   },
   value: {
     paddingRight: token.descriptionsLabelPaddingRight,
@@ -72,6 +75,9 @@ const descriptionsStyle: JsStyles<DescriptionsClassType> = {
     textAlign: 'left',
     boxSizing: 'border-box',
     color: token.descriptionsValueColor,
+    '$wrapper $body:not($border) table &': {
+      border: 'none',
+    },
     '&:last-child': {
       paddingRight: 0,
     },

--- a/packages/shineout/src/descriptions/__doc__/changelog.cn.md
+++ b/packages/shineout/src/descriptions/__doc__/changelog.cn.md
@@ -1,3 +1,8 @@
+## 3.9.5-beta.4
+2025-12-24
+### 🐞 BugFix
+- 修复 `Descriptions` 的非 border 模式在 Table 组件内使用时显示多余边框的问题  ([#1547](https://github.com/sheinsight/shineout-next/pull/1547))
+
 ## 3.8.10-beta.4
 2025-11-14
 


### PR DESCRIPTION
## 摘要
修复了 `Descriptions` 组件的非 border 模式在 `Table` 组件内使用时，`label` 和 `value` 显示多余边框的样式问题。

## 修改内容
- 在 `packages/shineout-style/src/descriptions/descriptions.ts` 中为 `label` 和 `value` 添加了针对 Table 内非 border 模式的样式规则
- 当 Descriptions 在 Table 内且非 border 模式时，移除 label 和 value 的边框
- 更新了版本号到 3.9.5-beta.4
- 更新了 changelog

## 测试计划
- [x] 验证非 border 模式的 Descriptions 在 Table 内不显示多余边框
- [x] 验证 border 模式的 Descriptions 在 Table 内正常显示边框
- [x] 验证 Descriptions 在非 Table 环境下样式不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)