### PR TITLE
fix: 修复 Pagination 重复点击相同页码时不触发 onChange 的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.5-beta.5",
+  "version": "3.9.5-beta.6",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-pagination/use-pagination.tsx
+++ b/packages/hooks/src/components/use-pagination/use-pagination.tsx
@@ -26,12 +26,16 @@ const usePagination = (props: BasePaginationProps) => {
   }, [currentProp]);
 
   const handleChange = usePersistFn((c: number, size?: number) => {
-    if (c === current && size === undefined) return;
+    const newPageSize = size || pageSize;
+    const sizeChange = size !== undefined && pageSize !== size;
+
+    // Always update state and trigger onChange, even for the same page
+    // This allows handlers to re-execute logic when clicking the same page
     setCurrent(c);
-    setPageSize(size || pageSize);
+    setPageSize(newPageSize);
+
     if (onChange) {
-      const sizeChange = size !== undefined && pageSize !== size;
-      onChange(c, size || pageSize, sizeChange);
+      onChange(c, newPageSize, sizeChange);
     }
   });
 

--- a/packages/shineout/src/pagination/__doc__/changelog.cn.md
+++ b/packages/shineout/src/pagination/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.9.5-beta.6
+2025-12-25
+### 🐞 BugFix
+- 修复 `Pagination` 重复点击相同页码时不触发 `onChange` 的问题 (Regression: since v3.2.3)([#1550](https://github.com/sheinsight/shineout-next/pull/1550))
+
+
 ## 3.9.5-beta.1
 2025-12-22
 ### 🐞 BugFix


### PR DESCRIPTION
## Summary
- 修复 Pagination 组件重复点击相同页码时不触发 onChange 回调的问题
- 移除 use-pagination 中的早期返回逻辑，允许每次点击都触发 onChange
- 修复 v3.2.3 引入的 regression 问题

## Background
在 v3.2.3 (#546) 中为了优化性能，添加了"点击相同页码时不触发 onChange"的逻辑。但这导致某些业务场景无法正常工作，例如：
- 表格与表单结合使用
- 第一页未填写完成，阻止跳转第二页
- 用户填写完成后再次点击第二页，需要重新执行验证逻辑
- 但因为 onChange 不触发，无法重新验证

## Changes
- `packages/hooks/src/components/use-pagination/use-pagination.tsx`: 移除了 `if (c === current && size === undefined) return;` 的早期返回逻辑
- `packages/shineout/src/pagination/__doc__/changelog.cn.md`: 添加 changelog 说明

## Test plan
- [x] 手动测试重复点击相同页码时 onChange 能正常触发
- [x] 验证表单验证场景可以正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)