### PR TITLE
fix: 修复 Input 在 Form 中按回车提交时 onEnterPress 事件触发两次的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.5-beta.6",
+  "version": "3.9.5-beta.7",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/input/input.tsx
+++ b/packages/base/src/input/input.tsx
@@ -38,6 +38,17 @@ const Input = (props: InputProps) => {
       hasSuffix={!!props.suffix}
       showClear={props.showClear}
       onKeyDown={(e) => {
+        // 在 Enter 键按下时,如果开启了 trim,先执行 trim 逻辑
+        if (e.key === 'Enter' && inputFormatParams.trim) {
+          const target = e.target as HTMLInputElement;
+          const value = target.value;
+          const trimmedValue = value.trim();
+          if (value !== trimmedValue) {
+            target.value = trimmedValue;
+            commonProps.onChange?.(trimmedValue);
+          }
+        }
+
         if (e.key === 'Enter' && !e.defaultPrevented) {
           const value = (e.target as HTMLInputElement).value;
           props.onChange?.(value);

--- a/packages/base/src/input/simple-input.tsx
+++ b/packages/base/src/input/simple-input.tsx
@@ -1,6 +1,6 @@
 import { getDataset, useInput, useKeyEvent, usePersistFn, util } from '@sheinx/hooks';
 import classNames from 'classnames';
-import React, { KeyboardEvent, useContext, useRef } from 'react';
+import React, { KeyboardEvent, useContext } from 'react';
 import { SimpleInputProps } from './input.type';
 import Icons from '../icons';
 import { useConfig } from '../config';
@@ -25,10 +25,6 @@ const Input = (props: SimpleInputProps) => {
     ...rest
   } = props;
 
-  const { current: context } = useRef({
-    needTriggerEnter: false,
-  });
-
   const inputStyle = jssStyle?.input?.();
   const config = useConfig();
   const { fieldId } = useContext(FormFieldContext);
@@ -36,23 +32,7 @@ const Input = (props: SimpleInputProps) => {
   const { getRootProps, getClearProps, getInputProps, showClear: showClearFromClearable, focused, disabled } = useInput({
     ...rest,
     onFocusedChange,
-    // 由于form的原生submit事件是在keydown中触发的，submit校验后触发scrollToError会导致当前焦点的input立即失焦，导致input的回车事件无法触发
-    // 所以这里在onKeyDown时机记录下needTriggerEnter标志，在onBlur时机判断是否需要触发onEnterPress
-    onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === 'Enter') {
-        context.needTriggerEnter = true;
-      }
-      props.onKeyDown?.(e);
-    },
-    onBlur: (e: any) => {
-      if (context.needTriggerEnter) {
-        context.needTriggerEnter = false;
-        onEnterPress?.(e.target.value || '', e);
-      }
-      props.onBlur?.(e);
-    },
   });
-
 
   const keyHandler = useKeyEvent<HTMLInputElement>({
     onEnterPress: (e) => {
@@ -61,9 +41,6 @@ const Input = (props: SimpleInputProps) => {
   });
 
   const onKeyUp = usePersistFn((e: KeyboardEvent<HTMLInputElement> & { target: HTMLInputElement }) => {
-    if (e.key === 'Enter') {
-      context.needTriggerEnter = false;
-    };
     props.onKeyUp?.(e);
     keyHandler(e);
   });

--- a/packages/hooks/src/components/use-form/use-form.ts
+++ b/packages/hooks/src/components/use-form/use-form.ts
@@ -442,8 +442,6 @@ const useForm = <T extends ObjectType>(props: UseFormProps<T>) => {
       return;
     }
     context.submitLock = true;
-    const activeEl = document.activeElement as HTMLElement;
-    if (activeEl) activeEl.blur();
 
     setTimeout(() => {
       // 防止连续点击
@@ -458,7 +456,6 @@ const useForm = <T extends ObjectType>(props: UseFormProps<T>) => {
       const result = await validateFields(undefined, { ignoreBind: true }).catch((e) => e);
       if (result === true) {
         props.onSubmit?.((context.value ?? {}) as T);
-        if (activeEl) activeEl.focus();
       } else {
         handleSubmitError(result);
       }

--- a/packages/shineout/src/input/__doc__/changelog.cn.md
+++ b/packages/shineout/src/input/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.9.5-beta.7
+2025-12-26
+### 🐞 BugFix
+- 修复 `Input` 在 `Form` 中按回车提交时 `onEnterPress` 事件触发两次的问题 ([#1550](https://github.com/sheinsight/shineout-next/pull/1550))
+
+
 ## 3.9.5-beta.5
 2025-12-24
 ### 🐞 BugFix


### PR DESCRIPTION
## 问题描述

Input 组件在 Form 中按回车提交时,`onEnterPress` 事件会被触发两次。

## 问题根因

### 历史背景

1. **PR #871** (commit `32c4ff713`):
   - **问题**: Form 在按回车提交时,Input 不会失焦,导致 trim 功能失效
   - **修复方案**: 在 Form submit 时主动调用 `blur()`,成功后调用 `focus()` 恢复焦点
   - **修改文件**: `packages/hooks/src/components/use-form/use-form.ts`

2. **PR #1182** (commit `c57121a7e`):
   - **问题**: 上述方案在开启 `scrollToError` 时,焦点恢复时机不对,导致 Input 的 `onEnterPress` 无法触发
   - **修复方案**: 
     - 将 `focus()` 移到 `onSubmit` 之前
     - 在 Input 的 `onBlur` 中添加补偿逻辑,当检测到 Enter 键按下标志时触发 `onEnterPress`
   - **修改文件**: `packages/base/src/input/simple-input.tsx`, `packages/hooks/src/components/use-form/use-form.ts`

3. **当前问题**:
   - PR #1182 的方案导致 `onEnterPress` 被触发两次:
     - 第一次: 在 `onBlur` 中触发(补偿逻辑)
     - 第二次: 在 `onKeyUp` 中触发(正常逻辑)
   - 并且事件顺序错误: `onEnterPress` → `onSubmit` (期望是 `onSubmit` → `onEnterPress`)

## 修复方案

**核心思路**: 将 trim 逻辑从依赖 Form 的 `blur` 改为在 Input 组件中主动处理

### 修改内容

1. **`packages/base/src/input/input.tsx`**:
   - 在 `onKeyDown` 中,当按下 Enter 键时,检查是否开启了 `trim`
   - 如果开启且值有前后空格,主动执行 trim 并更新值
   - 这样在 Form submit 之前就完成了 trim 处理

2. **`packages/base/src/input/simple-input.tsx`**:
   - 移除 PR #1182 添加的所有 `onBlur` 补偿逻辑
   - 移除 `useRef`、`needTriggerEnter` 相关代码
   - 恢复到原始的简单实现

3. **`packages/hooks/src/components/use-form/use-form.ts`**:
   - 移除 PR #871 添加的 `blur()` 和 `focus()` 调用
   - 因为现在 trim 不再依赖 blur 触发

### 优势

- ✅ **解耦**: Input 的 trim 不再依赖 Form 的 blur/focus 逻辑
- ✅ **时机正确**: trim 在 Enter 按下时立即执行,在 Form submit 之前
- ✅ **事件顺序正确**: onSubmit → onEnterPress
- ✅ **只触发一次**: onEnterPress 只在 `onKeyUp` 中触发一次
- ✅ **无需 blur/focus**: Form 不需要主动调用 blur 和 focus,避免各种焦点问题
- ✅ **代码更简洁**: 架构更清晰,职责划分更合理

## 测试建议

1. 测试按回车提交时 trim 功能是否正常
2. 测试按回车提交时 `onEnterPress` 只触发一次
3. 测试事件顺序: `onSubmit` → `onEnterPress`
4. 测试开启 `scrollToError` 时的表现

🤖 Generated with [Claude Code](https://claude.com/claude-code)