### PR TITLE
fix: 修复 Select、TreeSelect、Cascader 非 string 类型的 placeholder 在有输入值时重复显示的问题

### DIFF
--- a/docs/markdown/shineout/changelog-common.md
+++ b/docs/markdown/shineout/changelog-common.md
@@ -1,3 +1,10 @@
+## 3.9.5-beta.8
+2025-12-29
+
+### 🐞 BugFix
+-  修复 `Select`、`TreeSelect`、`Cascader` 非 string 类型的 `placeholder` 在有输入值时重复显示了的问题 ([#1551](https://github.com/sheinsight/shineout-next/pull/1551))
+
+
 ## 3.9.5-beta.2
 2025-12-23
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.5-beta.7",
+  "version": "3.9.5-beta.8",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/select/result-input.tsx
+++ b/packages/base/src/select/result-input.tsx
@@ -74,7 +74,7 @@ const ResultInput = (props: ResultInputProps) => {
   }, []);
 
   const renderResultPlaceholder = () => {
-    if (!inputText && !focus && props.placeholder && typeof props.placeholder !== 'string') {
+    if (props.isEmpty && !inputText && !focus && props.placeholder && typeof props.placeholder !== 'string') {
       return (
         <div className={styles.inputPlaceholder}>
           {props.placeholder}


### PR DESCRIPTION
## Summary
- 修复了 Select、TreeSelect、Cascader 组件中非 string 类型的 placeholder 在有输入值时重复显示的问题
- 在 `result-input.tsx` 中添加了 `props.isEmpty` 条件判断,确保只有在结果为空时才显示 placeholder
- 更新了 changelog 和版本号至 3.9.5-beta.8

## Test plan
- [x] 测试 Select 组件使用非 string 类型 placeholder 时的显示行为
- [x] 测试 TreeSelect 组件使用非 string 类型 placeholder 时的显示行为
- [x] 测试 Cascader 组件使用非 string 类型 placeholder 时的显示行为
- [x] 验证有输入值时 placeholder 不会重复显示
- [x] 验证无输入值且未聚焦时 placeholder 正常显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)