### PR TITLE
chore: release v3.9.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.5-beta.9",
+  "version": "3.9.5",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/version.ts
+++ b/packages/shineout-style/src/version.ts
@@ -1,1 +1,1 @@
-export default '3.9.4';
+export default '3.9.5';

--- a/packages/shineout/src/index.ts
+++ b/packages/shineout/src/index.ts
@@ -67,4 +67,4 @@ export * from './deprecated';
 
 export * as TYPE from './type';
 
-export default { version: '3.9.4' };
+export default { version: '3.9.5' };


### PR DESCRIPTION
## Summary
- 将版本号从 3.9.5-beta.9 更新到正式版 3.9.5
- 更新 package.json、packages/shineout-style/src/version.ts 和 packages/shineout/src/index.ts 中的版本号

## Test plan
- [x] 确认版本号已正确更新为 3.9.5
- [x] 验证所有测试通过
- [x] 确认构建成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)