### PR TITLE
fix(select): 修复 renderItem 函数第二参数 index 没有值的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.6-beta.4",
+  "version": "3.9.6-beta.5",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/select/list-option.tsx
+++ b/packages/base/src/select/list-option.tsx
@@ -70,7 +70,7 @@ const ListOption = <DataItem, Value>(props: ListOptionProps<DataItem, Value>) =>
   const { filterText, highlight } = useContext(FilterContext);
   const result = util.getHighlightText({
     enable: highlight,
-    nodeList: renderItem(data),
+    nodeList: renderItem(data, index),
     searchWords: filterText,
     highlightClassName: commonStyles?.highlight,
   });

--- a/packages/shineout/src/select/__doc__/changelog.cn.md
+++ b/packages/shineout/src/select/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.9.6-beta.5
+2025-12-31
+### 🐞 BugFix
+- 修复 `Select` 的 `renderItem` 函数第二参数 index 没有值的问题  ([#1560](https://github.com/sheinsight/shineout-next/pull/1560))
+
+
 ## 3.9.2-beta.4
 2025-12-03
 


### PR DESCRIPTION
## Summary
- 修复 Select 组件的 renderItem 函数第二参数 index 没有值的问题
- 在 `packages/base/src/select/list-option.tsx:73` 调用 renderItem 时传递 index 参数

## Changes
- 修复前: `renderItem(data)`
- 修复后: `renderItem(data, index)`
- 更新 changelog

## Related Issues
- 解决了 Select 组件中 renderItem 第二参数 index 始终为 undefined 的问题

🤖 Generated with [Claude Code](https://claude.com/claude-code)