### PR TITLE
fix(input): 修复 Input.Group 向非表单组件传递 placeTitle 导致的 React 警告

### DIFF
--- a/packages/base/src/input/input-group.tsx
+++ b/packages/base/src/input/input-group.tsx
@@ -7,6 +7,16 @@ import useWithFormConfig from '../common/use-with-form-config';
 import { util } from '@sheinx/hooks';
 import { useConfig } from '../config';
 
+// Components that support innerTitle and placeTitle props
+const INNER_TITLE_SUPPORTED_COMPONENTS = [
+  'Input',
+  'Select',
+  'Cascader',
+  'DatePicker',
+  'Textarea',
+  'EditableArea',
+];
+
 export default (props: InputGroupProps) => {
   const [focus, setFocus] = React.useState(false);
   const config = useConfig();
@@ -70,13 +80,24 @@ export default (props: InputGroupProps) => {
           return <span key={i}>{child}</span>;
         }
         if (React.isValidElement(child)) {
-          return cloneElement(child, {
+          const additionalProps: any = {
             ...getProps(child),
             disabled: child.props.disabled || disabled,
             size: child.props.size || size,
-            innerTitle: child.props.innerTitle || innerTitle,
-            placeTitle: child.props.placeTitle || placeTitle,
-          });
+          };
+
+          // Only pass innerTitle and placeTitle to components that support them
+          // Check by displayName to identify form components that accept these props
+          const displayName = (child.type as any)?.displayName;
+          const supportsInnerTitle = displayName &&
+            INNER_TITLE_SUPPORTED_COMPONENTS.some(name => displayName.includes(name));
+
+          if (supportsInnerTitle) {
+            additionalProps.innerTitle = child.props.innerTitle || innerTitle;
+            additionalProps.placeTitle = child.props.placeTitle || placeTitle;
+          }
+
+          return cloneElement(child, additionalProps);
         }
         return <span key={i}>{child}</span>;
       })}


### PR DESCRIPTION
## Summary
- 修复了 Input.Group 中，当 children 包含非表单组件（如 Link）时，innerTitle 和 placeTitle 属性被传递到原生 DOM 元素导致的 React 警告问题
- 通过检查子组件的 displayName 来判断是否应该传递 innerTitle 和 placeTitle 属性
- 只有支持这些属性的表单组件（Input、Select、Cascader、DatePicker、Textarea、EditableArea）才会收到这些 props

## 问题描述
在示例 `packages/shineout/src/input/__example__/03-number-1.tsx` 中，Input.Group 的 children 包含了 Link 组件。由于原来的实现无条件地将 innerTitle 和 placeTitle 传递给所有子组件，Link 组件通过 `...restProps` 将这些属性传递到了底层的 `<a>` 标签，触发了 React 警告：

```
Warning: React does not recognize the `placeTitle` prop on a DOM element.
```

## 解决方案
1. 在文件顶部定义 `INNER_TITLE_SUPPORTED_COMPONENTS` 常量数组，包含所有支持这些属性的组件名称关键字
2. 在处理 children 时，检查子组件的 `displayName` 是否包含支持的组件名称
3. 只有当子组件支持这些属性时，才传递 innerTitle 和 placeTitle

## 变更文件
- `packages/base/src/input/input-group.tsx`

## 测试计划
- [x] 验证示例页面不再出现 React 警告
- [x] 确认 Input.Group 的 innerTitle 和 placeTitle 属性仍能正常传递给 Input 等表单组件
- [x] 确认非表单组件（如 Link）不会收到这些属性

🤖 Generated with [Claude Code](https://claude.com/claude-code)