### PR TITLE
chore: Release v3.9.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.6-beta.9",
+  "version": "3.9.6",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/version.ts
+++ b/packages/shineout-style/src/version.ts
@@ -1,1 +1,1 @@
-export default '3.9.5';
+export default '3.9.6';

--- a/packages/shineout/src/index.ts
+++ b/packages/shineout/src/index.ts
@@ -67,4 +67,4 @@ export * from './deprecated';
 
 export * as TYPE from './type';
 
-export default { version: '3.9.5' };
+export default { version: '3.9.6' };


### PR DESCRIPTION
## Summary
- Bump version from 3.9.6-beta.8 to 3.9.6 in package.json
- Update shineout-style version to 3.9.6
- Update shineout package version to 3.9.6

## Test plan
- [x] Verify version numbers are correctly updated across all packages
- [x] Confirm build passes successfully
- [x] Check that the release is ready for production deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)