### PR TITLE
feat(tabs): 支持 Tabs.Panel 透传 data-* 属性到 tabs-header 元素

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.6",
+  "version": "3.9.7-beta.1",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/tabs/tab.tsx
+++ b/packages/base/src/tabs/tab.tsx
@@ -86,6 +86,7 @@ const Tab = (props: TabProps, ref: any) => {
   const containerProps = {
     className: tabClass,
     ...getStateProps(),
+    ...util.extractProps(props, "data-attr"),
     style: style,
     onClick: handleClick,
     ref: ref,

--- a/packages/base/src/tabs/tabs-panel.tsx
+++ b/packages/base/src/tabs/tabs-panel.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import { useLayoutEffect, useRef } from 'react';
 import { TabsClasses } from './tabs.type';
-import { useTabsContext } from '@sheinx/hooks';
+import { useTabsContext, util } from '@sheinx/hooks';
 import { TabsPanelProps } from './tabs-panel.type';
 import { TabData } from './tab.type';
 
@@ -22,6 +22,7 @@ const TabsPanel = (props: TabsPanelProps) => {
       jssStyle,
       background: shape !== 'button' && shape !== 'fill' ? background : undefined,
       color: props.color || (active === id ? color : undefined),
+      ...util.extractProps(props, 'data-attr'),
     } as TabData;
 
     setTabs((prev) => {

--- a/packages/shineout/src/tabs/__doc__/changelog.cn.md
+++ b/packages/shineout/src/tabs/__doc__/changelog.cn.md
@@ -1,8 +1,15 @@
+## 3.9.7-beta.1
+2026-01-07
+
+### 🆕 Feature
+- `Tabs.Panel` 支持透传 data-* 属性到 tabs-header 元素上 ([#1567](https://github.com/sheinsight/shineout-next/pull/1567))
+
+
 ## 3.9.6-beta.7
 2026-01-05
 
 ### 🐞 BugFix
-- 修复 `Tabs` 的 tab 属性传入带有 `to` 属性的自定义组件时渲染结构异常的问题 ([#1563](https://github.com/sheinsight/shineout-next/pull/1563))
+- 修复 `Tabs.Panel` 的 tab 属性传入带有 `to` 属性的自定义组件时渲染结构异常的问题 ([#1563](https://github.com/sheinsight/shineout-next/pull/1563))
 
 
 ## 3.9.0-beta.19


### PR DESCRIPTION
## Summary
- 新增 `Tabs.Panel` 支持透传 `data-*` 属性到 Tab 组件的 header 元素上
- 更新版本号至 3.9.7-beta.1
- 更新 changelog 文档

## Changes
- `packages/base/src/tabs/tab.tsx`: 在 Tab 组件中添加对 data-* 属性的提取和透传
- `packages/base/src/tabs/tabs-panel.tsx`: 在 TabsPanel 组件中引入 util 并提取 data-* 属性
- `package.json`: 版本号更新至 3.9.7-beta.1
- `packages/shineout/src/tabs/__doc__/changelog.cn.md`: 添加新版本的 changelog 条目

## Test plan
- [x] 验证 `Tabs.Panel` 可以正确透传 `data-*` 属性到对应的 tabs-header 元素
- [x] 验证现有的 Tabs 功能不受影响
- [x] 验证版本号更新正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)