### PR TITLE
fix(table): 修复虚拟滚动下 checkbox 列 rowSpan 导致的错误勾选问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.6-beta.8",
+  "version": "3.9.6-beta.9",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

修复了 Table 组件在虚拟滚动场景下，当 checkbox 列设置了 rowSpan 但实际不合并行时，由于其他列的 rowSpan 合并导致勾选单行时错误勾选多行的问题。

## 问题描述

**场景复现：**
- checkbox 列配置：`rowSpan: (a, b) => false`（永远不合并）
- SPU 列配置：`rowSpan: (a, b) => a.spu_name === b.spu_name`（合并相同 SPU 的行）
- 当第 1、2、3 行的 SPU 相同时，SPU 列会合并这三行
- **Bug**：勾选第 1 行的 checkbox 时，第 1、2、3 行都被勾选了

**根本原因：**
在虚拟滚动场景下，原代码使用全局的 `rowSpanIndexArray`（包含所有列的合并信息）来计算 checkbox 的选择数据 `rowSelectMergeStartData`，导致 checkbox 列的选择行为被其他列的 rowSpan 影响。

## 核心改动

### 1. 为 checkbox 列单独计算 rowSpan 索引数组
```typescript
const checkboxRowSpanIndexArray = useMemo(() => {
  // 只基于 checkbox 列的 rowSpan 函数计算索引数组
  // 不受其他列的 rowSpan 影响
}, [props.columns, props.originData, props.rowSpanIndexArray]);
```

### 2. 使用 useMemo 缓存以优化性能
- 避免虚拟滚动时每次都遍历整个 `originData`
- 只在 `columns`、`originData`、`rowSpanIndexArray` 变化时重新计算

### 3. 优化分支判断逻辑
将嵌套的 if-else 改为平行的三分支结构，更清晰：
- 虚拟滚动 + checkbox 有 rowSpan → 使用预计算的 `checkboxRowSpanIndexArray`
- 非虚拟滚动 + checkbox 有 rowSpan → 基于当前数据实时计算
- checkbox 无 rowSpan → 每行都是自己

### 4. 修复依赖项
在 `rowData` 的 useMemo 依赖数组中添加 `checkboxRowSpanIndexArray`，确保正确更新。

## Test plan

- [x] 测试虚拟滚动场景下，checkbox 列 rowSpan 返回 false 时，勾选单行不会影响其他行
- [x] 测试虚拟滚动场景下，checkbox 列有真实的 rowSpan 合并时，勾选行为正确
- [x] 测试非虚拟滚动场景下，功能不受影响
- [x] 验证性能：大数据量下虚拟滚动流畅，无重复计算

## 影响范围

- 文件：`packages/hooks/src/components/use-table/use-table-row.tsx`
- 版本：`3.9.6-beta.9`
- 影响场景：Table 组件使用虚拟滚动 + checkbox 列设置了 rowSpan 的情况

🤖 Generated with [Claude Code](https://claude.com/claude-code)