### PR TITLE
fix(image): 修复error信息默认没有居中显示的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.7-beta.3",
+  "version": "3.9.7-beta.4",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/image/image.ts
+++ b/packages/shineout-style/src/image/image.ts
@@ -184,6 +184,9 @@ const ImageStyle: JsStyles<ImageClass> = {
   rounded: {
     borderRadius: Token.imageBorderRadius,
     outline: `1px solid ${Token.imageBorderColor}`,
+    'a&:hover': {
+      outline: `1px solid ${Token.imageBorderColor}`,
+    }
   },
 
   thumbnail: {
@@ -239,6 +242,10 @@ const ImageStyle: JsStyles<ImageClass> = {
     height: '100%',
     margin: 'auto',
     backgroundColor: Token.imageErrorBackgroundColor,
+
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 
   overlay: {

--- a/packages/shineout/src/image/__doc__/changelog.cn.md
+++ b/packages/shineout/src/image/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.9.7-beta.4
+2026-01-09
+### 🐞 BugFix
+- 修复 `Image` 的 `error` 信息默认没有居中显示的问题 ([#1572](https://github.com/sheinsight/shineout-next/pull/1572))
+
+
 ## 3.8.0-beta.24
 2025-08-08
 


### PR DESCRIPTION
## Summary
- 修复 `Image` 组件的 `error` 信息默认没有居中显示的问题
- 为 error 容器添加 flex 布局实现内容居中
- 修复 rounded 模式下链接 hover 时 outline 样式被覆盖的问题
- 升级版本至 3.9.7-beta.4

## Test plan
- [x] 验证 Image 组件加载失败时 error 信息居中显示
- [x] 验证 rounded 模式下链接 hover 效果正常
- [ ] 验证不影响其他 Image 功能

🤖 Generated with [Claude Code](https://claude.com/claude-code)