### PR TITLE
fix(style): 修复 Modal 和 Transfer 组件的 UI 样式问题

### DIFF
--- a/packages/shineout-style/src/modal/modal.ts
+++ b/packages/shineout-style/src/modal/modal.ts
@@ -366,6 +366,7 @@ const modalStyle: JsStyles<ModalClassType> = {
     '& svg': {
       zIndex: 1,
       position: 'relative',
+      display: 'block',
     },
     '&:hover': {
       '&:after': {

--- a/packages/shineout-style/src/transfer/transfer.ts
+++ b/packages/shineout-style/src/transfer/transfer.ts
@@ -43,11 +43,15 @@ const TransferStyle: JsStyles<TransferClass> = {
     '& $source': {
       borderRadius: `${Token.transferBorderRadius} 0 0 ${Token.transferBorderRadius}`,
       borderRight: 0,
+      '& $header': {
+        borderRadius: `${Token.transferBorderRadius} 0 0 0`,
+      },
     },
     '& $target': {
       borderRadius: `0 ${Token.transferBorderRadius} ${Token.transferBorderRadius} 0`,
       '& $header': {
         paddingRight: 6,
+        borderRadius: `0 ${Token.transferBorderRadius} 0 0`,
       },
     },
   },


### PR DESCRIPTION
## Summary
- 修复 Modal 组件关闭按钮的 SVG 图标对齐问题,添加 `display: block` 样式
- 修复 Transfer 组件源列表和目标列表 header 的圆角显示问题,添加正确的 `borderRadius` 样式

## Test plan
- [x] 验证 Modal 组件关闭按钮图标对齐正确
- [x] 验证 Transfer 组件列表 header 圆角样式正确显示
- [x] 确认不影响其他组件样式

🤖 Generated with [Claude Code](https://claude.com/claude-code)