### PR TITLE
fix(tree): 修复受控高亮模式下无法通过设置 active 为 undefined 取消高亮的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.7-beta.4",
+  "version": "3.9.7-beta.5",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/tree/tree.tsx
+++ b/packages/base/src/tree/tree.tsx
@@ -126,12 +126,17 @@ const Tree = <DataItem, Value extends KeygenResult[]>(props: TreeProps<DataItem,
     return props.height || styleHeight;
   };
 
-  const handleUpdateActive = (active?: KeygenResult, item?: DataItem) => {
-    setActive(active);
-
-    if (active !== props.active) {
-      propSetActive?.(active, item);
+  const handleUpdateActive = (active?: KeygenResult, item?: DataItem, fromUser: boolean = false) => {
+    if (isActiveControlled && fromUser) {
+      // 受控模式下,用户点击时只调用外部回调,不更新内部状态
+      if (active !== props.active) {
+        propSetActive?.(active, item);
+      }
+      return;
     }
+
+    // 其他情况(非受控模式,或受控模式下由 props.active 变化触发),更新内部状态和节点
+    setActive(active);
 
     datum.updateMap.forEach((update, id) => {
       update('active', id === active);
@@ -139,7 +144,7 @@ const Tree = <DataItem, Value extends KeygenResult[]>(props: TreeProps<DataItem,
   };
 
   const handleNodeClick = (node: DataItem, id: KeygenResult) => {
-    handleUpdateActive(id, node);
+    handleUpdateActive(id, node, true);
 
     if (onClick) {
       onClick(node, id, datum.getPath(id));

--- a/packages/shineout/src/tree/__doc__/changelog.cn.md
+++ b/packages/shineout/src/tree/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.9.7-beta.5
+2026-01-12
+### 🐞 BugFix
+- 修复 `Tree` 受控高亮模式下无法通过设置 `active` 为 undefined 取消高亮的问题 ([#1574](https://github.com/sheinsight/shineout-next/pull/1574))
+
+
 ## 3.9.3-beta.10
 2025-12-09
 ### 🆕 Feature


### PR DESCRIPTION
## Summary
修复 Tree 组件在受控高亮模式下无法通过设置 `active` 为 `undefined` 取消高亮的问题

## 问题描述
在受控模式下(`active` 和 `setActive` 都设置),当用户点击节点时:
1. 组件会立即同步更新内部状态和所有节点的 active 状态
2. 即使外部回调中将 `active` 设置为 `undefined`,由于是异步更新,节点已经被高亮
3. 导致无法通过回调阻止节点高亮

## 解决方案
修改 `handleUpdateActive` 函数,添加 `fromUser` 参数区分更新来源:
- **用户点击时** (`fromUser=true`): 受控模式下只调用外部回调,不更新内部状态,等待外部决定 `props.active` 的值
- **props.active 变化时** (`fromUser=false`): 通过 useEffect 触发,更新内部状态和所有节点的 active 状态

这样实现了真正的受控模式,外部可以完全控制哪些节点可以高亮。

## 测试用例
参考示例: `packages/shineout/src/tree/__example__/13-highlight-control.tsx`

点击 id='1' 的节点时,在 `setActive` 回调中设置 `active` 为 `undefined`,节点不会高亮

## 相关文件
- `packages/base/src/tree/tree.tsx`
- `packages/shineout/src/tree/__doc__/changelog.cn.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)