### PR TITLE
fix(tree): 在访问 childrenKey 前添加 item 空值检查

### DIFF
--- a/docs/markdown/shineout/changelog-common.md
+++ b/docs/markdown/shineout/changelog-common.md
@@ -1,3 +1,9 @@
+## 3.9.7-beta.6
+2026-01-12
+### 🐞 BugFix
+- 修复树形数据类的组件可能报 "Cannot read properties of undefined (reading 'children')" 错误的问题 ([#1575](https://github.com/sheinsight/shineout-next/pull/1575))
+
+
 ## 3.9.5-beta.8
 2025-12-29
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.7-beta.5",
+  "version": "3.9.7-beta.6",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-tree/use-tree.ts
+++ b/packages/hooks/src/components/use-tree/use-tree.ts
@@ -321,7 +321,7 @@ const useTree = <DataItem>(props: BaseTreeProps<DataItem>) => {
 
       let children: KeygenResult[] = [];
 
-      if (Array.isArray(item[childrenKey])) {
+      if (item && Array.isArray(item[childrenKey])) {
         const _children = initData(
           item[childrenKey] as DataItem[],
           [...path, id],
@@ -371,7 +371,7 @@ const useTree = <DataItem>(props: BaseTreeProps<DataItem>) => {
         }
       }
 
-      if (Array.isArray(item[childrenKey])) {
+      if (item && Array.isArray(item[childrenKey])) {
         initFlatData(item[childrenKey] as DataItem[], [...path, id], level + 1, id, result);
       }
     }


### PR DESCRIPTION
## Summary
- 修复了 `initData` 和 `initFlatData` 函数中可能出现的空指针异常
- 在访问 `item[childrenKey]` 之前添加了 `item` 的空值检查
- 防止在某些边缘情况下（如数据中存在 null/undefined 项）出现运行时错误

## 修改内容
在 `packages/hooks/src/components/use-tree/use-tree.ts` 中的两处位置：
1. `initData` 函数（第324行）：`if (item && Array.isArray(item[childrenKey]))`
2. `initFlatData` 函数（第374行）：`if (item && Array.isArray(item[childrenKey]))`

## 影响范围
- 这是一个防御性编程的改进，不会影响正常数据的处理流程
- 提高了组件在处理异常数据时的健壮性
- 对现有功能无副作用

## Test plan
- [x] 验证正常的树形数据渲染功能
- [x] 验证虚拟滚动模式下的树形数据渲染
- [x] 验证含有 null/undefined 项的数据不会导致崩溃
- [x] 验证所有现有测试用例通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)