### PR TITLE
fix(menu): 修复折叠图标在 Safari 浏览器中不显示的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.7-beta.6",
+  "version": "3.9.7-beta.7",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/menu/menu.ts
+++ b/packages/shineout-style/src/menu/menu.ts
@@ -489,7 +489,11 @@ const menuStyle: JsStyles<MenuClassType> = {
     '&[dir=ltr] svg': { transform: 'rotate(-90deg)' },
     '&[dir=rtl] svg': { transform: 'rotate(90deg)' },
   },
-  icon: {},
+  icon: {
+    '& > svg': {
+      width: '100%',
+    }
+  },
   expandHover: {
     '&:hover': {
       backgroundColor: token.menuExpandHoverBackgroundColor,

--- a/packages/shineout/src/menu/__doc__/changelog.cn.md
+++ b/packages/shineout/src/menu/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.9.7-beta.7
+2026-01-12
+### 🐞 BugFix
+- 修复 `Menu` 的折叠图标在Safari浏览器中不显示的问题 ([#1576](https://github.com/sheinsight/shineout-next/pull/1576))
+
+
 ## 3.9.6-beta.2
 2025-12-30
 


### PR DESCRIPTION
## Summary
- 修复 Menu 组件的折叠图标在 Safari 浏览器中不显示的问题
- 为 icon 样式添加 svg 宽度设置为 100%
- 更新版本号至 3.9.7-beta.7

## Test plan
- [x] 在 Safari 浏览器中测试 Menu 组件的折叠图标是否正常显示
- [x] 在 Chrome、Firefox 等浏览器中验证无回归问题
- [x] 验证横向和纵向菜单的折叠图标都能正常显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)