### PR TITLE
style: 优化 normalize 和 jss-insertion-point 标签，增加 data-alita-ignore 属性

### DIFF
--- a/docs/markdown/shineout/changelog-common.md
+++ b/docs/markdown/shineout/changelog-common.md
@@ -1,3 +1,8 @@
+## 3.9.7-beta.9
+2026-01-13
+### 💅 Style
+- 优化 normalize 和 jss-insertion-point 标签，增加 data-alita-ignore 属性，避免被微前端框架删除 ([#1578](https://github.com/sheinsight/shineout-next/pull/1578))
+
 ## 3.9.7-beta.6
 2026-01-12
 ### 🐞 BugFix

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.7-beta.8",
+  "version": "3.9.7-beta.9",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/normalize.ts
+++ b/packages/shineout-style/src/normalize.ts
@@ -381,6 +381,7 @@ export const jssInsertionPointId = 'shineout-next-jss-insertion-point__' + versi
 function appendNormalizeStyle(styleString: string, id: string){
   const style = document.createElement('style');
   style.setAttribute('name', id);
+  style.setAttribute('data-alita-ignore', 'true');
   style.innerHTML = styleString;
   document.head.insertBefore(style, document.head.firstChild);
 }
@@ -388,6 +389,7 @@ function appendNormalizeStyle(styleString: string, id: string){
 function appendJssInsertionPoint(){
   const insertionPoint = document.createElement('style');
   insertionPoint.setAttribute('name', jssInsertionPointId);
+  insertionPoint.setAttribute('data-alita-ignore', 'true');
   document.head.insertBefore(insertionPoint, document.head.firstChild);
 
   jss.setup({insertionPoint: insertionPoint})


### PR DESCRIPTION
## Summary
- 为 normalize 和 jss-insertion-point 样式标签添加 `data-alita-ignore` 属性
- 避免被微前端框架（如 Alita）删除这些关键样式标签
- 确保组件样式的稳定性和正确性

## 背景
在微前端环境中，某些框架（如 Alita）会清理 DOM 中的样式标签。通过添加 `data-alita-ignore` 属性，可以标记这些样式标签不被清理，从而保证样式的正常加载和应用。

## 修改内容
- 在 `packages/shineout-style/src/normalize.ts` 中为 normalize 样式标签和 jss-insertion-point 标签添加 `data-alita-ignore="true"` 属性
- 更新版本号至 3.9.7-beta.9
- 更新 changelog

## Test plan
- [x] 验证在微前端环境（Alita）中样式标签不会被删除
- [x] 验证组件样式正常加载和显示
- [x] 验证不影响非微前端环境的正常使用

🤖 Generated with [Claude Code](https://claude.com/claude-code)