### PR TITLE
fix(hooks): 简化 isLink 函数的路由组件判断逻辑

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.7-beta.9",
+  "version": "3.9.7-beta.10",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/utils/is.ts
+++ b/packages/hooks/src/utils/is.ts
@@ -80,17 +80,8 @@ export const isLink = (el: unknown): el is React.ReactElement => {
     if (!React.isValidElement(el)) return false;
     if (!el.type) return false;
     if (el.type === 'a') return true;
-    // 只有当是已知的路由组件时才判断 to 属性
-    if (el.props && (el as React.ReactElement).props.to) {
-      const typeName = typeof el.type === 'function' ? el.type.name : '';
-      const displayName = typeof el.type === 'object' && el.type !== null ? (el.type as any).displayName : '';
-      // 检查是否为常见的路由链接组件
-      const isRouterComponent = typeName === 'Link' ||
-                                typeName === 'NavLink' ||
-                                displayName === 'Link' ||
-                                displayName === 'NavLink';
-      return isRouterComponent;
-    }
+    // 有 to 属性 和 render 函数 就认为是链接组件（react-router Link NavLink 的特征）
+    if (el.props && (el as React.ReactElement).props.to && (el as any).type?.render) return true;
   }
 
   return false;


### PR DESCRIPTION
## Summary
- 移除了 isLink 函数中复杂的组件名称判断逻辑
- 使用 `to` 属性和 `render` 函数作为判断路由组件的标准
- 版本升级至 3.9.7-beta.10

## Changes
- **packages/hooks/src/utils/is.ts**: 简化了 isLink 函数的实现，使用更简洁的逻辑判断 react-router 的 Link 和 NavLink 组件
- **package.json**: 版本号从 3.9.7-beta.9 升级到 3.9.7-beta.10

## Test plan
- [x] 验证常规 `<a>` 标签仍能正确识别为链接
- [x] 验证 react-router 的 Link 组件能正确识别
- [x] 验证 react-router 的 NavLink 组件能正确识别
- [x] 运行现有测试确保无回归

## Payground ID
6f7e0a9a-435c-4ea0-bc4c-b403ba00a336

🤖 Generated with [Claude Code](https://claude.com/claude-code)