### PR TITLE
fix(hooks): 修复 isLink 函数在生产构建后判断失效的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.7-beta.10",
+  "version": "3.9.7-beta.11",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/utils/is.ts
+++ b/packages/hooks/src/utils/is.ts
@@ -80,8 +80,7 @@ export const isLink = (el: unknown): el is React.ReactElement => {
     if (!React.isValidElement(el)) return false;
     if (!el.type) return false;
     if (el.type === 'a') return true;
-    // 有 to 属性 和 render 函数 就认为是链接组件（react-router Link NavLink 的特征）
-    if (el.props && (el as React.ReactElement).props.to && (el as any).type?.render) return true;
+    if (el.props && (el as React.ReactElement).props.to) return true;
   }
 
   return false;


### PR DESCRIPTION
## Summary
- 移除了 `isLink` 函数中对 `type.render` 属性的检查
- 修复了本地开发环境判断正常，但生产构建后判断失效的问题
- 升级版本号至 3.9.7-beta.11

## Problem
之前的实现依赖 `(el as any).type?.render` 来判断是否为路由组件（如 react-router 的 Link/NavLink）。但这个属性在 webpack 生产构建时可能会被 Terser/UglifyJS 等压缩工具优化掉，导致：
- 开发环境：`type.render` 存在 → 判断为 true ✅
- 生产环境：`type.render` 被移除 → 判断为 false ❌

## Solution
简化判断逻辑，只要元素有 `to` 属性就认为是链接组件。这样可以避免构建工具的影响，保证开发和生产环境行为一致。

## Test plan
- [ ] 在本地开发环境测试 Tabs/Menu 组件使用路由链接的场景
- [ ] 构建生产版本后验证路由链接功能正常
- [ ] 确认版本号已更新为 3.9.7-beta.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)