### PR TITLE
fix(style): 修复 Select 和 Tree 组件的 UI 尺寸问题

### DIFF
--- a/packages/shineout-style/src/select/select.ts
+++ b/packages/shineout-style/src/select/select.ts
@@ -312,7 +312,7 @@ const selectStyle: JsStyles<SelectClassType> = {
       fontSize: token.selectLargeFontSize,
     },
     '& $optionGroupTitle': {
-      padding: `calc(${token.selectFontSize} + 2px) calc(${token.selectOptionPaddingX} + ${token.selectLargeOptionInnerPaddingX}) ${token.selectGroupTitleLargeBottom} calc(${token.selectOptionPaddingX} + ${token.selectLargeOptionInnerPaddingX})`,
+      padding: `${token.selectFontSize} calc(${token.selectOptionPaddingX} + ${token.selectLargeOptionInnerPaddingX}) ${token.selectGroupTitleLargeBottom} calc(${token.selectOptionPaddingX} + ${token.selectLargeOptionInnerPaddingX})`,
     },
   },
   iconWrapper: {
@@ -399,7 +399,15 @@ const selectStyle: JsStyles<SelectClassType> = {
   },
   moreIcon: {},
   hideTag: {},
-  list: {},
+  list: {
+    '--group-font-size': `calc(${token.selectFontSize} - 2px)`,
+    '$pickerSmall &': {
+      '--group-font-size': `${token.selectSmallFontSize}`,
+    },
+    '$pickerLarge &': {
+      '--group-font-size': `calc(${token.selectLargeFontSize} - 2px)`,
+    },
+  },
   tree: {
     padding: '0 4px',
     overflow: 'auto',
@@ -530,9 +538,9 @@ const selectStyle: JsStyles<SelectClassType> = {
   },
   optionGroup: {},
   optionGroupTitle: {
-    fontSize: token.selectGroupTitleFontSize,
+    fontSize: `var(--group-font-size, ${token.selectGroupTitleFontSize})`,
     lineHeight: token.lineHeightDynamic,
-    padding: `calc(${token.selectFontSize} - 4px) ${token.selectGroupTitlePaddingX} ${token.selectGroupTitlePaddingBottom} ${token.selectGroupTitlePaddingX}`,
+    padding: `calc(${token.selectFontSize} - 2px) ${token.selectGroupTitlePaddingX} ${token.selectGroupTitlePaddingBottom} ${token.selectGroupTitlePaddingX}`,
     color: token.selectGroupTitleFontColor,
     fontWeight: token.selectGroupTitleFontWeight,
   },

--- a/packages/shineout-style/src/tree/tree.ts
+++ b/packages/shineout-style/src/tree/tree.ts
@@ -347,7 +347,7 @@ const treeStyle: JsStyles<TreeClassType> = {
     position: 'absolute',
     width: 24,
     height: 24,
-    margin: '1px 0',
+    margin: `calc((${Token.treeFontSize} - 12px)/2) 0`,
     display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',


### PR DESCRIPTION
## Summary
- 优化 Select 组件 group title 的 padding 计算，移除不必要的 calc 运算
- 添加 CSS 变量 `--group-font-size` 以支持不同尺寸下的字体大小动态调整
- 修正 Select large 尺寸下 group title 的 padding 值（从 `calc(fontSize + 2px)` 改为 `fontSize`）
- 修复 Tree 组件 icon 的 margin 计算，使其基于字体大小动态调整（从固定 `1px 0` 改为 `calc((fontSize - 12px)/2) 0`）

## Test plan
- [x] 测试 Select 组件在不同尺寸（small/default/large）下的显示效果
- [x] 验证 Select group title 的间距是否正确
- [x] 测试 Tree 组件 icon 的垂直对齐是否正确
- [x] 确认样式改动不影响其他组件功能

🤖 Generated with [Claude Code](https://claude.com/claude-code)