### PR TITLE
fix(textarea): 修复 clearable 属性在禁用状态下仍然显示清除按钮的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.8-beta.3",
+  "version": "3.9.8-beta.4",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/textarea/simple-textarea.tsx
+++ b/packages/base/src/textarea/simple-textarea.tsx
@@ -88,7 +88,7 @@ const Textarea = (props: SimpleTextareaProps) => {
   }
 
   let clearEl = null;
-  if (clearable && props.value) {
+  if (clearable && props.value && !disabled) {
     clearEl = (
       <div
         className={textareaClasses?.clear}

--- a/packages/shineout/src/textarea/__doc__/changelog.cn.md
+++ b/packages/shineout/src/textarea/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.9.8-beta.4
+2026-01-19
+### 🐞 BugFix
+- 修复 `Textarea` 的 `clearable` 属性在禁用状态下仍然显示清除按钮的问题 ([#1586](https://github.com/sheinsight/shineout-next/pull/1586))
+
+
 ## 3.8.5-beta.4
 2025-09-29
 


### PR DESCRIPTION
## Summary
- 修复 Textarea 组件在 disabled 状态下,clearable 属性仍然显示清除按钮的问题
- 更新版本号至 3.9.8-beta.4

## Changes
- `packages/base/src/textarea/simple-textarea.tsx`: 在 clearable 判断条件中添加 `!disabled` 检查
- `package.json`: 版本号从 3.9.8-beta.3 升级到 3.9.8-beta.4
- `packages/shineout/src/textarea/__doc__/changelog.cn.md`: 添加此次修复的更新日志

## Test plan
- [x] 验证 Textarea 在禁用状态下不显示清除按钮
- [x] 验证 Textarea 在非禁用状态下正常显示清除按钮
- [x] 确保不影响其他已有功能

🤖 Generated with [Claude Code](https://claude.com/claude-code)