### PR TITLE
fix(table): optimize table layout to reduce unnecessary reflows

### DIFF
--- a/packages/hooks/src/components/use-table/use-table-layout.tsx
+++ b/packages/hooks/src/components/use-table/use-table-layout.tsx
@@ -138,7 +138,16 @@ const useTableLayout = (props: UseTableLayoutProps) => {
     // 修改`Table`被display:none时，表格头样式错乱的问题
     if (cols && cols.every((v) => v === 0)) return;
 
-    setColgroup(shiftDecimalToLastColumn(cols));
+    const shifted = shiftDecimalToLastColumn(cols);
+    // 值未变化时跳过，避免触发不必要的 useLayoutEffect
+    if (
+      colgroup &&
+      shifted.length === colgroup.length &&
+      shifted.every((v, i) => v === colgroup[i])
+    ) {
+      return;
+    }
+    setColgroup(shifted);
     setAdjust(adjust);
     if (!adjust) {
       updateResizeFlag();
@@ -188,7 +197,7 @@ const useTableLayout = (props: UseTableLayoutProps) => {
     let index = 0;
     let sum = 0;
     for (let i = 0, count = items.length; i < count; i++) {
-      const { width } = items[i].getBoundingClientRect();
+      const width = (items[i] as HTMLElement).offsetWidth;
       sum += width;
       const colspan = items[i].getAttribute('colspan');
       const colspanNum = parseInt(colspan || '1', 10);

--- a/packages/shineout/src/table/__doc__/changelog.cn.md
+++ b/packages/shineout/src/table/__doc__/changelog.cn.md
@@ -1,5 +1,5 @@
-## 3.9.13-beta.1
-2026-04-01
+## 3.9.14-beta.1
+2026-04-20
 ### 🚀 Performance
 - 优化 `Table` 布局计算逻辑，跳过未变化的 colgroup 更新并减少不必要的重排（reflow） ([#1655](https://github.com/sheinsight/shineout-next/pull/1655))
 

--- a/packages/shineout/src/table/__doc__/changelog.cn.md
+++ b/packages/shineout/src/table/__doc__/changelog.cn.md
@@ -1,3 +1,8 @@
+## 3.9.11-beta.11
+2026-03-16
+### 🚀 Performance
+- 优化 `Table` 点击交互时的布局计算性能，减少不必要的浏览器回流 ([#1655](https://github.com/sheinsight/shineout-next/pull/1655))
+
 ## 3.9.11-beta.4
 2026-03-09
 ### 🚀 Performance

--- a/packages/shineout/src/table/__doc__/changelog.cn.md
+++ b/packages/shineout/src/table/__doc__/changelog.cn.md
@@ -1,5 +1,5 @@
-## 3.9.12-beta.11
-2026-03-30
+## 3.9.13-beta.1
+2026-04-01
 ### 🚀 Performance
 - 优化 `Table` 布局计算逻辑，跳过未变化的 colgroup 更新并减少不必要的重排（reflow） ([#1655](https://github.com/sheinsight/shineout-next/pull/1655))
 

--- a/packages/shineout/src/table/__doc__/changelog.cn.md
+++ b/packages/shineout/src/table/__doc__/changelog.cn.md
@@ -1,7 +1,7 @@
-## 3.9.11-beta.11
-2026-03-16
+## 3.9.12-beta.11
+2026-03-30
 ### 🚀 Performance
-- 优化 `Table` 点击交互时的布局计算性能，减少不必要的浏览器回流 ([#1655](https://github.com/sheinsight/shineout-next/pull/1655))
+- 优化 `Table` 布局计算逻辑，跳过未变化的 colgroup 更新并减少不必要的重排（reflow） ([#1655](https://github.com/sheinsight/shineout-next/pull/1655))
 
 ## 3.9.11-beta.4
 2026-03-09


### PR DESCRIPTION
## Summary
- Skip `setColgroup` when colgroup values are unchanged, avoiding unnecessary `useLayoutEffect` triggers that cause forced reflows (`checkScroll` + `checkFloat`)
- Replace `getBoundingClientRect().width` with `offsetWidth` in `getColgroup` to reduce forced layout recalculations during click events

## Test plan
- [ ] Verify Table renders correctly with fixed columns and scroll
- [ ] Verify column drag resize still works properly
- [ ] Use Chrome Performance profiler to confirm reduced reflow cost under `measureHostInstance` during click events
- [ ] Verify Table with `dataChangeResize` prop still recalculates columns on data change

🤖 Generated with [Claude Code](https://claude.com/claude-code)