### PR TITLE
fix(style): 修复 Select 和 DatePicker 样式 token

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.13-beta.9",
+  "version": "3.9.13-beta.10",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/date-picker/date-picker.ts
+++ b/packages/shineout-style/src/date-picker/date-picker.ts
@@ -163,6 +163,12 @@ const datePickerStyle: JsStyles<DatePickerClassType> = {
       '&::placeholder': {
         color: token.inputPlaceholderColor,
       },
+      '$wrapperDisabled &': {
+        color: token.inputDisabledFontColor,
+        '&::placeholder': {
+          color: token.inputDisabledPlaceholderColor,
+        },
+      },
     },
   },
   resultTextBg: {

--- a/packages/shineout-style/src/select/select.ts
+++ b/packages/shineout-style/src/select/select.ts
@@ -338,7 +338,7 @@ const selectStyle: JsStyles<SelectClassType> = {
     color: token.inputClearColor,
     verticalAlign: 'middle',
     '&:hover': {
-      color: token.selectIconColor,
+      color: token.inputHoverClearColor,
     },
     '$wrapperSmall &': {
       width: token.inputSmallFontSize,
@@ -352,7 +352,7 @@ const selectStyle: JsStyles<SelectClassType> = {
     verticalAlign: 'middle',
     width: token.inputFontSize,
     lineHeight: 0,
-    color: token.selectIconColor,
+    color: token.inputIconColor,
     transition: 'transform 0.3s',
   },
   arrowIconOpen: {


### PR DESCRIPTION
## Summary
- 修复 Select 清除按钮 hover 颜色和箭头图标颜色使用了错误的 token
- 修复 DatePicker 禁用状态下文字和 placeholder 颜色未正确显示
- bump version to 3.9.13-beta.10

## Test plan
- [ ] 验证 Select 清除按钮 hover 态颜色正确
- [ ] 验证 Select 箭头图标颜色正确
- [ ] 验证 DatePicker 禁用态文字颜色和 placeholder 颜色正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)