### PR TITLE
fix(style/input): fix date picker time item tokens and Input.Number step button bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.13-beta.11",
+  "version": "3.9.13-beta.12",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-input/use-input-number.ts
+++ b/packages/hooks/src/components/use-input/use-input-number.ts
@@ -162,15 +162,18 @@ const useNumberFormat = (props: InputNumberProps) => {
     }
     num = commonFormat(num) as number;
     onChange?.(num);
+    return num;
   };
 
   const handlePlus = usePersistFn(() => {
     if (disabled) return;
-    changeValue(step);
+    const num = changeValue(step);
+    if (num !== undefined) setInternalInputValue(getStringValue(num));
   });
   const handleMinus = usePersistFn(() => {
     if (disabled) return;
-    changeValue(-step);
+    const num = changeValue(-step);
+    if (num !== undefined) setInternalInputValue(getStringValue(num));
   });
 
   return {

--- a/packages/shineout-style/src/date-picker/date-picker.ts
+++ b/packages/shineout-style/src/date-picker/date-picker.ts
@@ -478,7 +478,7 @@ const datePickerStyle: JsStyles<DatePickerClassType> = {
   pickerCell: {
     color: token.datePickerCellColor,
     '&$pickerCellBound': {
-      color: token.datePickerCellOtherColor,
+      color: token.datePickerCellDisabledColor,
     },
 
     '&:not($pickerCellDisabled):not($pickerCellActive):hover': {

--- a/packages/shineout-style/src/date-picker/date-picker.ts
+++ b/packages/shineout-style/src/date-picker/date-picker.ts
@@ -660,6 +660,8 @@ const datePickerStyle: JsStyles<DatePickerClassType> = {
     position: 'relative',
     borderRadius: token.datePickerTimeItemBorderRadius,
     color: token.datePickerCellColor,
+    fontWeight: token.datePickerPanelFontWeight,
+    fontSize: token.datePickerPanelBodyFontSize,
     '&:not($timeItemDisabled):hover': {
       color: token.datePickerCellHoverColor,
       backgroundColor: token.datePickerCellHoverBackgroundColor,

--- a/packages/shineout/src/input/__doc__/changelog.cn.md
+++ b/packages/shineout/src/input/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.9.13-beta.12
+2026-04-14
+### 🐞 BugFix
+- 修复 `Input.Number` 点击步进按钮（step）时仅首次生效，后续点击不再递增/递减的问题（Regression since v3.9.11） ([#1694](https://github.com/sheinsight/shineout-next/pull/1694))
+
+
 ## 3.9.11-beta.10
 2026-03-16
 ### 🐞 BugFix


### PR DESCRIPTION
## Summary
- 修复 `DatePicker` 时间面板项缺少 `fontWeight` 和 `fontSize` token
- 修复 `Input.Number` 步进按钮（step）仅首次点击生效，后续点击不再递增/递减的问题（Regression since v3.9.11）
  - 根因：step 按钮点击时 input 保持焦点，`focusedRef` 阻断了 `inernalInputValue` 同步，导致 `useInputFormat` 将值回退
  - 修复：在 `handlePlus`/`handleMinus` 中显式同步 `inernalInputValue`

## Test plan
- [ ] 验证 `Input.Number` 步进按钮连续点击能正常递增/递减
- [ ] 验证 `Input.Number` 受控模式下步进按钮正常工作
- [ ] 验证 `Input.Number` 在 Form 中使用 `defaultValue` 时，聚焦清空不会被立即回填（原有功能不受影响）
- [ ] 验证 DatePicker 时间面板项的字体大小和字重正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)