### PR TITLE
fix(style): fix tabs card arrow background and Switch small text alignment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.13-beta.12",
+  "version": "3.9.13-beta.13",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/switch/switch.ts
+++ b/packages/shineout-style/src/switch/switch.ts
@@ -30,6 +30,7 @@ const switchStyle: JsStyles<keyof SwitchClasses> = {
     color: token.switchFontColor,
     verticalAlign: 'middle',
     outline: 'none',
+    lineHeight: token.switchCircleSize,
     '$wrapperDisabled&': {
       backgroundColor: token.switchDisabledBackgroundColor,
       color: token.switchDisabledFontColor,
@@ -55,6 +56,7 @@ const switchStyle: JsStyles<keyof SwitchClasses> = {
       minWidth: token.switchSmallWidth,
       borderRadius: `calc( ${token.switchSmallCircleSize} / 2 + ${token.switchSmallPaddingY} )`,
       fontSize: token.switchSmallFontSize,
+      lineHeight: token.switchSmallCircleSize,
       '[data-soui-role="form-control"] > &': {
         marginTop: 8,
       }
@@ -65,6 +67,7 @@ const switchStyle: JsStyles<keyof SwitchClasses> = {
       minWidth: token.switchLargeWidth,
       borderRadius: `calc( ${token.switchLargeCircleSize} / 2 + ${token.switchLargePaddingY} )`,
       fontSize: token.switchLargeFontSize,
+      lineHeight: token.switchLargeCircleSize,
     },
   },
   wrapperChecked: {},

--- a/packages/shineout-style/src/tabs/tabs.ts
+++ b/packages/shineout-style/src/tabs/tabs.ts
@@ -368,7 +368,7 @@ const tabsStyle: JsStyles<keyof TabsClasses> = {
       border: '1px solid transparent',
     },
     '&[data-soui-shape="card"] $prev, &[data-soui-shape="card"] $next': {
-      background: Token.tabsCardBackgroundColor,
+      background: Token.tabsCardCheckedBackgroundColor,
       alignSelf: 'stretch',
       display: 'flex',
       alignItems: 'center',

--- a/packages/shineout/src/switch/__doc__/changelog.cn.md
+++ b/packages/shineout/src/switch/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.9.13-beta.13
+2026-04-14
+### 🐞 BugFix
+- 修复 `Switch` 小尺寸下自定义文案未垂直居中的问题 ([#1695](https://github.com/sheinsight/shineout-next/pull/1695))
+
+
 ## 3.1.10
 2024-05-15
 


### PR DESCRIPTION
## Summary
- 修复 `Tabs` card 模式下前后箭头按钮背景色使用错误的 token
- 修复 `Switch` 小尺寸下自定义文案未垂直居中的问题
- bump version to 3.9.13-beta.13

## Test plan
- [ ] 验证 Tabs card 模式下箭头按钮背景色正确
- [ ] 验证 Switch 小尺寸下文案垂直居中显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)