### PR TITLE
fix(style/theme): fix Button.Group split line, add Bg tokens, Cascader size example

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.13-beta.14",
+  "version": "3.9.13-beta.15",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/button/button-group.ts
+++ b/packages/shineout-style/src/button/button-group.ts
@@ -9,12 +9,16 @@ type ButtonStyleType = 'Text' | 'Outline' | '';
 // 引用 button stylesheet 的常量类名（元素同时拥有 hash class 和常量 class）
 const bc = (key: string) => `.${prefix}-button-${key}`;
 
+const heightAndTop = {
+  height: `var(--button-before-line-height, calc(50% - 2px))`,
+  top: `var(--button-before-line-top, calc(25% + 1px))`,
+}
+
 const beforeLine = () => ({
   '&::before': {
     position: 'absolute',
     content: '" "',
-    height: 'calc(50% - 2px)',
-    top: 'calc(25% + 1px)',
+    ...heightAndTop,
     width: 1,
     background: Token.buttonSplitlineFullBackgroundColor,
   },
@@ -70,8 +74,7 @@ const outlineBeforeLine = (type: ButtonTypeWithoutLink, styles: ButtonStyleType)
   '&::before': {
     position: 'absolute',
     content: '" "',
-    height: 'calc(50% - 2px)',
-    top: 'calc(25% + 1px)',
+    ...heightAndTop,
     width: 1,
     background: Token[`button${type}${styles}BorderColor`],
   },
@@ -114,8 +117,8 @@ const outlineBeforeLine = (type: ButtonTypeWithoutLink, styles: ButtonStyleType)
 
   [`&${bc('primary')},&${bc('success')},&${bc('warning')},&${bc('danger')},${bc('secondary')}`]: {
     '&::before': {
-      height: 'calc(50% - 2px)',
-      top:'calc(25% + 1px)',
+      ...heightAndTop,
+      top: `var(--button-before-line-top, calc(25% + 1px))`,
       left: -1,
       width: 1,
       bottom: -1,
@@ -149,8 +152,7 @@ const textBeforeLine = () => ({
     transition: 'all 0.3s',
     position: 'absolute',
     content: '" "',
-    height: 'calc(50% - 2px)',
-    top: 'calc(25% + 1px)',
+    ...heightAndTop,
     width: 1,
     background: Token.buttonSplitlineOutlineBackgroundColor,
   },
@@ -232,7 +234,7 @@ const ButtonGroupStyle: JsStyles<keyof ButtonGroupClasses> = {
       },
 
     // 填充型 button
-    [`& ${bc('button')}:not(${bc('outline')}):not(${bc('text')})`]: {
+    [`& ${bc('button')}:not(${bc('outline')}):not(${bc('dashed')}):not(${bc('text')})`]: {
       position: 'relative',
 
       '&::before': {
@@ -244,8 +246,7 @@ const ButtonGroupStyle: JsStyles<keyof ButtonGroupClasses> = {
         '&::before': {
           position: 'absolute',
           content: '" "',
-          height: 'calc(50% - 2px)',
-          top: 'calc(25% + 1px)',
+          ...heightAndTop,
           width: 1,
           background: Token.buttonSplitlineOutlineBackgroundColor,
           transition: 'none',
@@ -292,21 +293,6 @@ const ButtonGroupStyle: JsStyles<keyof ButtonGroupClasses> = {
       // secondary 比较特殊，单独拎出来写覆盖掉 &::before
       [`&${bc('secondary')}`]: {
         ...outlineBeforeLine('Secondary', 'Outline'),
-        '&::before': {
-          position: 'absolute',
-          content: '" "',
-          height: 'calc(50% - 2px)',
-          top: 'calc(25% + 1px)',
-          width: 1,
-          background: Token.buttonSplitlineOutlineBackgroundColor, // Neutral-border-1
-          transition: 'none',
-        },
-        '&[dir=ltr]::before': {
-          left: -1,
-        },
-        '&[dir=rtl]::before': {
-          right: -1,
-        },
       },
       [`&${bc('primary')}`]: {
         ...outlineBeforeLine('Primary', 'Outline'),
@@ -329,9 +315,23 @@ const ButtonGroupStyle: JsStyles<keyof ButtonGroupClasses> = {
     },
 
     // dashed 型 button
-    [`&${bc('dashed')}`]: {
+    [`& ${bc('dashed')}`]: {
       position: 'relative',
-      borderStyle: 'none',
+      [`&${bc('secondary')}`]: {
+        ...outlineBeforeLine('Secondary', 'Outline'),
+      },
+      [`&${bc('primary')}`]: {
+        ...outlineBeforeLine('Primary', 'Outline'),
+      },
+      [`&${bc('success')}`]: {
+        ...outlineBeforeLine('Success', 'Outline'),
+      },
+      [`&${bc('warning')}`]: {
+        ...outlineBeforeLine('Warning', 'Outline'),
+      },
+      [`&${bc('danger')}`]: {
+        ...outlineBeforeLine('Danger', 'Outline'),
+      },
     },
   },
 };

--- a/packages/shineout-style/src/button/button-group.ts
+++ b/packages/shineout-style/src/button/button-group.ts
@@ -114,8 +114,8 @@ const outlineBeforeLine = (type: ButtonTypeWithoutLink, styles: ButtonStyleType)
 
   [`&${bc('primary')},&${bc('success')},&${bc('warning')},&${bc('danger')},${bc('secondary')}`]: {
     '&::before': {
-      height: 'calc(100% + 2px)',
-      top: -1,
+      height: 'calc(50% - 2px)',
+      top:'calc(25% + 1px)',
       left: -1,
       width: 1,
       bottom: -1,
@@ -236,7 +236,7 @@ const ButtonGroupStyle: JsStyles<keyof ButtonGroupClasses> = {
       position: 'relative',
 
       '&::before': {
-        transition: 'all 0.3s',
+        // transition: 'all 0.3s',
       },
       // secondary 比较特殊，单独拎出来写覆盖掉 &::before
       [`&${bc('secondary')}`]: {
@@ -299,6 +299,7 @@ const ButtonGroupStyle: JsStyles<keyof ButtonGroupClasses> = {
           top: 'calc(25% + 1px)',
           width: 1,
           background: Token.buttonSplitlineOutlineBackgroundColor, // Neutral-border-1
+          transition: 'none',
         },
         '&[dir=ltr]::before': {
           left: -1,

--- a/packages/shineout-style/src/radio/radio.ts
+++ b/packages/shineout-style/src/radio/radio.ts
@@ -42,7 +42,10 @@ const radioStyle: JsStyles<keyof RadioClasses> = {
       marginTop: token.radioIndicatorMarginTop,
     },
   },
-  wrapperChecked: {},
+  wrapperChecked: {
+    '--button-before-line-height': '100%',
+    '--button-before-line-top': 0,
+  },
   wrapperDisabled: {
     cursor: 'not-allowed',
   },

--- a/packages/shineout/src/button/__doc__/changelog.cn.md
+++ b/packages/shineout/src/button/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.9.13-beta.15
+2026-04-16
+### 💅 Style
+- 优化 `Button.Group` 按钮之间分割线的样式，适配设计 token 配置 ([#1697](https://github.com/sheinsight/shineout-next/pull/1697))
+
+
 ## 3.9.11-beta.4
 2026-03-09
 ### 🚀 Performance

--- a/packages/shineout/src/button/__example__/test-001-group.tsx
+++ b/packages/shineout/src/button/__example__/test-001-group.tsx
@@ -16,7 +16,7 @@ export default () => {
       <div>
         <Radio.Group
           keygen
-          data={['primary', 'secondary', 'outline', 'dashed', 'text']}
+          data={['primary', 'secondary', 'warning', 'danger', 'success', 'default']}
           value={buttonType}
           onChange={setButtonType}
           style={{ marginBottom: 16 }}
@@ -46,6 +46,15 @@ export default () => {
         <Button.Group
           type={buttonType}
           mode={buttonMode}
+          style={{ marginLeft: 'var(--soui-button-nearly-margin, 8px)' }}
+        >
+          <Button>按钮1</Button>
+          <Button>按钮2</Button>
+          <Button>按钮3</Button>
+        </Button.Group>
+
+        <Button.Group
+          mode='outline'
           style={{ marginLeft: 'var(--soui-button-nearly-margin, 8px)' }}
         >
           <Button>按钮1</Button>

--- a/packages/shineout/src/button/__example__/test-001-group.tsx
+++ b/packages/shineout/src/button/__example__/test-001-group.tsx
@@ -6,81 +6,44 @@
  */
 
 import React from 'react';
-import { Button, Radio } from 'shineout';
+import { Button, Radio, Form } from 'shineout';
 export default () => {
-  const [buttonType, setButtonType] = React.useState('primary');
-  const [buttonMode, setButtonMode] = React.useState('outline');
+  const [buttonType, setButtonType] = React.useState('secondary');
+  const [buttonMode, setButtonMode] = React.useState('默认(填充模式)');
 
   return (
     <div>
-      <div>
-        <Radio.Group
-          keygen
-          data={['primary', 'secondary', 'warning', 'danger', 'success', 'default']}
-          value={buttonType}
-          onChange={setButtonType}
-          style={{ marginBottom: 16 }}
-        />
-        <Radio.Group
-          keygen
-          data={['outline', 'dashed', 'text']}
-          value={buttonMode}
-          onChange={setButtonMode}
-          style={{ marginBottom: 16 }}
-        />
-      </div>
-      <div>
-        <Button type={buttonType} mode={buttonMode}>
-          按钮
-        </Button>
-      </div>
-      <div>
+      <Form labelAlign='top' colon>
+        <Form.Item label={<strong>type</strong>}>
+          <Radio.Group
+            keygen
+            data={['secondary', 'primary', 'warning', 'danger', 'success']}
+            value={buttonType}
+            onChange={setButtonType}
+            style={{ marginBottom: 16 }}
+          />
+        </Form.Item>
+        <Form.Item label={<strong>mode</strong>}>
+          <Radio.Group
+            keygen
+            data={['默认(填充模式)', 'outline', 'dashed', 'text']}
+            value={buttonMode}
+            onChange={setButtonMode}
+            style={{ marginBottom: 16 }}
+          />
+        </Form.Item>
+      </Form>
+      <div style={{ marginTop: 'var(--soui-button-nearly-margin, 8px)' }}>
         <Button.Group
-          type={buttonType}
-          style={{ marginLeft: 'var(--soui-button-nearly-margin, 8px)' }}
+          type={buttonType as any}
+          mode={buttonMode === '默认(填充模式)' ? undefined : buttonMode as any}
         >
           <Button>按钮1</Button>
           <Button>按钮2</Button>
           <Button>按钮3</Button>
+          <Button>按钮4</Button>
+          <Button>按钮5</Button>
         </Button.Group>
-        <Button.Group
-          type={buttonType}
-          mode={buttonMode}
-          style={{ marginLeft: 'var(--soui-button-nearly-margin, 8px)' }}
-        >
-          <Button>按钮1</Button>
-          <Button>按钮2</Button>
-          <Button>按钮3</Button>
-        </Button.Group>
-
-        <Button.Group
-          mode='outline'
-          style={{ marginLeft: 'var(--soui-button-nearly-margin, 8px)' }}
-        >
-          <Button>按钮1</Button>
-          <Button>按钮2</Button>
-          <Button>按钮3</Button>
-        </Button.Group>
-{/*
-        <Button.Group
-          type={buttonType}
-          mode={buttonMode}
-          style={{ marginLeft: 'var(--soui-button-nearly-margin, 8px)' }}
-        >
-          <Button>按钮1</Button>
-          <Button>按钮2</Button>
-          <Button>按钮3</Button>
-        </Button.Group>
-
-        <Button.Group
-          type={buttonType}
-          mode={buttonMode}
-          style={{ marginLeft: 'var(--soui-button-nearly-margin, 8px)' }}
-        >
-          <Button>按钮1</Button>
-          <Button>按钮2</Button>
-          <Button>按钮3</Button>
-        </Button.Group> */}
       </div>
     </div>
   );

--- a/packages/shineout/src/cascader/__example__/12-size.tsx
+++ b/packages/shineout/src/cascader/__example__/12-size.tsx
@@ -1,0 +1,80 @@
+/**
+ * cn - 尺寸
+ *    -- 设置 `size` 属性，调整组件尺寸
+ * en - Size
+ *    -- Set the `size` property to adjust the component size
+ */
+import React from 'react';
+import { Cascader } from 'shineout';
+
+interface DataItem {
+  value: string;
+  children?: DataItem[];
+}
+
+const data: DataItem[] = [
+  {
+    value: 'jiangsu',
+    children: [
+      {
+        value: 'nanjing',
+        children: [
+          {
+            value: 'jiangning',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    value: 'anhui',
+    children: [
+      {
+        value: 'hefei',
+        children: [
+          {
+            value: 'feidong',
+          },
+        ],
+      },
+    ],
+  },
+];
+
+export default () => {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <Cascader
+        width={300}
+        clearable
+        placeholder='Please select city'
+        data={data}
+        keygen='value'
+        renderItem={(n) => `${n?.value}`}
+        onClear={() => console.log('Cascader onClear triggered')}
+        size='small'
+      />
+
+      <Cascader
+        width={300}
+        clearable
+        placeholder='Please select city'
+        data={data}
+        keygen='value'
+        renderItem={(n) => `${n?.value}`}
+        onClear={() => console.log('Cascader onClear triggered')}
+      />
+
+      <Cascader
+        width={300}
+        clearable
+        placeholder='Please select city'
+        data={data}
+        keygen='value'
+        renderItem={(n) => `${n?.value}`}
+        onClear={() => console.log('Cascader onClear triggered')}
+        size='large'
+      />
+    </div>
+  );
+};

--- a/packages/theme/src/token/figma.js
+++ b/packages/theme/src/token/figma.js
@@ -70,6 +70,20 @@ const figma = [
     locked: true,
   },
   {
+    name: 'colorBgLayout',
+    value: '#F4F5F8',
+    describe: '布局背景色',
+    token: 'Bg-layout',
+    locked: false,
+  },
+  {
+    name: 'colorBgPopup',
+    value: '#FFFFFF',
+    describe: '浮层容器背景色',
+    token: 'Bg-popup',
+    locked: false,
+  },
+  {
     name: '青色-1',
     value: '#e8fffb',
     describe: '浅色背景',

--- a/packages/theme/src/token/token.ts
+++ b/packages/theme/src/token/token.ts
@@ -13,6 +13,8 @@ const Token: Tokens = {
   'Brand-7': '#0B5BD4',
   'Brand-8': '#0040AD',
   'Brand-9': '#002D87',
+  'Bg-layout': '#F4F5F8',
+  'Bg-popup': '#FFFFFF',
   'Cyan-1': '#e8fffb',
   'Cyan-10': '#00424d',
   'Cyan-2': '#b7f1e9',

--- a/packages/theme/src/token/type.ts
+++ b/packages/theme/src/token/type.ts
@@ -72,6 +72,20 @@ export interface Tokens {
   /**
    * @type {string}
    * @categoty color
+   * @default '#F4F5F8'
+   * @description 布局背景色
+   */
+  'Bg-layout': string;
+  /**
+   * @type {string}
+   * @categoty color
+   * @default '#FFFFFF'
+   * @description 浮层容器背景色
+   */
+  'Bg-popup': string;
+  /**
+   * @type {string}
+   * @categoty color
    * @default '#e8fffb'
    * @description 浅色背景
    */


### PR DESCRIPTION
## Summary
- 优化 `Button.Group` 按钮之间分割线的样式，调整高度、定位和过渡效果以适配设计 token
- 修复 `Radio` 指示器样式
- 新增全局背景色 token：`Bg-layout`（布局背景色）和 `Bg-popup`（浮层背景色）
- 新增 `Cascader` 尺寸示例
- bump version to 3.9.13-beta.15

## Test plan
- [ ] 验证 Button.Group 各模式（outline/dashed/text）下分割线样式正确
- [ ] 验证 Button.Group 各类型（primary/secondary/warning/danger/success）下分割线颜色正确
- [ ] 验证 Radio 指示器样式正确
- [ ] 验证 Cascader small/default/large 三种尺寸渲染正常
- [ ] 验证 Bg-layout 和 Bg-popup token 可正常使用

🤖 Generated with [Claude Code](https://claude.com/claude-code)