### PR TITLE
feat(theme): add Radius-rect token for zero border radius

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.13-beta.17",
+  "version": "3.9.13-beta.18",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/theme/src/token/figma.js
+++ b/packages/theme/src/token/figma.js
@@ -1338,6 +1338,13 @@ const figma = [
     locked: true,
   },
   {
+    name: 'borderRadiusRect',
+    value: '0px',
+    describe: '直角 Radius-rect (0px)',
+    token: 'Radius-rect',
+    locked: true,
+  },
+  {
     name: 'borderRadiusLesser',
     value: '2px',
     describe: '小 Radius-lesser (2px)',

--- a/packages/theme/src/token/token.ts
+++ b/packages/theme/src/token/token.ts
@@ -194,6 +194,7 @@ const Token: Tokens = {
   Transparent: 'transparent',
   'Mask-fill-1': 'rgba(2, 11, 24, 0.3)',
   Size: '2',
+  'Radius-rect': '0px',
   'Radius-lesser': '2px',
   'Radius-small': '3px',
   'Radius-default': '4px',

--- a/packages/theme/src/token/type.ts
+++ b/packages/theme/src/token/type.ts
@@ -1339,6 +1339,13 @@ export interface Tokens {
   /**
    * @type {string}
    * @categoty string
+   * @default '0px'
+   * @description 直角 Radius-rect (0px)
+   */
+  'Radius-rect': string;
+  /**
+   * @type {string}
+   * @categoty string
    * @default '2px'
    * @description 小 Radius-lesser (2px)
    */


### PR DESCRIPTION
## Summary
- 新增 `Radius-rect` 全局 token（值为 `0px`），用于直角场景
- bump version to 3.9.13-beta.18

## Test plan
- [ ] 验证 Radius-rect token 可在主题编辑器中正常使用

🤖 Generated with [Claude Code](https://claude.com/claude-code)