### PR TITLE
fix(style): fix menu dark theme hover background for disabled items

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.13",
+  "version": "3.9.14-beta.1",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/menu/menu.ts
+++ b/packages/shineout-style/src/menu/menu.ts
@@ -204,7 +204,7 @@ const menuStyle: JsStyles<MenuClassType> = {
     },
 
     // 一级菜单展不展开都是fill-9，一级展开后的子级都是fill-10
-    '[data-soui-theme=dark] $root > $item:not($itemActive) > &': {
+    '[data-soui-theme=dark] $root > $item:not($itemActive):not($itemDisabled) > &': {
       backgroundColor: token.menuDarkItemBackgroundColor,
       '&:hover': {
         backgroundColor: token.menuDarkItemHoverBackgroundColor,


### PR DESCRIPTION
## Summary
- 修复 Menu 组件暗色主题下，禁用状态的根菜单项仍显示 hover 背景色的问题
- 在选择器中排除 disabled 状态的项，使其不受 hover 样式影响

## Changes
- `packages/shineout-style/src/menu/menu.ts`: 暗色主题根菜单项选择器增加 `:not` 排除 disabled 状态