### PR TITLE
fix: fix Input.Group child component width and Form.Reset with delayed input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.14-beta.1",
+  "version": "3.9.14-beta.2",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-form/use-form.ts
+++ b/packages/hooks/src/components/use-form/use-form.ts
@@ -360,6 +360,8 @@ const useForm = <T extends ObjectType>(props: UseFormProps<T>) => {
       vals: { [key: string]: any },
       option: { validate?: boolean; forceUpdate?: boolean } = { validate: false },
     ) => {
+      // 重置保护期内（500ms），忽略子组件延迟 onChange 写回的旧值
+      if (context.resetTime && Date.now() - context.resetTime < 500) return;
       onChange((draft) => {
         const values = Object.keys(vals);
         // 针对 name 为数组模式，如 datepicker 的 name={['startTime', 'endTime']} 时，前者校验可能需要依赖后者，因此需要提前将后者数据整合至 draft 用于多字段整合校验
@@ -509,7 +511,7 @@ const useForm = <T extends ObjectType>(props: UseFormProps<T>) => {
     onChange(getDefaultValue());
     clearValidate();
     update();
-    context.resetTime = 1;
+    context.resetTime = Date.now();
     props.onReset?.();
     other?.onReset?.(e);
   };

--- a/packages/hooks/src/components/use-form/use-form.ts
+++ b/packages/hooks/src/components/use-form/use-form.ts
@@ -9,6 +9,7 @@ import { SchemaBuilder } from './use-form-schema/form-schema-builder';
 
 const globalKey = '__global__&&@@';
 const SUBMIT_TIMEOUT = 10;
+const RESET_TIMEOUT = 500;
 
 import { current, produce } from '../../utils/immer';
 import {
@@ -361,7 +362,7 @@ const useForm = <T extends ObjectType>(props: UseFormProps<T>) => {
       option: { validate?: boolean; forceUpdate?: boolean } = { validate: false },
     ) => {
       // 重置保护期内（500ms），忽略子组件延迟 onChange 写回的旧值
-      if (context.resetTime && Date.now() - context.resetTime < 500) return;
+      if (context.resetTime && Date.now() - context.resetTime < RESET_TIMEOUT) return;
       onChange((draft) => {
         const values = Object.keys(vals);
         // 针对 name 为数组模式，如 datepicker 的 name={['startTime', 'endTime']} 时，前者校验可能需要依赖后者，因此需要提前将后者数据整合至 draft 用于多字段整合校验

--- a/packages/shineout-style/src/input/input-border.ts
+++ b/packages/shineout-style/src/input/input-border.ts
@@ -80,7 +80,7 @@ export default <T extends string>(name: T, token: Token = {} as any) => {
         borderRadius: 0,
         boxShadow: 'none',
         backgroundColor: 'transparent',
-        flex: 1,
+        flex: '1 1 auto',
         minWidth: 0,
       },
       '[data-soui-role="input-group"]:not([data-soui-border="false"]) [data-soui-input-border] + &&&': {

--- a/packages/shineout/src/form/__doc__/changelog.cn.md
+++ b/packages/shineout/src/form/__doc__/changelog.cn.md
@@ -1,5 +1,5 @@
 ## 3.9.14-beta.2
-2026-04-20
+2026-04-21
 ### 🐞 BugFix
 - 修复 `Form` 中带有延迟的表单元素（如 `Textarea`）输入内容后立即点击 `Form.Reset`，内容会短暂消失后又重新出现的问题 ([#1704](https://github.com/sheinsight/shineout-next/pull/1704))
 

--- a/packages/shineout/src/form/__doc__/changelog.cn.md
+++ b/packages/shineout/src/form/__doc__/changelog.cn.md
@@ -1,3 +1,8 @@
+## 3.9.14-beta.2
+2026-04-20
+### 🐞 BugFix
+- 修复 `Form` 中带有延迟的表单元素（如 `Textarea`）输入内容后立即点击 `Form.Reset`，内容会短暂消失后又重新出现的问题 ([#1704](https://github.com/sheinsight/shineout-next/pull/1704))
+
 ## 3.9.13-beta.5
 2026-04-03
 ### 💅 Style

--- a/packages/shineout/src/input/__doc__/changelog.cn.md
+++ b/packages/shineout/src/input/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.9.14-beta.2
+2026-04-20
+### 🐞 BugFix
+- 修复 `Input.Group` 中子组件设置 `width` 不生效的问题 ([#1703](https://github.com/sheinsight/shineout-next/pull/1703))
+
+
 ## 3.9.13-beta.12
 2026-04-14
 ### 🐞 BugFix


### PR DESCRIPTION
## Summary
- 修复 `Input.Group` 中子组件设置 `width` 属性不生效的问题
- 子组件（如 `Select`）在 Group 中设置了宽度后会被忽略，自动拉伸填满空间，现在可以正确保持指定宽度
- 修复 `Form` 中带有延迟的表单元素（如 `Textarea`）输入内容后立即点击 `Form.Reset`，内容会短暂消失后又重新出现的问题

## Changes
- 调整 `Input.Group` 内子组件的 flex 布局策略，使其尊重子组件自身的宽度设置
- 在 Form 的 `setValue` 中增加重置保护期（500ms），忽略重置后延迟回调写入的旧值