### PR TITLE
fix(style): replace hardcoded background color with token in image thumbnail

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.14-beta.4",
+  "version": "3.9.14-beta.5",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/image/image.ts
+++ b/packages/shineout-style/src/image/image.ts
@@ -191,7 +191,7 @@ const ImageStyle: JsStyles<ImageClass> = {
 
   thumbnail: {
     borderRadius: Token.imageBorderRadius,
-    backgroundColor: '#FFFFFF',
+    backgroundColor: Token.imageBackgroundColor,
     outline: `1px solid ${Token.imageBorderColor}`,
 
     '& $inner': {


### PR DESCRIPTION
## 变更内容

- 将 Image 组件 thumbnail 的背景色从硬编码 `#FFFFFF` 替换为 `Token.imageBackgroundColor`，使其支持主题 token 配置
- bump version to 3.9.14-beta.5