### PR TITLE
fix(table): 修复 sticky 模式下隐藏容器中表头与表体列宽错位

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.14-beta.5",
+  "version": "3.9.14-beta.6",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-table/use-table-layout.tsx
+++ b/packages/hooks/src/components/use-table/use-table-layout.tsx
@@ -139,8 +139,13 @@ const useTableLayout = (props: UseTableLayoutProps) => {
     if (cols && cols.every((v) => v === 0)) return;
 
     const shifted = shiftDecimalToLastColumn(cols);
+    // 当 colgroup 中存在 undefined（说明从未被成功测量过），跳过相等判断，强制触发重新测量
+    // 场景：Table 在 display:none 容器中挂载时 getColgroup 测量失败，
+    // 后续 resetColGroup 产出值与初始值相同会被跳过，导致未设 width 的列永远无法获得实际宽度
+    const hasUndefined = shifted.some((v) => v === undefined);
     // 值未变化时跳过，避免触发不必要的 useLayoutEffect
     if (
+      !hasUndefined &&
       colgroup &&
       shifted.length === colgroup.length &&
       shifted.every((v, i) => v === colgroup[i])

--- a/packages/shineout/src/table/__doc__/changelog.cn.md
+++ b/packages/shineout/src/table/__doc__/changelog.cn.md
@@ -1,3 +1,8 @@
+## 3.9.14-beta.6
+2026-04-29
+### 🐞 BugFix
+- 修复 `Table` 在表头附着（sticky）模式下，从隐藏容器（如弹窗、标签页、折叠面板）中显示时，未设置宽度的列表头与表体内容错位的问题 ([#1707](https://github.com/sheinsight/shineout-next/pull/1707))
+
 ## 3.9.14-beta.1
 2026-04-20
 ### 🚀 Performance


### PR DESCRIPTION
## Summary

修复 Table 在表头附着（sticky）模式下，从隐藏容器（弹窗、标签页、折叠面板等）中显示时，未设置宽度的列表头与表体内容水平错位的问题。

**根因：** Table 在 `display:none` 容器中挂载时，列宽测量结果全为 0 被跳过。容器变为可见后，重新计算的列宽与初始值相同，被相等判断拦截，导致未设 width 的列永远无法获得实际测量宽度。

**修复：** 当 colgroup 中存在未测量的列时，跳过相等判断，强制触发重新测量。

## Test Plan

1. 将 Table（sticky 模式，部分列未设 width）放入一个初始 `display:none` 的容器中
2. 切换容器为可见
3. 验证所有列的表头与表体严格垂直对齐