### PR TITLE
fix(table): 修复 sticky Table 在 Modal 等动画容器中列宽错位

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.14-beta.6",
+  "version": "3.9.14-beta.7",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-table/use-table-layout.tsx
+++ b/packages/hooks/src/components/use-table/use-table-layout.tsx
@@ -320,6 +320,36 @@ const useTableLayout = (props: UseTableLayoutProps) => {
     };
   }, [scrollRef.current]);
 
+  // 当祖先元素的 CSS 动画结束时（如 Modal 入场动画），重新测量列宽
+  // 解决 Table 在动画容器（如 Modal）中渲染时，动画期间测量的列宽不准确导致 sticky 表头与表体列宽错位的问题
+  useEffect(() => {
+    const scrollEl = scrollRef.current;
+    if (!scrollEl) return;
+
+    // 查找最近的 fixed 定位祖先（如 Modal wrapper），仅在该元素上监听动画结束
+    let fixedAncestor: HTMLElement | null = null;
+    let parent = scrollEl.parentElement;
+    while (parent) {
+      if (window.getComputedStyle(parent).position === 'fixed') {
+        fixedAncestor = parent;
+        break;
+      }
+      parent = parent.parentElement;
+    }
+
+    if (!fixedAncestor) return;
+
+    const handleAnimationEnd = () => {
+      getColgroup(false);
+    };
+
+    fixedAncestor.addEventListener('animationend', handleAnimationEnd);
+
+    return () => {
+      fixedAncestor!.removeEventListener('animationend', handleAnimationEnd);
+    };
+  }, [scrollRef.current]);
+
   useLayoutEffect(() => {
     if (adjust) {
       getColgroup(adjust === 'drag');

--- a/packages/shineout/src/table/__doc__/changelog.cn.md
+++ b/packages/shineout/src/table/__doc__/changelog.cn.md
@@ -1,3 +1,8 @@
+## 3.9.14-beta.7
+2026-04-30
+### 🐞 BugFix
+- 修复 `Table` 在表头附着（sticky）模式下，在 `Modal` 等带有入场动画的容器中渲染时，表头与表体列宽错位的问题 ([#1709](https://github.com/sheinsight/shineout-next/pull/1709))
+
 ## 3.9.14-beta.6
 2026-04-29
 ### 🐞 BugFix


### PR DESCRIPTION
## Summary

修复 `Table` 在表头附着（sticky）模式下，于 `Modal` 等带有入场动画的容器中渲染时，表头与表体列宽错位的问题。

**原因**：sticky 模式下 Table 拆分为两个独立的 `<table>`（thead + tbody），共享同一 `colgroup` 状态。在 Modal 入场动画期间测量的列宽不准确，动画结束后没有重新测量的机制。

**方案**：在 `useTableLayout` 中向上查找最近的 `position: fixed` 祖先元素（如 Modal wrapper），监听其 `animationend` 事件，在动画结束后重新测量列宽。关闭动画同样会触发，但 `changeColGroup` 的相等性检查会自动跳过无变化的更新，不产生副作用。

## Test Plan

1. 打开 Modal，内含 sticky Table（参考 `20-sticky` 示例）
2. 验证表头与表体列宽对齐
3. 关闭 Modal，重新打开，确认无闪烁或错位
4. 非 Modal 场景下 Table 行为不受影响