### PR TITLE
fix(style): 修复 Input.Group 在 Table 中使用时 b 标签文本异常换行

### DIFF
--- a/packages/shineout-style/src/input/input.ts
+++ b/packages/shineout-style/src/input/input.ts
@@ -81,6 +81,7 @@ const groupSpace = (gap: string) => ({
     padding: `0 ${gap}`,
     display: 'flex',
     alignItems: 'center',
+    flexShrink: 0,
     borderLeft: `1px solid ${token.inputBorderColor}`,
     borderRight: `1px solid ${token.inputBorderColor}`,
     background: token.inputGroupFontBackgroundColor,

--- a/packages/shineout/src/input/__doc__/changelog.cn.md
+++ b/packages/shineout/src/input/__doc__/changelog.cn.md
@@ -7,7 +7,7 @@
 ## 3.9.14-beta.2
 2026-04-20
 ### 🐞 BugFix
-- 修复 `Input.Group` 中子组件设置 `width` 不生效的问题 ([#1703](https://github.com/sheinsight/shineout-next/pull/1703))
+- 修复 `Input.Group` 中子组件设置 `width` 不生效的问题，以及在 `Table` 中使用时 `<b>` 标签内文本出现异常换行的问题 ([#1710](https://github.com/sheinsight/shineout-next/pull/1710))
 
 
 ## 3.9.13-beta.12

--- a/packages/shineout/src/table/__doc__/changelog.cn.md
+++ b/packages/shineout/src/table/__doc__/changelog.cn.md
@@ -1,12 +1,8 @@
 ## 3.9.14-beta.7
 2026-04-30
 ### 🐞 BugFix
-- 修复 `Table` 在表头附着（sticky）模式下，在 `Modal` 等带有入场动画的容器中渲染时，表头与表体列宽错位的问题 ([#1709](https://github.com/sheinsight/shineout-next/pull/1709))
+- 修复 `Table` 在表头附着（sticky）模式下，从隐藏容器（如弹窗、标签页、折叠面板）中显示时，未设置宽度的列表头与表体内容错位的问题 ([#1707](https://github.com/sheinsight/shineout-next/pull/1707)) ([#1709](https://github.com/sheinsight/shineout-next/pull/1709))
 
-## 3.9.14-beta.6
-2026-04-29
-### 🐞 BugFix
-- 修复 `Table` 在表头附着（sticky）模式下，从隐藏容器（如弹窗、标签页、折叠面板）中显示时，未设置宽度的列表头与表体内容错位的问题 ([#1707](https://github.com/sheinsight/shineout-next/pull/1707))
 
 ## 3.9.14-beta.1
 2026-04-20


### PR DESCRIPTION
## Summary

修复 `Input.Group` 在 `Table` 中使用时，`<b>` 标签内的文本（如 "USD"）出现异常换行的问题。

### 原因分析

- Table 的 `td` 设置了 `word-break: break-all`，允许单词在任意字符处断行
- 之前的修复（#1703）将 Input.Group 内子组件的 `flex` 从 `1` 改为 `1 1 auto`，导致 Input 组件占用更多空间挤压 `<b>` 标签
- `<b>` 标签默认 `flex-shrink: 1`，被挤压后继承了 `word-break: break-all`，文本在字符边界断行

### 修复方式

为 `Input.Group` 中 `<b>` 标签添加 `flexShrink: 0`，使其作为标签元素不会被 flex 布局挤压。

## Test Plan

- 在 `Table` 中渲染 `Input.Group`，包含 `<b>USD</b>` 和 `Input.Number`，验证文本不再换行
- 在 Table 外单独使用 `Input.Group`，确认行为无回归