### PR TITLE
fix(input-number): 修复外部数字类型 value 与内部字符串状态不匹配导致显示值未同步的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.14-beta.8",
+  "version": "3.9.14-beta.9",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-input/use-input-number.ts
+++ b/packages/hooks/src/components/use-input/use-input-number.ts
@@ -37,10 +37,12 @@ const useNumberFormat = (props: InputNumberProps) => {
   const focusedRef = React.useRef(false);
 
   useEffect(() => {
+    // 将外部值转为字符串后再比较，避免 number 5 vs string "5" 的类型不匹配误判
+    const stringValue = getStringValue(props.value);
     // 聚焦编辑期间不同步外部值，避免 form 回填 defaultValue 覆盖用户输入
     // 但当外部值被清空时(如 clearable 触发)，即使聚焦也需要同步
-    if(props.value !== inernalInputValue && (!focusedRef.current || props.value == null || props.value === '')){
-      setInternalInputValue(getStringValue(props.value))
+    if(stringValue !== inernalInputValue && (!focusedRef.current || props.value == null || props.value === '')){
+      setInternalInputValue(stringValue)
     }
   }, [props.value])
 

--- a/packages/shineout/src/input/__doc__/changelog.cn.md
+++ b/packages/shineout/src/input/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.9.14-beta.9
+2026-05-09
+### 🐞 BugFix
+- 修复 `Input.Number` 外部传入数字类型的 `value` 时，与内部字符串状态类型不匹配导致显示值未正确同步的问题 ([#1711](https://github.com/sheinsight/shineout-next/pull/1711))
+
+
 ## 3.9.14-beta.2
 2026-04-20
 ### 🐞 BugFix


### PR DESCRIPTION
## Summary

- 修复 `Input.Number` 在外部传入数字类型 `value` 时，因与内部字符串状态类型不匹配（如 `5` vs `"5"`），导致 `useEffect` 误判为"值未变化"，从而跳过同步、显示值不更新的问题
- 修复方式：在比较前将外部值通过 `getStringValue` 转为字符串，确保比较的一致性

## Test plan

- [ ] 受控模式下通过 `value` 传入数字类型，验证显示值正确同步
- [ ] 在聚焦状态下修改值，确认外部清空（如 clearable）时仍能正确同步
- [ ] 配合 Form 使用时，验证 defaultValue 回填和用户输入不互相干扰

🤖 Generated with [Claude Code](https://claude.com/claude-code)