### PR TITLE
fix(input-number): 修复 clearable 清除按钮未能正确清空值的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.14-beta.9",
+  "version": "3.9.14-beta.10",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/input/input-number.tsx
+++ b/packages/base/src/input/input-number.tsx
@@ -42,6 +42,7 @@ const InputNumber = (props: InputNumberProps) => {
     onChange: commonProps.onChange,
     disabled: !!commonProps.disabled,
     defaultValue: props.defaultValue,
+    clearToUndefined: props.clearToUndefined,
     ...numberFormatParams,
   });
 

--- a/packages/hooks/src/components/use-input/use-input-number.ts
+++ b/packages/hooks/src/components/use-input/use-input-number.ts
@@ -16,6 +16,7 @@ const useNumberFormat = (props: InputNumberProps) => {
     min,
     max,
     allowNull,
+    clearToUndefined,
     step = 1,
     cancelBlurChange,
     disabled,
@@ -177,7 +178,7 @@ const useNumberFormat = (props: InputNumberProps) => {
 
   const handleClear = usePersistFn(() => {
     setInternalInputValue('');
-    onChange?.(allowNull ? null : undefined);
+    onChange?.(clearToUndefined ? undefined : (allowNull ? null : ''));
   });
 
   return {

--- a/packages/hooks/src/components/use-input/use-input-number.ts
+++ b/packages/hooks/src/components/use-input/use-input-number.ts
@@ -176,7 +176,8 @@ const useNumberFormat = (props: InputNumberProps) => {
   });
 
   const handleClear = usePersistFn(() => {
-    onInnerChange('');
+    setInternalInputValue('');
+    onChange?.(allowNull ? null : undefined);
   });
 
   return {

--- a/packages/hooks/src/components/use-input/use-input-number.ts
+++ b/packages/hooks/src/components/use-input/use-input-number.ts
@@ -37,11 +37,8 @@ const useNumberFormat = (props: InputNumberProps) => {
   const focusedRef = React.useRef(false);
 
   useEffect(() => {
-    // 将外部值转为字符串后再比较，避免 number 5 vs string "5" 的类型不匹配误判
     const stringValue = getStringValue(props.value);
-    // 聚焦编辑期间不同步外部值，避免 form 回填 defaultValue 覆盖用户输入
-    // 但当外部值被清空时(如 clearable 触发)，即使聚焦也需要同步
-    if(stringValue !== inernalInputValue && (!focusedRef.current || props.value == null || props.value === '')){
+    if(stringValue !== inernalInputValue && (!focusedRef.current || props.value == null)){
       setInternalInputValue(stringValue)
     }
   }, [props.value])
@@ -178,6 +175,10 @@ const useNumberFormat = (props: InputNumberProps) => {
     if (num !== undefined) setInternalInputValue(getStringValue(num));
   });
 
+  const handleClear = usePersistFn(() => {
+    onInnerChange('');
+  });
+
   return {
     ...useInputFormat({
       value: inernalInputValue,
@@ -193,6 +194,7 @@ const useNumberFormat = (props: InputNumberProps) => {
     }),
     onPlus: handlePlus,
     onMinus: handleMinus,
+    onClear: handleClear,
   };
 };
 

--- a/packages/hooks/src/components/use-input/use-input-number.type.ts
+++ b/packages/hooks/src/components/use-input/use-input-number.type.ts
@@ -25,6 +25,7 @@ export interface InputNumberProps
    * @cn 清空后值为 null
    */
   allowNull?: boolean;
+  clearToUndefined?: boolean;
   /**
    * @en Change the digital span. It can be decimal
    * @cn 改变数字跨度，可为小数

--- a/packages/shineout/src/input/__doc__/changelog.cn.md
+++ b/packages/shineout/src/input/__doc__/changelog.cn.md
@@ -1,7 +1,8 @@
-## 3.9.14-beta.9
+## 3.9.14-beta.10
 2026-05-09
 ### 🐞 BugFix
-- 修复 `Input.Number` 外部传入数字类型的 `value` 时，与内部字符串状态类型不匹配导致显示值未正确同步的问题 ([#1711](https://github.com/sheinsight/shineout-next/pull/1711))
+- 修复 `Input.Number` 在@shined/reactive状态管理中使用时，第一次输入后被清空的问题 ([#1711](https://github.com/sheinsight/shineout-next/pull/1711))
+- 修复 `Input.Number` 在设置 `clearable` 时，点击清除按钮未能正确清空值的问题 ([#1712](https://github.com/sheinsight/shineout-next/pull/1712))
 
 
 ## 3.9.14-beta.2

--- a/packages/shineout/src/input/__example__/03-number-1.tsx
+++ b/packages/shineout/src/input/__example__/03-number-1.tsx
@@ -67,6 +67,7 @@ const App: React.FC = () => {
           console.log('🚀outter Input.Number onChange', v);
         }}
         placeholder='please enter'
+        clearable
       />
     </Gap>
   );


### PR DESCRIPTION
## 问题描述

`Input.Number` 设置 `clearable` 时，点击清除按钮未能正确清空值。

## 原因分析

聚焦状态下，外部值同步逻辑排除了 `props.value === ''` 的情况，导致清除操作产生的空值无法在聚焦时同步到内部状态。

## 修复方案

移除外部值同步中对空字符串的特判，改为提供专用的 `onClear` 回调，在清除时直接触发内部值更新。

## Changelog

- 修复 `Input.Number` 在设置 `clearable` 时，点击清除按钮未能正确清空值的问题