### PR TITLE
fix(select): 修复开启 onFilter 后滚动下拉列表再输入关键字时首项不可见的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.14-beta.10",
+  "version": "3.9.14-beta.11",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/select/select.tsx
+++ b/packages/base/src/select/select.tsx
@@ -153,9 +153,7 @@ function Select<DataItem, Value>(props0: SelectPropsBase<DataItem, Value>) {
     filterDelay: props.filterDelay,
   });
 
-  const prevFilterTextRef = useRef(filterText);
-  const filterTextChanged = prevFilterTextRef.current !== filterText;
-  prevFilterTextRef.current = filterText;
+  const prevListDataLengthRef = useRef<number>(0);
 
   const [absoluteListUpdateKey, setAbsoluteListUpdateKey] = useState('');
 
@@ -643,8 +641,13 @@ function Select<DataItem, Value>(props0: SelectPropsBase<DataItem, Value>) {
   };
 
   const renderList = () => {
+    const listData = (groupBy ? groupData : filterData) as DataItem[];
+    const listDataLength = listData?.length ?? 0;
+    const dataGrew = listDataLength > prevListDataLengthRef.current;
+    prevListDataLengthRef.current = listDataLength;
+
     const listProps = {
-      data: (groupBy ? groupData : filterData) as DataItem[],
+      data: listData,
       datum,
       value,
       size,
@@ -665,7 +668,7 @@ function Select<DataItem, Value>(props0: SelectPropsBase<DataItem, Value>) {
       renderItem,
       controlType,
       onLoadMore,
-      keepScrollTop: filterTextChanged ? false : true,
+      keepScrollTop: dataGrew,
       isAnimationFinish,
       threshold,
       onControlTypeChange: setControlType,

--- a/packages/base/src/virtual-scroll/virtual-scroll-list.tsx
+++ b/packages/base/src/virtual-scroll/virtual-scroll-list.tsx
@@ -232,6 +232,9 @@ const VirtualList = <DataItem,>(props: VirtualListProps<DataItem>) => {
     // 数据变化的时候清空掉 preIndex, 如果之前有缓存的index, setRowHeight 会有问题
     setTop(0);
     setStartIndex(0);
+    if (wrapperRef.current) {
+      wrapperRef.current.scrollTop = 0;
+    }
     context.prevWrapperRefHeight = currentWrapperRefHeight;
     return () => {
       context.preIndex = null;

--- a/packages/shineout/src/select/__doc__/changelog.cn.md
+++ b/packages/shineout/src/select/__doc__/changelog.cn.md
@@ -1,3 +1,8 @@
+## 3.9.14-beta.11
+2026-05-19
+### 🐞 BugFix
+- 修复 `Select` 开启 `onFilter` 后，在下拉列表中滚动再输入关键字时首项不可见的问题（Regression: since v3.9.9） ([#1713](https://github.com/sheinsight/shineout-next/pull/1713))
+
 ## 3.9.14-beta.8
 2026-05-06
 ### 🐞 BugFix

--- a/packages/shineout/src/select/__example__/19-loadmore.tsx
+++ b/packages/shineout/src/select/__example__/19-loadmore.tsx
@@ -63,6 +63,7 @@ export default () => {
         renderItem={(d) => d.firstName}
         placeholder='Select User'
         onLoadMore={onLoadMore}
+        onFilter={(v) => (d) => d.firstName.indexOf(v) >= 0}
         renderOptionList={(List) => {
           return (
             <Spin loading={loading} name='ring' size={14}>


### PR DESCRIPTION
## Summary

修复 `Select` 组件开启 `onFilter` 后，用户在下拉列表中先滚动再输入能命中第一项的关键字时，首项不可见的问题。原因是虚拟列表的 `translate3d` 偏移未被正确重置。

**Regression introduced in #1619**

## Root Cause

#1619 引入了 `filterTextChanged` 单帧信号来控制 `keepScrollTop`，但由于 `filterDelay`（默认 400ms）的存在，`filterText` 变化与 `filterData` 变化不在同一次渲染中，导致 `keepScrollTop` 在数据真正变化时已回到 `true`，重置逻辑被跳过。

## Fix

- 改用数据长度变化方向判断：数据增长（scroll-loading 追加）→ 保持位置；数据缩减（filter 过滤）→ 重置到顶部
- 在 VirtualScrollList 重置 `top`/`startIndex` 时同步重置 `scrollTop`，防止残留值触发 scroll 事件再次设置非零偏移

## Test Plan

1. 打开 Select（带 `onFilter` + `onLoadMore`）
2. 滚动下拉列表加载更多数据 → 列表不应跳回第一条 ✓
3. 滚动后输入能命中第一项的关键字 → 首项应可见，无 translate 偏移 ✓