### PR TITLE
feat(table): 支持外部滚动容器驱动虚拟滚动

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.14",
+  "version": "3.9.15-beta.1",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/table/table.tsx
+++ b/packages/base/src/table/table.tsx
@@ -283,6 +283,7 @@ export default function Table<Item, Value>(props: TableProps<Item, Value>) {
     tfootHeight: context.tfootHeight,
     virtualScrollContainer: props.virtualScrollContainer,
     tableRef: tableRef,
+    externalStickyHeader: !!props.virtualScrollContainer && !!props.sticky,
   });
 
   const syncHeaderScroll = usePersistFn((left: number) => {
@@ -588,24 +589,28 @@ export default function Table<Item, Value>(props: TableProps<Item, Value>) {
       const showStickyHeader = !props.hideHeader && props.sticky;
 
       if (virtualInfo.isExternalScroll) {
-        const externalStickyTop = props.sticky
+        const stickyTopOffset = props.sticky
           ? (typeof props.sticky === 'object' ? props.sticky.top ?? 0 : 0)
-          : undefined;
+          : -virtualInfo.tableOffsetRef.current;
         const externalContainer = props.virtualScrollContainer?.();
         const stickyDivHeight = externalContainer
-          ? externalContainer.clientHeight - (externalStickyTop ?? 0)
+          ? externalContainer.clientHeight - stickyTopOffset
           : undefined;
         return (
           <div style={{ position: 'relative', height: virtualInfo.scrollHeight }}>
             <div
-              ref={props.sticky ? undefined : virtualInfo.externalStickyRef}
-              style={{ position: 'sticky', top: externalStickyTop ?? 0, height: stickyDivHeight, overflowX: 'auto', overflowY: 'hidden' }}
+              ref={virtualInfo.externalStickyRef}
+              style={{ position: 'sticky', top: stickyTopOffset, height: stickyDivHeight, overflowX: 'auto', overflowY: 'hidden' }}
             >
-              {!props.hideHeader && $headTable}
+              {!props.hideHeader && (
+                <div style={{ position: 'relative', zIndex: 1, marginTop: props.sticky ? 0 : -virtualInfo.headerOffset }}>
+                  {$headTable}
+                </div>
+              )}
 
               {!!props.data?.length && (
                 <table
-                  style={{ ...tableStyle, transform: virtualInfo.translateStyle }}
+                  style={{ ...tableStyle, transform: virtualInfo.translateStyle, willChange: 'transform' }}
                   ref={tbodyRef}
                 >
                   {Group}

--- a/packages/base/src/table/table.tsx
+++ b/packages/base/src/table/table.tsx
@@ -88,7 +88,7 @@ export default function Table<Item, Value>(props: TableProps<Item, Value>) {
   const virtual =
     !fakeVirtual &&
     props.rowsInView !== 0 &&
-    (!!props.virtual || props.fixed === 'both' || props.fixed === 'y' || props.fixed === 'auto');
+    (!!props.virtual || !!props.virtualScrollContainer || props.fixed === 'both' || props.fixed === 'y' || props.fixed === 'auto');
 
   useLayoutEffect(() => {
     if (!virtual) return;
@@ -105,7 +105,7 @@ export default function Table<Item, Value>(props: TableProps<Item, Value>) {
   const { height: tbodyHeight } = useResize({ targetRef: virtual ? emptyRef : tbodyRef });
 
   // default height
-  const defaultHeight = virtual && !props.height ? '100%' : props.height;
+  const defaultHeight = virtual && !props.height && !props.virtualScrollContainer ? '100%' : props.height;
 
   const selection = useTableSelect({
     cellSelectable: props.cellSelectable,
@@ -281,6 +281,8 @@ export default function Table<Item, Value>(props: TableProps<Item, Value>) {
     isRtl,
     theadHeight: context.theadHeight,
     tfootHeight: context.tfootHeight,
+    virtualScrollContainer: props.virtualScrollContainer,
+    tableRef: tableRef,
   });
 
   const syncHeaderScroll = usePersistFn((left: number) => {
@@ -489,7 +491,7 @@ export default function Table<Item, Value>(props: TableProps<Item, Value>) {
       !!$empty && tableClasses.emptyHeader,
       props.sticky && isScrollY && tableClasses.scrollY,
       props.sticky && isScrollY && browserScrollbarWidth === 0 && tableClasses.overlayScrollbar,
-      props.sticky && !isScrollY && tableClasses.scrollX,
+      props.sticky && !isScrollY && !virtualInfo.isExternalScroll && tableClasses.scrollX,
     );
 
     const footWrapperClass = classNames(tableClasses?.footWrapper);
@@ -584,6 +586,48 @@ export default function Table<Item, Value>(props: TableProps<Item, Value>) {
 
     if (isRenderVirtualTable) {
       const showStickyHeader = !props.hideHeader && props.sticky;
+
+      if (virtualInfo.isExternalScroll) {
+        const externalStickyTop = props.sticky
+          ? (typeof props.sticky === 'object' ? props.sticky.top ?? 0 : 0)
+          : undefined;
+        const externalContainer = props.virtualScrollContainer?.();
+        const stickyDivHeight = externalContainer
+          ? externalContainer.clientHeight - (externalStickyTop ?? 0)
+          : undefined;
+        return (
+          <div style={{ position: 'relative', height: virtualInfo.scrollHeight }}>
+            <div
+              ref={props.sticky ? undefined : virtualInfo.externalStickyRef}
+              style={{ position: 'sticky', top: externalStickyTop ?? 0, height: stickyDivHeight, overflowX: 'auto', overflowY: 'hidden' }}
+            >
+              {!props.hideHeader && $headTable}
+
+              {!!props.data?.length && (
+                <table
+                  style={{ ...tableStyle, transform: virtualInfo.translateStyle }}
+                  ref={tbodyRef}
+                >
+                  {Group}
+                  <Tbody
+                    {...bodyCommonProps}
+                    currentRowIndex={virtualInfo.startIndex}
+                    currentColIndex={currentColIndex}
+                    data={virtualInfo.data}
+                    originData={treeData}
+                    rowSpanIndexArray={virtualInfo.rowSpanInfo?.rowSpanIndexArray}
+                    setRowHeight={virtualInfo.setRowHeight}
+                    scrolling={scrolling}
+                  />
+                </table>
+              )}
+
+              {$empty}
+            </div>
+          </div>
+        );
+      }
+
       return (
         <>
           {renderHeadMirrorScroller()}

--- a/packages/base/src/table/table.tsx
+++ b/packages/base/src/table/table.tsx
@@ -589,9 +589,9 @@ export default function Table<Item, Value>(props: TableProps<Item, Value>) {
       const showStickyHeader = !props.hideHeader && props.sticky;
 
       if (virtualInfo.isExternalScroll) {
-        const stickyTopOffset = props.sticky
-          ? (typeof props.sticky === 'object' ? props.sticky.top ?? 0 : 0)
-          : -virtualInfo.tableOffsetRef.current;
+        const tableOffset = virtualInfo.tableOffsetRef.current;
+        const stickyTop = typeof props.sticky === 'object' ? (props.sticky.top ?? 0) : 0;
+        const stickyTopOffset = stickyTop - tableOffset;
         const externalContainer = props.virtualScrollContainer?.();
         const stickyDivHeight = externalContainer
           ? externalContainer.clientHeight - stickyTopOffset

--- a/packages/base/src/table/table.type.ts
+++ b/packages/base/src/table/table.type.ts
@@ -406,7 +406,13 @@ export interface TableProps<DataItem, Value>
    * @default null
    * @version 3.9.0
    */
-  strictRowHeight?: number
+  strictRowHeight?: number;
+
+  /**
+   * @en External scroll container for virtual scrolling. When set, the table won't have internal scroll but will be driven by the external container's scroll event. Pass a function that returns the scroll container element (e.g., () => document.body)
+   * @cn 虚拟滚动的外部滚动容器。设置后表格不再产生内部滚动，而是由外部容器的滚动事件驱动虚拟列表。传入一个函数，返回滚动容器元素（如 () => document.documentElement）
+   */
+  virtualScrollContainer?: () => HTMLElement | null;
 }
 
 interface BottomScrollbarOption extends Pick<StickyProps, 'bottom' | 'scrollContainer'> {

--- a/packages/hooks/src/components/use-table/use-table-virtual-external.tsx
+++ b/packages/hooks/src/components/use-table/use-table-virtual-external.tsx
@@ -1,0 +1,91 @@
+import { usePersistFn } from '../../common/use-persist-fn';
+import { useState, useRef, useEffect } from 'react';
+
+interface UseTableVirtualExternalProps {
+  disabled?: boolean;
+  dataLength: number;
+  theadHeight: number;
+  tfootHeight: number;
+  externalStickyHeader?: boolean;
+  virtualScrollContainer: () => HTMLElement | null;
+  tableRef?: React.RefObject<HTMLDivElement>;
+  getContentHeight: (index: number) => number;
+  updateIndexAndTopFromTop: (scrollTop: number) => void;
+}
+
+const useTableVirtualExternal = (props: UseTableVirtualExternalProps) => {
+  const [headerOffset, setHeaderOffset] = useState(0);
+  const externalStickyRef = useRef<HTMLDivElement>(null);
+  const tableOffsetRef = useRef<number>(0);
+
+  const handleExternalScroll = usePersistFn(() => {
+    if (props.disabled) return;
+    const container = props.virtualScrollContainer();
+    const tableEl = props.tableRef?.current;
+    if (!container || !tableEl) return;
+
+    if (tableOffsetRef.current === 0) {
+      if (container === document.documentElement || container === document.body) {
+        tableOffsetRef.current = tableEl.getBoundingClientRect().top + window.scrollY;
+      } else {
+        tableOffsetRef.current =
+          tableEl.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop;
+      }
+    }
+
+    let rawScrollTop: number;
+    if (container === document.documentElement || container === document.body) {
+      const rect = tableEl.getBoundingClientRect();
+      rawScrollTop = -rect.top;
+    } else {
+      const containerRect = container.getBoundingClientRect();
+      const tableRect = tableEl.getBoundingClientRect();
+      rawScrollTop = containerRect.top - tableRect.top;
+    }
+    if (rawScrollTop < 0) rawScrollTop = 0;
+
+    const sumHeight = props.getContentHeight(props.dataLength - 1);
+    const viewportHeight = externalStickyRef.current?.clientHeight || container.clientHeight;
+
+    let scrollTop: number;
+    let max: number;
+    if (props.externalStickyHeader) {
+      max = sumHeight - props.tfootHeight - viewportHeight;
+      scrollTop = rawScrollTop;
+    } else {
+      const newHeaderOffset = Math.min(rawScrollTop, props.theadHeight);
+      if (newHeaderOffset !== headerOffset) {
+        setHeaderOffset(newHeaderOffset);
+      }
+      max = sumHeight - props.theadHeight - props.tfootHeight - viewportHeight;
+      scrollTop = rawScrollTop - props.theadHeight;
+      if (scrollTop < 0) scrollTop = 0;
+    }
+    if (max > 0 && scrollTop > max) {
+      scrollTop = max;
+    }
+
+    props.updateIndexAndTopFromTop(scrollTop);
+  });
+
+  useEffect(() => {
+    if (props.disabled) return;
+    const container = props.virtualScrollContainer();
+    if (!container) return;
+    const scrollTarget =
+      container === document.documentElement || container === document.body ? window : container;
+    scrollTarget.addEventListener('scroll', handleExternalScroll, { passive: true });
+    handleExternalScroll();
+    return () => {
+      scrollTarget.removeEventListener('scroll', handleExternalScroll);
+    };
+  }, [props.disabled, props.dataLength]);
+
+  return {
+    externalStickyRef,
+    headerOffset,
+    tableOffsetRef,
+  };
+};
+
+export default useTableVirtualExternal;

--- a/packages/hooks/src/components/use-table/use-table-virtual.tsx
+++ b/packages/hooks/src/components/use-table/use-table-virtual.tsx
@@ -1,6 +1,7 @@
 import { usePersistFn } from '../../common/use-persist-fn';
 import { useState, useRef, useEffect, useMemo } from 'react';
 import { TableFormatColumn } from './use-table.type';
+import useTableVirtualExternal from './use-table-virtual-external';
 
 // 找出最大的连续数字的个数
 function getMaxRowSpanLength(input: number[]) {
@@ -28,6 +29,7 @@ interface UseTableVirtualProps {
   tfootHeight: number;
   virtualScrollContainer?: () => HTMLElement | null;
   tableRef?: React.RefObject<HTMLDivElement>;
+  externalStickyHeader?: boolean;
 }
 const useTableVirtual = (props: UseTableVirtualProps) => {
   const [innerTop, setTop] = useState(0);
@@ -114,7 +116,6 @@ const useTableVirtual = (props: UseTableVirtualProps) => {
     preIndex: null as number | null,
     rowSpanRows: 0,
     autoAddRows: 0,
-    latestTop: 0,
   });
 
   const getContentHeight = (index: number) => {
@@ -137,12 +138,7 @@ const useTableVirtual = (props: UseTableVirtualProps) => {
     context.cachedHeight[index] = height;
 
     if (context.shouldUpdateHeight) {
-      const newHeight = getContentHeight(props.data.length - 1);
-      if (props.virtualScrollContainer) {
-        setHeight((prev) => Math.max(prev, newHeight));
-      } else {
-        setHeight(newHeight);
-      }
+      setHeight(getContentHeight(props.data.length - 1));
     }
     const { preIndex } = context;
     // 解决: 从下往上滚 由于高度变化会导致滚动条跳动（仅内部滚动需要）
@@ -219,7 +215,6 @@ const useTableVirtual = (props: UseTableVirtualProps) => {
         }, 300);
       }
     }
-    context.latestTop = top;
     setTop(top);
   };
 
@@ -414,83 +409,18 @@ const useTableVirtual = (props: UseTableVirtualProps) => {
   }, [innerTop]);
 
   const isExternalScroll = !!props.virtualScrollContainer;
-  const externalStickyRef = useRef<HTMLDivElement>(null);
-  const tableOffsetRef = useRef<number | null>(null);
 
-  /**
-   * TODO: 外部滚动模式待修复的两个问题
-   * 1. 快速拖动滚动条到顶部时出现空白（松手后缓慢回弹）
-   *    - 原因: React state(innerTop/startIndex) 异步更新，scroll事件同步触发，导致旧的translateStyle在新位置生效
-   *    - 已尝试: 在handleExternalScroll末尾同步写入 innerRef.style.transform (context.latestTop)
-   *    - 结果: 反而更严重了，可能是同步DOM更新与React渲染的translateStyle冲突/闪烁
-   *    - 方向: 考虑外部滚动模式完全不用React state驱动transform，改为纯ref+DOM操作；
-   *           或者用 requestAnimationFrame 节流；或者用 CSS will-change 优化
-   * 2. 滚动到底部时到不了最后一条数据（停在约9318行左右）
-   *    - 原因: scrollHeight(撑高外部容器的div高度)可能不够，或 updateIndexAndTopFromTop 的 maxIndex 限制
-   *    - 已尝试: setHeight用Math.max只增不减、添加context.latestTop同步
-   *    - 结果: Math.max方案本身是对的，但配合同步DOM更新后问题更明显
-   *    - 方向: 去掉同步DOM更新(恢复之前的版本)，单独排查scrollHeight是否等于真实内容高度；
-   *           检查外部容器padding(24px)对最大rawScrollTop的影响
-   *
-   * 恢复方案: 去掉 context.latestTop 相关代码和 handleExternalScroll 末尾的同步DOM更新
-   */
-  const handleExternalScroll = usePersistFn(() => {
-    if (props.disabled || !isExternalScroll) return;
-    const container = props.virtualScrollContainer!();
-    const tableEl = props.tableRef?.current;
-    if (!container || !tableEl) return;
-
-    let rawScrollTop: number;
-    if (container === document.documentElement || container === document.body) {
-      const rect = tableEl.getBoundingClientRect();
-      rawScrollTop = -rect.top;
-    } else {
-      const containerRect = container.getBoundingClientRect();
-      const tableRect = tableEl.getBoundingClientRect();
-      rawScrollTop = containerRect.top - tableRect.top;
-    }
-
-    if (rawScrollTop < 0) rawScrollTop = 0;
-
-    if (externalStickyRef.current) {
-      if (tableOffsetRef.current === null) {
-        if (container === document.documentElement || container === document.body) {
-          tableOffsetRef.current = tableEl.getBoundingClientRect().top + window.scrollY;
-        } else {
-          tableOffsetRef.current =
-            tableEl.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop;
-        }
-      }
-      externalStickyRef.current.style.top = `${-(props.theadHeight + tableOffsetRef.current)}px`;
-    }
-
-    let scrollTop = rawScrollTop - props.theadHeight;
-    if (scrollTop < 0) scrollTop = 0;
-    const sumHeight = getContentHeight(props.data.length - 1);
-    if (scrollTop > sumHeight) scrollTop = sumHeight;
-
-    updateIndexAndTopFromTop(scrollTop);
-
-    // 同步更新 DOM transform，防止 React 异步渲染期间出现空白
-    if (props.innerRef?.current) {
-      const t = Math.max(0, context.latestTop);
-      props.innerRef.current.style.transform = `translate3d(0, ${-t}px, 0)`;
-    }
+  const externalInfo = useTableVirtualExternal({
+    disabled: props.disabled || !isExternalScroll,
+    dataLength: props.data.length,
+    theadHeight: props.theadHeight,
+    tfootHeight: props.tfootHeight,
+    externalStickyHeader: props.externalStickyHeader,
+    virtualScrollContainer: props.virtualScrollContainer || (() => null),
+    tableRef: props.tableRef,
+    getContentHeight,
+    updateIndexAndTopFromTop,
   });
-
-  useEffect(() => {
-    if (!isExternalScroll || props.disabled) return;
-    const container = props.virtualScrollContainer!();
-    if (!container) return;
-    const scrollTarget = (container === document.documentElement || container === document.body)
-      ? window
-      : container;
-    scrollTarget.addEventListener('scroll', handleExternalScroll, { passive: true });
-    handleExternalScroll();
-    return () => {
-      scrollTarget.removeEventListener('scroll', handleExternalScroll);
-    };
-  }, [isExternalScroll, props.disabled, props.data.length]);
 
   return {
     scrollHeight,
@@ -504,7 +434,9 @@ const useTableVirtual = (props: UseTableVirtualProps) => {
     scrollColumnIntoView,
     rowSpanInfo,
     isExternalScroll,
-    externalStickyRef,
+    externalStickyRef: externalInfo.externalStickyRef,
+    headerOffset: externalInfo.headerOffset,
+    tableOffsetRef: externalInfo.tableOffsetRef,
   };
 };
 

--- a/packages/hooks/src/components/use-table/use-table-virtual.tsx
+++ b/packages/hooks/src/components/use-table/use-table-virtual.tsx
@@ -26,6 +26,8 @@ interface UseTableVirtualProps {
   colgroup: (number | string | undefined)[];
   theadHeight: number;
   tfootHeight: number;
+  virtualScrollContainer?: () => HTMLElement | null;
+  tableRef?: React.RefObject<HTMLDivElement>;
 }
 const useTableVirtual = (props: UseTableVirtualProps) => {
   const [innerTop, setTop] = useState(0);
@@ -112,6 +114,7 @@ const useTableVirtual = (props: UseTableVirtualProps) => {
     preIndex: null as number | null,
     rowSpanRows: 0,
     autoAddRows: 0,
+    latestTop: 0,
   });
 
   const getContentHeight = (index: number) => {
@@ -134,11 +137,16 @@ const useTableVirtual = (props: UseTableVirtualProps) => {
     context.cachedHeight[index] = height;
 
     if (context.shouldUpdateHeight) {
-      setHeight(getContentHeight(props.data.length - 1));
+      const newHeight = getContentHeight(props.data.length - 1);
+      if (props.virtualScrollContainer) {
+        setHeight((prev) => Math.max(prev, newHeight));
+      } else {
+        setHeight(newHeight);
+      }
     }
     const { preIndex } = context;
-    // 解决: 从下往上滚 由于高度变化会导致滚动条跳动
-    if (preIndex && preIndex > startIndex && startIndex === index) {
+    // 解决: 从下往上滚 由于高度变化会导致滚动条跳动（仅内部滚动需要）
+    if (!props.virtualScrollContainer && preIndex && preIndex > startIndex && startIndex === index) {
       // 发生在顶部
       if (context.heightCallback) return;
       const offset = height - (beforeHeight || props.rowHeight);
@@ -211,6 +219,7 @@ const useTableVirtual = (props: UseTableVirtualProps) => {
         }, 300);
       }
     }
+    context.latestTop = top;
     setTop(top);
   };
 
@@ -404,6 +413,85 @@ const useTableVirtual = (props: UseTableVirtualProps) => {
     return `translate3d(0, ${0 - t}px, 0)`;
   }, [innerTop]);
 
+  const isExternalScroll = !!props.virtualScrollContainer;
+  const externalStickyRef = useRef<HTMLDivElement>(null);
+  const tableOffsetRef = useRef<number | null>(null);
+
+  /**
+   * TODO: 外部滚动模式待修复的两个问题
+   * 1. 快速拖动滚动条到顶部时出现空白（松手后缓慢回弹）
+   *    - 原因: React state(innerTop/startIndex) 异步更新，scroll事件同步触发，导致旧的translateStyle在新位置生效
+   *    - 已尝试: 在handleExternalScroll末尾同步写入 innerRef.style.transform (context.latestTop)
+   *    - 结果: 反而更严重了，可能是同步DOM更新与React渲染的translateStyle冲突/闪烁
+   *    - 方向: 考虑外部滚动模式完全不用React state驱动transform，改为纯ref+DOM操作；
+   *           或者用 requestAnimationFrame 节流；或者用 CSS will-change 优化
+   * 2. 滚动到底部时到不了最后一条数据（停在约9318行左右）
+   *    - 原因: scrollHeight(撑高外部容器的div高度)可能不够，或 updateIndexAndTopFromTop 的 maxIndex 限制
+   *    - 已尝试: setHeight用Math.max只增不减、添加context.latestTop同步
+   *    - 结果: Math.max方案本身是对的，但配合同步DOM更新后问题更明显
+   *    - 方向: 去掉同步DOM更新(恢复之前的版本)，单独排查scrollHeight是否等于真实内容高度；
+   *           检查外部容器padding(24px)对最大rawScrollTop的影响
+   *
+   * 恢复方案: 去掉 context.latestTop 相关代码和 handleExternalScroll 末尾的同步DOM更新
+   */
+  const handleExternalScroll = usePersistFn(() => {
+    if (props.disabled || !isExternalScroll) return;
+    const container = props.virtualScrollContainer!();
+    const tableEl = props.tableRef?.current;
+    if (!container || !tableEl) return;
+
+    let rawScrollTop: number;
+    if (container === document.documentElement || container === document.body) {
+      const rect = tableEl.getBoundingClientRect();
+      rawScrollTop = -rect.top;
+    } else {
+      const containerRect = container.getBoundingClientRect();
+      const tableRect = tableEl.getBoundingClientRect();
+      rawScrollTop = containerRect.top - tableRect.top;
+    }
+
+    if (rawScrollTop < 0) rawScrollTop = 0;
+
+    if (externalStickyRef.current) {
+      if (tableOffsetRef.current === null) {
+        if (container === document.documentElement || container === document.body) {
+          tableOffsetRef.current = tableEl.getBoundingClientRect().top + window.scrollY;
+        } else {
+          tableOffsetRef.current =
+            tableEl.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop;
+        }
+      }
+      externalStickyRef.current.style.top = `${-(props.theadHeight + tableOffsetRef.current)}px`;
+    }
+
+    let scrollTop = rawScrollTop - props.theadHeight;
+    if (scrollTop < 0) scrollTop = 0;
+    const sumHeight = getContentHeight(props.data.length - 1);
+    if (scrollTop > sumHeight) scrollTop = sumHeight;
+
+    updateIndexAndTopFromTop(scrollTop);
+
+    // 同步更新 DOM transform，防止 React 异步渲染期间出现空白
+    if (props.innerRef?.current) {
+      const t = Math.max(0, context.latestTop);
+      props.innerRef.current.style.transform = `translate3d(0, ${-t}px, 0)`;
+    }
+  });
+
+  useEffect(() => {
+    if (!isExternalScroll || props.disabled) return;
+    const container = props.virtualScrollContainer!();
+    if (!container) return;
+    const scrollTarget = (container === document.documentElement || container === document.body)
+      ? window
+      : container;
+    scrollTarget.addEventListener('scroll', handleExternalScroll, { passive: true });
+    handleExternalScroll();
+    return () => {
+      scrollTarget.removeEventListener('scroll', handleExternalScroll);
+    };
+  }, [isExternalScroll, props.disabled, props.data.length]);
+
   return {
     scrollHeight,
     startIndex,
@@ -415,6 +503,8 @@ const useTableVirtual = (props: UseTableVirtualProps) => {
     scrollColumnByLeft,
     scrollColumnIntoView,
     rowSpanInfo,
+    isExternalScroll,
+    externalStickyRef,
   };
 };
 

--- a/packages/shineout/src/table/__doc__/changelog.cn.md
+++ b/packages/shineout/src/table/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.9.15-beta.1
+2026-05-21
+### 🆕 Feature
+- `Table` 虚拟列表新增 `virtualScrollContainer` 属性，支持由外部滚动容器驱动虚拟滚动 ([#1715](https://github.com/sheinsight/shineout-next/pull/1715))
+
+
 ## 3.9.14-beta.7
 2026-04-30
 ### 🐞 BugFix

--- a/packages/shineout/src/table/__example__/07-04-virtual-scroll-external.tsx
+++ b/packages/shineout/src/table/__example__/07-04-virtual-scroll-external.tsx
@@ -4,8 +4,8 @@
  * en - External Scroll
  *    -- Set `virtualScrollContainer` to drive the virtual list by an external container's scroll event
  */
-import React, { useRef } from 'react';
-import { Table, TYPE } from 'shineout';
+import React, { useRef, useState } from 'react';
+import { Table, Switch, TYPE } from 'shineout';
 import { user } from '@sheinx/mock';
 
 interface TableRowData {
@@ -41,11 +41,16 @@ const columns: TableColumnItem[] = [
 
 const App: React.FC = () => {
   const containerRef = useRef<HTMLDivElement>(null);
+  const [sticky, setSticky] = useState(false);
 
   return (
     <div>
-      <div style={{ marginBottom: 16 }}>
-        下方容器高度为 500px，表格通过外部容器的滚动事件驱动虚拟列表渲染（共 10000 条数据）
+      <div style={{ marginBottom: 16, display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span>Sticky Header:</span>
+        <Switch value={sticky} onChange={setSticky} />
+        <span style={{ marginLeft: 16 }}>
+          下方容器高度为 500px，表格通过外部容器的滚动事件驱动虚拟列表渲染（共 10000 条数据）
+        </span>
       </div>
       <div
         ref={containerRef}
@@ -64,7 +69,7 @@ const App: React.FC = () => {
           keygen='id'
           bordered
           data={data}
-          // sticky={{ top: -24 }}
+          sticky={sticky}
           width={1400}
           rowsInView={20}
           columns={columns}

--- a/packages/shineout/src/table/__example__/07-04-virtual-scroll-external.tsx
+++ b/packages/shineout/src/table/__example__/07-04-virtual-scroll-external.tsx
@@ -1,0 +1,77 @@
+/**
+ * cn - 外部滚动
+ *    -- 设置 `virtualScrollContainer` 使虚拟列表由外部容器的滚动驱动，表格本身不产生内滚
+ * en - External Scroll
+ *    -- Set `virtualScrollContainer` to drive the virtual list by an external container's scroll event
+ */
+import React, { useRef } from 'react';
+import { Table, TYPE } from 'shineout';
+import { user } from '@sheinx/mock';
+
+interface TableRowData {
+  id: number;
+  time: string;
+  start: string;
+  height: number;
+  salary: number;
+  office: string;
+  country: string;
+  office5: string;
+  position: string;
+  lastName: string;
+  firstName: string;
+}
+
+type TableColumnItem = TYPE.Table.ColumnItem<TableRowData>;
+
+const data: TableRowData[] = user.fetchSync(10000);
+
+const columns: TableColumnItem[] = [
+  { title: 'id', render: 'id', width: 80 },
+  {
+    title: 'Name',
+    render: (d) => `${d.firstName} ${d.lastName}`,
+    width: 160,
+  },
+  { title: 'Country', render: 'country', width: 120 },
+  { title: 'Position', render: 'position' },
+  { title: 'Office', render: 'office' },
+  { title: 'Start Date', render: 'start', width: 140 },
+];
+
+const App: React.FC = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <div>
+      <div style={{ marginBottom: 16 }}>
+        下方容器高度为 500px，表格通过外部容器的滚动事件驱动虚拟列表渲染（共 10000 条数据）
+      </div>
+      <div
+        ref={containerRef}
+        style={{
+          height: 500,
+          padding: 24,
+          overflow: 'auto',
+          border: '1px solid #e8e8e8',
+          backgroundImage: 'linear-gradient(45deg, #f0f0f0 25%, transparent 25%, transparent 75%, #f0f0f0 75%), linear-gradient(45deg, #f0f0f0 25%, transparent 25%, transparent 75%, #f0f0f0 75%)',
+          backgroundSize: '20px 20px',
+          backgroundPosition: '0 0, 10px 10px',
+        }}
+      >
+        <Table
+          keygen='id'
+          bordered
+          data={data}
+          // sticky={{ top: -24 }}
+          width={1400}
+          rowsInView={20}
+          columns={columns}
+          virtualScrollContainer={() => containerRef.current}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default App;

--- a/packages/shineout/src/table/__example__/07-04-virtual-scroll-external.tsx
+++ b/packages/shineout/src/table/__example__/07-04-virtual-scroll-external.tsx
@@ -57,6 +57,7 @@ const App: React.FC = () => {
           backgroundImage: 'linear-gradient(45deg, #f0f0f0 25%, transparent 25%, transparent 75%, #f0f0f0 75%), linear-gradient(45deg, #f0f0f0 25%, transparent 25%, transparent 75%, #f0f0f0 75%)',
           backgroundSize: '20px 20px',
           backgroundPosition: '0 0, 10px 10px',
+          overscrollBehavior: 'none',
         }}
       >
         <Table


### PR DESCRIPTION
## Summary

`Table` 虚拟列表新增 `virtualScrollContainer` 属性，支持由外部滚动容器驱动虚拟滚动，表格本身不产生内滚。

### 变更内容
- 新增 `virtualScrollContainer` 属性，接收返回外部滚动容器元素的函数
- 新增 `use-table-virtual-external` hook 处理外部滚动逻辑
- 支持 `sticky` 表头在外部滚动模式下的吸顶
- 优化 `stickyTopOffset` 计算逻辑，消除重复访问
- 新增示例 `07-04-virtual-scroll-external`

## Test Plan
- 打开外部滚动示例页，验证 10000 条数据虚拟滚动正常
- 切换 Sticky Header 开关，验证表头吸顶效果
- 快速滚动验证无空白行，可滚动到底部