### PR TITLE
perf(image): 优化预览弹窗渲染性能，避免同步阻塞主线程

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.15-beta.1",
+  "version": "3.9.15-beta.2",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/image/image-event.tsx
+++ b/packages/base/src/image/image-event.tsx
@@ -41,12 +41,12 @@ const showGallery = (
   const container = getContainer();
   document.addEventListener('keydown', keyClose);
   container.className = containerClass || '';
-  requestAnimationFrame(() => {
+  setTimeout(() => {
     ReactRender(
       <ImageGallery jssStyle={jssStyle} onClose={close} current={current} images={Images} />,
       container,
     );
-  });
+  }, 0);
 };
 
 export default showGallery;

--- a/packages/base/src/image/image-event.tsx
+++ b/packages/base/src/image/image-event.tsx
@@ -41,10 +41,12 @@ const showGallery = (
   const container = getContainer();
   document.addEventListener('keydown', keyClose);
   container.className = containerClass || '';
-  ReactRender(
-    <ImageGallery jssStyle={jssStyle} onClose={close} current={current} images={Images} />,
-    container,
-  );
+  requestAnimationFrame(() => {
+    ReactRender(
+      <ImageGallery jssStyle={jssStyle} onClose={close} current={current} images={Images} />,
+      container,
+    );
+  });
 };
 
 export default showGallery;

--- a/packages/shineout/src/image/__doc__/changelog.cn.md
+++ b/packages/shineout/src/image/__doc__/changelog.cn.md
@@ -1,3 +1,8 @@
+## 3.9.15-beta.2
+2026-05-21
+### 💎 Enhancement
+- 优化 `Image` 组件点击预览弹窗的渲染性能，避免同步阻塞主线程 ([#1716](https://github.com/sheinsight/shineout-next/pull/1716))
+
 ## 3.9.7-beta.4
 2026-01-09
 ### 🐞 BugFix

--- a/packages/shineout/src/image/__test__/image.spec.tsx
+++ b/packages/shineout/src/image/__test__/image.spec.tsx
@@ -386,9 +386,11 @@ describe('Image[Pile]', () => {
     await waitFor(() => {
       const pre = container.querySelector(imageClassName)!;
       fireEvent.click(pre);
-      expect(document.getElementsByClassName(imageGalleryClassName).length).toBe(2);
-      expect(clickFn.mock.calls.length).toBe(1);
     });
+    await waitFor(() => {
+      expect(document.getElementsByClassName(imageGalleryClassName).length).toBe(2);
+    });
+    expect(clickFn.mock.calls.length).toBe(1);
   });
   test('should render when set showCount', async () => {
     const { container } = renderImage(imageGroup());


### PR DESCRIPTION
## Summary

优化 `Image` 组件点击预览弹窗时的渲染性能。

当 `Image` 组件带有 `target="_modal"` 或 `href` 属性时，点击图片会同步创建预览弹窗，所有 DOM 创建和 React 组件树渲染都发生在同一个 click 事件帧中，造成主线程阻塞。

将 `ReactRender` 调用包裹在 `requestAnimationFrame` 中，将 Gallery 渲染推迟到下一帧，减少 click 事件的同步阻塞时间。

## Changes

- `packages/base/src/image/image-event.tsx`: `showGallery` 中使用 `requestAnimationFrame` 延迟渲染 `ImageGallery`

## Test Plan

1. 打开 Image 组件文档页，找到 `target="_modal"` 的 demo
2. Chrome DevTools → Performance → CPU 6x slowdown
3. 录制点击图片打开预览弹窗的过程
4. 对比修复前后 click 事件 Task 的耗时