### PR TITLE
fix(empty): 修复外部 reset 样式导致 svg 图标无法居中的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.15-beta.2",
+  "version": "3.9.15-beta.3",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/empty/empty.ts
+++ b/packages/shineout-style/src/empty/empty.ts
@@ -16,6 +16,9 @@ const emptyStyle: JsStyles<keyof EmptyClasses> = {
   image: {
     marginBottom: 8,
     lineHeight: 1,
+    '& > svg': {
+      display: 'inline-block',
+    },
     '& img': {
       width: 100,
       height: 75,

--- a/packages/shineout/src/empty/__doc__/changelog.cn.md
+++ b/packages/shineout/src/empty/__doc__/changelog.cn.md
@@ -1,3 +1,11 @@
+## 3.9.15-beta.3
+2026-05-22
+
+### 🐞 BugFix
+
+- 修复外部 reset 样式将 svg 设为 block 时，`Empty` 图标无法水平居中的问题 ([#1717](https://github.com/sheinsight/shineout-next/pull/1717))
+
+
 ## 3.8.3-beta.2
 2025-09-15
 


### PR DESCRIPTION
## 问题

用户系统添加了 reset 样式，将 svg 元素设置为 block，导致 Table 空数据时 Empty 组件的 svg 图标未能水平居中对齐。

## 修复

在 Empty 组件的 `image` 样式中添加 `& > svg { display: inline-block }`，重置直接子 svg 的 display 属性，确保不受外部 reset 样式影响。

## 关联

NDP-64721