### PR TITLE
fix(table): 修复 virtualScrollContainer 模式下 sticky 表头滚动到底部时吸附失效

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.15-beta.3",
+  "version": "3.9.15-beta.4",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/table/table.tsx
+++ b/packages/base/src/table/table.tsx
@@ -603,7 +603,7 @@ export default function Table<Item, Value>(props: TableProps<Item, Value>) {
               style={{ position: 'sticky', top: stickyTopOffset, height: stickyDivHeight, overflowX: 'auto', overflowY: 'hidden' }}
             >
               {!props.hideHeader && (
-                <div style={{ position: 'relative', zIndex: 1, marginTop: props.sticky ? 0 : -virtualInfo.headerOffset }}>
+                <div style={{ position: 'relative', zIndex: 1, marginTop: props.sticky ? 0 : -virtualInfo.headerOffset, transform: 'translateY(var(--sticky-compensation, 0px))', willChange: 'transform' }}>
                   {$headTable}
                 </div>
               )}

--- a/packages/hooks/src/components/use-table/use-table-virtual-external.tsx
+++ b/packages/hooks/src/components/use-table/use-table-virtual-external.tsx
@@ -17,6 +17,7 @@ const useTableVirtualExternal = (props: UseTableVirtualExternalProps) => {
   const [headerOffset, setHeaderOffset] = useState(0);
   const externalStickyRef = useRef<HTMLDivElement>(null);
   const tableOffsetRef = useRef<number>(0);
+  const stickyCompensationTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleExternalScroll = usePersistFn(() => {
     if (props.disabled) return;
@@ -63,6 +64,25 @@ const useTableVirtualExternal = (props: UseTableVirtualExternalProps) => {
     }
     if (max > 0 && scrollTop > max) {
       scrollTop = max;
+    }
+
+    // 补偿 sticky 失效：滚动停止后设置补偿值，避免滚动中抖动
+    if (externalStickyRef.current && props.externalStickyHeader) {
+      const stickyDivFullHeight = externalStickyRef.current.offsetHeight;
+      const stickyBreakPoint = sumHeight - stickyDivFullHeight;
+
+      if (stickyCompensationTimer.current) {
+        clearTimeout(stickyCompensationTimer.current);
+      }
+      externalStickyRef.current.style.setProperty('--sticky-compensation', '0px');
+
+      if (rawScrollTop > stickyBreakPoint && stickyBreakPoint > 0) {
+        const el = externalStickyRef.current;
+        stickyCompensationTimer.current = setTimeout(() => {
+          const compensation = rawScrollTop - stickyBreakPoint;
+          el.style.setProperty('--sticky-compensation', `${compensation}px`);
+        }, 150);
+      }
     }
 
     props.updateIndexAndTopFromTop(scrollTop);


### PR DESCRIPTION
## Summary

修复 `virtualScrollContainer` 模式下，开启 sticky 表头时，外部滚动容器滚动到底部表头吸附失效的问题。

## Problem

CSS `position: sticky` 有固有限制：sticky 元素不能超出其包含块的边界。当外部滚动容器滚动到底部时，Table 的 sticky div 已经到达其包含块的底边界，导致表头失去吸附效果。

## Solution

使用 JS 驱动的 transform 补偿方案：

1. 计算 sticky div 的顶部边界超出容器可视区域顶部的距离（breakpoint = sumHeight - offsetHeight）
2. 当 `rawScrollTop > stickyBreakPoint` 时，计算溢出距离作为补偿值
3. 通过 CSS custom property (`--sticky-compensation`) 传递补偿值，表头 div 使用 `translateY(var(--sticky-compensation, 0px))` 进行偏移
4. 补偿值仅在滚动停止后（150ms debounce）设置，避免滚动过程中的视觉抖动
5. 使用 `offsetHeight` 而非 `clientHeight` 计算，正确包含水平滚动条的高度

## Test Plan

1. 打开 Table 外部滚动示例（07-04-virtual-scroll-external）
2. 开启 Sticky Header
3. 滚动容器到底部，验证表头始终保持吸附
4. 滚动过程中无明显表头抖动