### PR TITLE
fix(table): 优化外部虚拟滚动模式下的横滚条和滚动条拖拽问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.15-beta.4",
+  "version": "3.9.15-beta.5",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/table/table.tsx
+++ b/packages/base/src/table/table.tsx
@@ -603,14 +603,14 @@ export default function Table<Item, Value>(props: TableProps<Item, Value>) {
               style={{ position: 'sticky', top: stickyTopOffset, height: stickyDivHeight, overflowX: 'auto', overflowY: 'hidden' }}
             >
               {!props.hideHeader && (
-                <div style={{ position: 'relative', zIndex: 1, marginTop: props.sticky ? 0 : -virtualInfo.headerOffset, transform: 'translateY(var(--sticky-compensation, 0px))', willChange: 'transform' }}>
+                <div style={{ position: 'relative', zIndex: 1, marginTop: props.sticky ? 0 : -virtualInfo.headerOffset, transform: 'translateY(var(--sticky-compensation, 0px))' }}>
                   {$headTable}
                 </div>
               )}
 
               {!!props.data?.length && (
                 <table
-                  style={{ ...tableStyle, transform: virtualInfo.translateStyle, willChange: 'transform' }}
+                  style={{ ...tableStyle, transform: virtualInfo.translateStyle }}
                   ref={tbodyRef}
                 >
                   {Group}

--- a/packages/hooks/src/components/use-table/use-table-virtual-external.tsx
+++ b/packages/hooks/src/components/use-table/use-table-virtual-external.tsx
@@ -101,6 +101,34 @@ const useTableVirtualExternal = (props: UseTableVirtualExternalProps) => {
     };
   }, [props.disabled, props.dataLength]);
 
+  // 动态控制 overflowX：当 table 仅因亚像素舍入比容器宽 1px 时隐藏滚动条，
+  // 容器真正变小（如 resize）需要横滚时恢复 auto
+  useEffect(() => {
+    const stickyEl = externalStickyRef.current;
+    if (!stickyEl) return;
+
+    const checkOverflowX = () => {
+      const overflow = stickyEl.scrollWidth - stickyEl.clientWidth;
+      const next = overflow <= 1 ? 'hidden' : 'auto';
+      if (stickyEl.style.overflowX !== next) {
+        stickyEl.style.overflowX = next;
+      }
+    };
+
+    checkOverflowX();
+
+    const ro = new ResizeObserver(checkOverflowX);
+    ro.observe(stickyEl);
+
+    const mo = new MutationObserver(checkOverflowX);
+    mo.observe(stickyEl, { childList: true, subtree: true, attributes: true, attributeFilter: ['style'] });
+
+    return () => {
+      ro.disconnect();
+      mo.disconnect();
+    };
+  }, [props.disabled]);
+
   return {
     externalStickyRef,
     headerOffset,

--- a/packages/hooks/src/components/use-table/use-table-virtual-external.tsx
+++ b/packages/hooks/src/components/use-table/use-table-virtual-external.tsx
@@ -11,6 +11,8 @@ interface UseTableVirtualExternalProps {
   tableRef?: React.RefObject<HTMLDivElement>;
   getContentHeight: (index: number) => number;
   updateIndexAndTopFromTop: (scrollTop: number) => void;
+  scrollHeight: number;
+  setScrollHeight: (height: number) => void;
 }
 
 const useTableVirtualExternal = (props: UseTableVirtualExternalProps) => {
@@ -18,6 +20,7 @@ const useTableVirtualExternal = (props: UseTableVirtualExternalProps) => {
   const externalStickyRef = useRef<HTMLDivElement>(null);
   const tableOffsetRef = useRef<number>(0);
   const stickyCompensationTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const heightSyncTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleExternalScroll = usePersistFn(() => {
     if (props.disabled) return;
@@ -48,19 +51,42 @@ const useTableVirtualExternal = (props: UseTableVirtualExternalProps) => {
     const sumHeight = props.getContentHeight(props.dataLength - 1);
     const viewportHeight = externalStickyRef.current?.clientHeight || container.clientHeight;
 
+    // 物理可滚动范围：基于当前外层 div 高度（滚动中不变）
+    const physicalMax = props.scrollHeight - viewportHeight;
+
+    // 滚动停止后才同步外层 div 高度，防止滚动中 div 变高导致滑块倒退
+    if (sumHeight !== props.scrollHeight) {
+      if (heightSyncTimer.current) clearTimeout(heightSyncTimer.current);
+      heightSyncTimer.current = setTimeout(() => {
+        props.setScrollHeight(sumHeight);
+      }, 200);
+    }
+
     let scrollTop: number;
     let max: number;
     if (props.externalStickyHeader) {
       max = sumHeight - props.tfootHeight - viewportHeight;
-      scrollTop = rawScrollTop;
+      if (physicalMax > 0 && max > 0) {
+        const rate = Math.min(rawScrollTop / physicalMax, 1);
+        scrollTop = rate * max;
+      } else {
+        scrollTop = rawScrollTop;
+      }
     } else {
       const newHeaderOffset = Math.min(rawScrollTop, props.theadHeight);
       if (newHeaderOffset !== headerOffset) {
         setHeaderOffset(newHeaderOffset);
       }
       max = sumHeight - props.theadHeight - props.tfootHeight - viewportHeight;
-      scrollTop = rawScrollTop - props.theadHeight;
-      if (scrollTop < 0) scrollTop = 0;
+      const adjustedRaw = rawScrollTop - props.theadHeight;
+      const physicalMaxBody = physicalMax - props.theadHeight;
+      if (physicalMaxBody > 0 && max > 0) {
+        const rate = Math.min(Math.max(adjustedRaw, 0) / physicalMaxBody, 1);
+        scrollTop = rate * max;
+      } else {
+        scrollTop = adjustedRaw;
+        if (scrollTop < 0) scrollTop = 0;
+      }
     }
     if (max > 0 && scrollTop > max) {
       scrollTop = max;
@@ -98,6 +124,7 @@ const useTableVirtualExternal = (props: UseTableVirtualExternalProps) => {
     handleExternalScroll();
     return () => {
       scrollTarget.removeEventListener('scroll', handleExternalScroll);
+      if (heightSyncTimer.current) clearTimeout(heightSyncTimer.current);
     };
   }, [props.disabled, props.dataLength]);
 

--- a/packages/hooks/src/components/use-table/use-table-virtual.tsx
+++ b/packages/hooks/src/components/use-table/use-table-virtual.tsx
@@ -137,7 +137,8 @@ const useTableVirtual = (props: UseTableVirtualProps) => {
 
     context.cachedHeight[index] = height;
 
-    if (context.shouldUpdateHeight) {
+    // 外部滚动模式下不由 setRowHeight 更新高度，由 handleExternalScroll debounce 同步
+    if (context.shouldUpdateHeight && !props.virtualScrollContainer) {
       setHeight(getContentHeight(props.data.length - 1));
     }
     const { preIndex } = context;
@@ -420,6 +421,8 @@ const useTableVirtual = (props: UseTableVirtualProps) => {
     tableRef: props.tableRef,
     getContentHeight,
     updateIndexAndTopFromTop,
+    scrollHeight,
+    setScrollHeight: setHeight,
   });
 
   return {


### PR DESCRIPTION
## Summary

修复 `virtualScrollContainer` 外部滚动模式下的两个问题：

1. **假横滚条**：`table-layout: fixed` 下亚像素舍入导致 table 比容器宽 1px，产生不必要的横向滚动条。通过 ResizeObserver + MutationObserver 动态控制 `overflowX`，差值 ≤ 1px 时隐藏滚动条，容器 resize 变小时恢复。

2. **滚动条拖不到底**：10000 条数据时拖拽滚动条无法到达底部。根因是 `setRowHeight` 在滚动中实时更新外层 div 高度，导致滚动条 track 不断变长、滑块相对位置倒退。修复方案：
   - 外部滚动模式下 `setRowHeight` 不再直接更新高度
   - 使用比例映射（rate = rawScrollTop / physicalMax）替代绝对像素值计算虚拟位置
   - 高度同步延迟到滚动停止 200ms 后执行

## Test Plan

1. 使用 `virtualScrollContainer` 模式，10000 条数据，拖拽右侧滚动条滑块到底部，确认可以一次到达最后一条数据
2. 调整浏览器宽度，确认不出现多余的横向滚动条
3. 设置 `width` 属性使表格宽度超出容器时，确认横向滚动条正常出现且可用
4. 常规滚轮滚动、快速滚动、从底部往上滚动均表现正常