### PR TITLE
feat(input): add placeholder to innerTitle example

### DIFF
--- a/packages/shineout/src/input/__example__/09-inner-title.tsx
+++ b/packages/shineout/src/input/__example__/09-inner-title.tsx
@@ -10,9 +10,9 @@ import { Input } from 'shineout';
 
 const App: React.FC = () => (
   <div style={{ width: 300, display: 'flex', flexDirection: 'column', gap: 24 }}>
-    <Input innerTitle='Small title' clearable size={'small'} />
-    <Input innerTitle='Medium Title' clearable />
-    <Input innerTitle='Large Title' clearable size={'large'} />
+    <Input innerTitle='Small title' clearable size={'small'} placeholder='input something' />
+    <Input innerTitle='Medium Title' clearable placeholder='input something' />
+    <Input innerTitle='Large Title' clearable size={'large'} placeholder='input something' />
   </div>
 );
 

--- a/packages/shineout/src/input/__test__/__snapshots__/input.spec.tsx.snap
+++ b/packages/shineout/src/input/__test__/__snapshots__/input.spec.tsx.snap
@@ -644,6 +644,7 @@ exports[`Input[Base] should render correctly about innerTitle 1`] = `
         >
           <input
             class="soui-input-input"
+            placeholder="input something"
             value=""
           />
         </div>
@@ -679,6 +680,7 @@ exports[`Input[Base] should render correctly about innerTitle 1`] = `
         >
           <input
             class="soui-input-input"
+            placeholder="input something"
             value=""
           />
         </div>
@@ -714,6 +716,7 @@ exports[`Input[Base] should render correctly about innerTitle 1`] = `
         >
           <input
             class="soui-input-input"
+            placeholder="input something"
             value=""
           />
         </div>


### PR DESCRIPTION
## Summary

为 Input 组件的 innerTitle 示例（09-inner-title）添加 placeholder 属性，展示 innerTitle 与 placeholder 配合使用的效果。

## Changes

- 为 small / medium / large 三种尺寸的 Input 示例分别添加 `placeholder='input something'`

## Test Plan

- 查看 Input innerTitle 示例页面，确认 placeholder 文案正常显示
- 确认 innerTitle 与 placeholder 交互行为正常（聚焦/失焦时的标题动画不受影响）