### PR TITLE
fix(collapse): fix content padding when expandIconPosition is left or right

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.15",
+  "version": "3.9.16-beta.1",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/collapse/collapse-item.tsx
+++ b/packages/base/src/collapse/collapse-item.tsx
@@ -74,6 +74,8 @@ const CollapseItem = (props: CollapseItemProps) => {
     className,
     jssStyle?.collapseItem.wrapper,
     judgeExpanded && jssStyle?.collapseItem.active,
+    expandIconPosition === 'left' && jssStyle?.collapseItem.expandLeft,
+    expandIconPosition === 'right' && jssStyle?.collapseItem.expandRight,
     (disabled || triggerRegion === 'disabled') && jssStyle?.collapseItem.disabled,
     !border && jssStyle?.collapseItem.borderLess,
   );

--- a/packages/base/src/collapse/collapse-item.tsx
+++ b/packages/base/src/collapse/collapse-item.tsx
@@ -43,6 +43,13 @@ const CollapseItem = (props: CollapseItemProps) => {
       disabled,
       onChange,
     });
+
+  const resolvedExpandIcon = showExpandIcon
+    ? expandIcon !== undefined
+      ? expandIcon
+      : parentExpandIcon
+    : null;
+
   const headerIconItem = (direction: 'left' | 'right') => {
     const collapseItemIconClassName = classNames(
       jssStyle?.collapseItem.icon,
@@ -52,14 +59,9 @@ const CollapseItem = (props: CollapseItemProps) => {
       //   ? jssStyle?.collapseItem.activeTransformRight
       //   : jssStyle?.collapseItem.activeTransform,
     );
-    const headerIcon = showExpandIcon
-      ? expandIcon !== undefined
-        ? expandIcon
-        : parentExpandIcon
-      : null;
     return (
-      headerIcon && (
-        <div dir={config.direction} {...getHeaderIconProps({ className: collapseItemIconClassName })} role="button">{headerIcon}</div>
+      resolvedExpandIcon && (
+        <div dir={config.direction} {...getHeaderIconProps({ className: collapseItemIconClassName })} role="button">{resolvedExpandIcon}</div>
       )
     );
   };
@@ -74,8 +76,8 @@ const CollapseItem = (props: CollapseItemProps) => {
     className,
     jssStyle?.collapseItem.wrapper,
     judgeExpanded && jssStyle?.collapseItem.active,
-    expandIconPosition === 'left' && jssStyle?.collapseItem.expandLeft,
-    expandIconPosition === 'right' && jssStyle?.collapseItem.expandRight,
+    resolvedExpandIcon && expandIconPosition === 'left' && jssStyle?.collapseItem.expandLeft,
+    resolvedExpandIcon && expandIconPosition === 'right' && jssStyle?.collapseItem.expandRight,
     (disabled || triggerRegion === 'disabled') && jssStyle?.collapseItem.disabled,
     !border && jssStyle?.collapseItem.borderLess,
   );

--- a/packages/base/src/collapse/collapse-item.type.ts
+++ b/packages/base/src/collapse/collapse-item.type.ts
@@ -16,6 +16,8 @@ export interface CollapseItemClasses {
   extra: string;
   content: string;
   expanded: string;
+  expandLeft: string;
+  expandRight: string;
   contentMain: string;
   noIcon: string;
   disabled: string;

--- a/packages/shineout-style/src/collapse/collapse-item.ts
+++ b/packages/shineout-style/src/collapse/collapse-item.ts
@@ -1,12 +1,14 @@
 import { JsStyles } from '../jss-style';
 import Token from '@sheinx/theme';
 import { CollapseItemClasses } from '@sheinx/base';
+import { getTokenName } from '@sheinx/theme';
 
 export type CollapseItemClassType = keyof CollapseItemClasses;
 
 const collapseItemStyle: JsStyles<CollapseItemClassType> = {
   rootClass: {},
   wrapper: {
+    [getTokenName('collapseContentPaddingLeft')]: Token.collapseWrapperPaddingX,
     boxSizing: 'border-box',
     borderBottom: `${Token.collapseWrapperBorderSize} solid ${Token.collapseHeaderBorderColor}`,
     '&:last-child': {
@@ -136,6 +138,12 @@ const collapseItemStyle: JsStyles<CollapseItemClassType> = {
     },
   },
   expanded: {},
+  expandLeft: {
+    [getTokenName('collapseContentPaddingLeft')]: `calc(${Token.collapseWrapperPaddingX} + ${Token.collapseHeaderIconWidth} + ${Token.collapseHeaderGap})`,
+  },
+  expandRight: {
+    [getTokenName('collapseContentPaddingRight')]: `calc(${Token.collapseWrapperPaddingX} + ${Token.collapseHeaderIconWidth} + ${Token.collapseHeaderGap})`,
+  },
   region: {
     cursor: 'pointer',
     '& $icon': {

--- a/packages/shineout/src/collapse/__doc__/changelog.cn.md
+++ b/packages/shineout/src/collapse/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.9.16-beta.1
+2026-06-02
+
+### 🐞 BugFix
+- 修复 `Collapse` 设置 `expandIconPosition` 为 `left` 或 `right` 时，内容区域左右内边距未随图标位置正确调整的问题 ([#1723](https://github.com/sheinsight/shineout-next/pull/1723))
+
 ## 3.6.0
 2025-02-13
 

--- a/packages/shineout/src/collapse/__test__/__snapshots__/collapse.spec.tsx.snap
+++ b/packages/shineout/src/collapse/__test__/__snapshots__/collapse.spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`Collapse[Base] should render correctly  1`] = `
     style="max-width: 1180px;"
   >
     <div
-      class="soui-collapseItem-wrapper"
+      class="soui-collapseItem-wrapper soui-collapseItem-expand-left"
     >
       <div
         class="soui-collapseItem-header soui-collapseItem-region"
@@ -52,7 +52,7 @@ exports[`Collapse[Base] should render correctly  1`] = `
       </div>
     </div>
     <div
-      class="soui-collapseItem-wrapper soui-collapseItem-active"
+      class="soui-collapseItem-wrapper soui-collapseItem-active soui-collapseItem-expand-left"
     >
       <div
         class="soui-collapseItem-header soui-collapseItem-region"
@@ -97,7 +97,7 @@ exports[`Collapse[Base] should render correctly  1`] = `
       </div>
     </div>
     <div
-      class="soui-collapseItem-wrapper soui-collapseItem-disabled"
+      class="soui-collapseItem-wrapper soui-collapseItem-expand-left soui-collapseItem-disabled"
     >
       <div
         class="soui-collapseItem-header soui-collapseItem-region"
@@ -142,7 +142,7 @@ exports[`Collapse[Base] should render correctly  1`] = `
       </div>
     </div>
     <div
-      class="soui-collapseItem-wrapper soui-collapseItem-active soui-collapseItem-disabled"
+      class="soui-collapseItem-wrapper soui-collapseItem-active soui-collapseItem-expand-left soui-collapseItem-disabled"
     >
       <div
         class="soui-collapseItem-header soui-collapseItem-region"
@@ -197,7 +197,7 @@ exports[`Collapse[Base] should render correctly about accordion 1`] = `
     style="max-width: 1180px;"
   >
     <div
-      class="soui-collapseItem-wrapper"
+      class="soui-collapseItem-wrapper soui-collapseItem-expand-left"
     >
       <div
         class="soui-collapseItem-header soui-collapseItem-region"
@@ -242,7 +242,7 @@ exports[`Collapse[Base] should render correctly about accordion 1`] = `
       </div>
     </div>
     <div
-      class="soui-collapseItem-wrapper"
+      class="soui-collapseItem-wrapper soui-collapseItem-expand-left"
     >
       <div
         class="soui-collapseItem-header soui-collapseItem-region"
@@ -287,7 +287,7 @@ exports[`Collapse[Base] should render correctly about accordion 1`] = `
       </div>
     </div>
     <div
-      class="soui-collapseItem-wrapper"
+      class="soui-collapseItem-wrapper soui-collapseItem-expand-left"
     >
       <div
         class="soui-collapseItem-header soui-collapseItem-region"
@@ -332,7 +332,7 @@ exports[`Collapse[Base] should render correctly about accordion 1`] = `
       </div>
     </div>
     <div
-      class="soui-collapseItem-wrapper"
+      class="soui-collapseItem-wrapper soui-collapseItem-expand-left"
     >
       <div
         class="soui-collapseItem-header soui-collapseItem-region"
@@ -387,7 +387,7 @@ exports[`Collapse[Base] should render correctly about customize 1`] = `
     style="max-width: 1180px;"
   >
     <div
-      class="soui-collapseItem-wrapper"
+      class="soui-collapseItem-wrapper soui-collapseItem-expand-left"
       style="background: rgb(244, 245, 248);"
     >
       <div
@@ -435,7 +435,7 @@ exports[`Collapse[Base] should render correctly about customize 1`] = `
       </div>
     </div>
     <div
-      class="soui-collapseItem-wrapper soui-collapseItem-active"
+      class="soui-collapseItem-wrapper soui-collapseItem-active soui-collapseItem-expand-left"
       style="background: rgb(244, 245, 248);"
     >
       <div
@@ -483,7 +483,7 @@ exports[`Collapse[Base] should render correctly about customize 1`] = `
       </div>
     </div>
     <div
-      class="soui-collapseItem-wrapper soui-collapseItem-disabled"
+      class="soui-collapseItem-wrapper soui-collapseItem-expand-left soui-collapseItem-disabled"
       style="background: rgb(244, 245, 248);"
     >
       <div
@@ -541,7 +541,7 @@ exports[`Collapse[Base] should render correctly about extra 1`] = `
     style="max-width: 1180px;"
   >
     <div
-      class="soui-collapseItem-wrapper"
+      class="soui-collapseItem-wrapper soui-collapseItem-expand-left"
     >
       <div
         class="soui-collapseItem-header soui-collapseItem-region"
@@ -600,7 +600,7 @@ exports[`Collapse[Base] should render correctly about extra 1`] = `
       </div>
     </div>
     <div
-      class="soui-collapseItem-wrapper soui-collapseItem-active"
+      class="soui-collapseItem-wrapper soui-collapseItem-active soui-collapseItem-expand-left"
     >
       <div
         class="soui-collapseItem-header soui-collapseItem-region"
@@ -674,7 +674,7 @@ exports[`Collapse[Base] should render correctly about extra 1`] = `
       </div>
     </div>
     <div
-      class="soui-collapseItem-wrapper"
+      class="soui-collapseItem-wrapper soui-collapseItem-expand-left"
     >
       <div
         class="soui-collapseItem-header soui-collapseItem-region"
@@ -902,7 +902,7 @@ exports[`Collapse[Base] should render correctly about icon 1`] = `
     style="max-width: 1180px;"
   >
     <div
-      class="soui-collapseItem-wrapper"
+      class="soui-collapseItem-wrapper soui-collapseItem-expand-left"
     >
       <div
         class="soui-collapseItem-header soui-collapseItem-region"
@@ -947,7 +947,7 @@ exports[`Collapse[Base] should render correctly about icon 1`] = `
       </div>
     </div>
     <div
-      class="soui-collapseItem-wrapper"
+      class="soui-collapseItem-wrapper soui-collapseItem-expand-left"
     >
       <div
         class="soui-collapseItem-header soui-collapseItem-region"
@@ -992,7 +992,7 @@ exports[`Collapse[Base] should render correctly about icon 1`] = `
       </div>
     </div>
     <div
-      class="soui-collapseItem-wrapper"
+      class="soui-collapseItem-wrapper soui-collapseItem-expand-left"
     >
       <div
         class="soui-collapseItem-header soui-collapseItem-region"
@@ -1047,7 +1047,7 @@ exports[`Collapse[Base] should render correctly about nested panels 1`] = `
     style="max-width: 1180px;"
   >
     <div
-      class="soui-collapseItem-wrapper soui-collapseItem-active"
+      class="soui-collapseItem-wrapper soui-collapseItem-active soui-collapseItem-expand-left"
     >
       <div
         class="soui-collapseItem-header soui-collapseItem-region"
@@ -1091,7 +1091,7 @@ exports[`Collapse[Base] should render correctly about nested panels 1`] = `
             class="soui-collapse soui-collapse-wrapper"
           >
             <div
-              class="soui-collapseItem-wrapper soui-collapseItem-active"
+              class="soui-collapseItem-wrapper soui-collapseItem-active soui-collapseItem-expand-left"
             >
               <div
                 class="soui-collapseItem-header soui-collapseItem-region"
@@ -1136,7 +1136,7 @@ exports[`Collapse[Base] should render correctly about nested panels 1`] = `
               </div>
             </div>
             <div
-              class="soui-collapseItem-wrapper"
+              class="soui-collapseItem-wrapper soui-collapseItem-expand-left"
             >
               <div
                 class="soui-collapseItem-header soui-collapseItem-region"
@@ -1185,7 +1185,7 @@ exports[`Collapse[Base] should render correctly about nested panels 1`] = `
       </div>
     </div>
     <div
-      class="soui-collapseItem-wrapper"
+      class="soui-collapseItem-wrapper soui-collapseItem-expand-left"
     >
       <div
         class="soui-collapseItem-header soui-collapseItem-region"
@@ -1230,7 +1230,7 @@ exports[`Collapse[Base] should render correctly about nested panels 1`] = `
       </div>
     </div>
     <div
-      class="soui-collapseItem-wrapper"
+      class="soui-collapseItem-wrapper soui-collapseItem-expand-left"
     >
       <div
         class="soui-collapseItem-header soui-collapseItem-region"
@@ -1275,7 +1275,7 @@ exports[`Collapse[Base] should render correctly about nested panels 1`] = `
       </div>
     </div>
     <div
-      class="soui-collapseItem-wrapper"
+      class="soui-collapseItem-wrapper soui-collapseItem-expand-left"
     >
       <div
         class="soui-collapseItem-header soui-collapseItem-region"
@@ -1330,7 +1330,7 @@ exports[`Collapse[Base] should render correctly about simple panel 1`] = `
     style="max-width: 1180px;"
   >
     <div
-      class="soui-collapseItem-wrapper soui-collapseItem-active soui-collapseItem-border-less"
+      class="soui-collapseItem-wrapper soui-collapseItem-active soui-collapseItem-expand-left soui-collapseItem-border-less"
     >
       <div
         class="soui-collapseItem-header soui-collapseItem-region"
@@ -1375,7 +1375,7 @@ exports[`Collapse[Base] should render correctly about simple panel 1`] = `
       </div>
     </div>
     <div
-      class="soui-collapseItem-wrapper soui-collapseItem-border-less"
+      class="soui-collapseItem-wrapper soui-collapseItem-expand-left soui-collapseItem-border-less"
     >
       <div
         class="soui-collapseItem-header soui-collapseItem-region"
@@ -1420,7 +1420,7 @@ exports[`Collapse[Base] should render correctly about simple panel 1`] = `
       </div>
     </div>
     <div
-      class="soui-collapseItem-wrapper soui-collapseItem-border-less"
+      class="soui-collapseItem-wrapper soui-collapseItem-expand-left soui-collapseItem-border-less"
     >
       <div
         class="soui-collapseItem-header soui-collapseItem-region"


### PR DESCRIPTION
## Summary

修复 `Collapse` 组件在设置 `expandIconPosition` 为 `left` 或 `right` 时，内容区域左右内边距未随图标位置正确调整的问题。

**变更内容：**
- 新增 `expandLeft` / `expandRight` 样式类，根据图标位置动态调整内容区 padding
- 内边距偏移量使用 `calc()` 基于 token 计算（基础 padding + 图标宽度 + 间距），避免魔法数字

**为什么用 CSS 自定义属性（token）方式而不是父类名 + `contentMain` 选择器？**

如果用 `.expandLeft .contentMain { padding-left: 38px }` 这种方式，选择器权重会提升。对于历史上通过单个类名覆盖过 `contentMain` padding 的用户，他们的自定义样式会被更高权重的选择器覆盖，造成 breaking change。

通过在父容器上覆盖 CSS 自定义属性（`--so-collapseContentPaddingLeft`），`contentMain` 的选择器权重完全不变，仍然是 `var(--so-collapseContentPaddingLeft)` 读取变量值。这样既能实现 padding 随图标位置变化，又不影响任何已有的自定义样式。

## Test plan

- [ ] `expandIconPosition="left"` 时，内容区左侧 padding 正确留出图标空间
- [ ] `expandIconPosition="right"` 时，内容区右侧 padding 正确留出图标空间
- [ ] 默认无 `expandIconPosition` 时，内容区 padding 表现不变