### PR TITLE
fix(theme): fix setToken with update:true failing for custom selectors

### DIFF
--- a/docs/markdown/shineout/changelog-common.md
+++ b/docs/markdown/shineout/changelog-common.md
@@ -1,3 +1,8 @@
+## 3.9.16-beta.3
+2026-06-03
+### 🐞 BugFix
+- 修复 `setToken` 使用增量更新模式（`update: true`）配合自定义选择器时，样式变量无法生效的问题 ([#1726](https://github.com/sheinsight/shineout-next/pull/1726))
+
 ## 3.9.14-beta.4
 2026-04-24
 ### 💅 Style

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.16-beta.2",
+  "version": "3.9.16-beta.3",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/theme/src/utils/token-setter.ts
+++ b/packages/theme/src/utils/token-setter.ts
@@ -120,6 +120,25 @@ const setToken = (options?: Options) => {
   const extraToken = getExtraToken(prefix);
 
   if (update && token) {
+    // 如果标签不存在，先初始化选择器结构并插入 DOM
+    if (!cacheTag) {
+      tag.setAttribute('data-token', tokenName || '');
+      tag.setAttribute('data-token-id', id);
+      tag.setAttribute('data-token-selector', selector);
+      tag.innerHTML = `${selector} {}`;
+
+      if (!target) {
+        document.head.appendChild(tag);
+      } else if (target instanceof HTMLElement) {
+        target.appendChild(tag);
+      } else if (typeof target === 'string') {
+        const el = document.getElementById(target);
+        if (el instanceof HTMLElement) {
+          el.appendChild(tag);
+        }
+      }
+    }
+
     Object.keys(token).forEach((key: string) => {
       const cssvar = isCustomToken(key) ? key : `--${prefix}-${camelCaseToDash(key)}`;
       const targetValue = token[key as keyof Tokens];

--- a/packages/theme/src/utils/token-setter.ts
+++ b/packages/theme/src/utils/token-setter.ts
@@ -84,7 +84,9 @@ const replaceCssVarValue = (innerHTML: string, cssvar: string, targetValue?: str
   const regex = new RegExp(`(${cssvar}:.*?;)`);
   // 如果没有 token ，则向后插入新的 token
   if (innerHTML.indexOf(cssvar) === -1) {
-    return innerHTML.slice(0, -1) + `;${cssvar}: ${targetValue};` + innerHTML.slice(-1);
+    const before = innerHTML.slice(0, -1);
+    const separator = before.endsWith('{') ? '' : ';';
+    return before + `${separator}${cssvar}: ${targetValue};` + innerHTML.slice(-1);
   }
   return innerHTML.replace(regex, `${cssvar}: ${targetValue};`);
 };


### PR DESCRIPTION
## Summary

修复 `setToken` 使用增量更新模式（`update: true`）配合自定义选择器（如 `.examples`）时，样式变量无法生效的问题。

**根因：** 当目标选择器没有已缓存的 style 标签时，`update` 分支只修改了新创建元素的 innerHTML 但没有将其插入 DOM。同时修复了首次插入 token 时产生多余分号的格式问题。

## Changes
- 在 `update` 模式下，若缓存标签不存在则先初始化并插入 DOM
- 修复 `replaceCssVarValue` 在空选择器块内插入时开头多余分号的问题

## Test Plan
1. 调用 `setToken({ token: { '--soui-font-14': '12px' }, selector: '.examples', update: true })`
2. 验证 DOM 中生成了正确的 style 标签且样式变量生效
3. 验证生成的 CSS 内容格式正确（无多余分号）