### PR TITLE
fix(popup): fix popup invisible when root container is position fixed

### DIFF
--- a/.claude/commands/submit.md
+++ b/.claude/commands/submit.md
@@ -1,12 +1,12 @@
 将当前分支的所有变更提交并创建 GitHub PR。
 
 步骤：
-
-1. **检查状态**：运行 `git status` 和 `git diff main..HEAD --stat` 了解当前变更情况
-2. **确认分支**：如果当前已在非 main 的功能分支上，直接使用该分支；否则根据变更内容自动创建一个语义化的新分支（格式如 `fix/xxx`、`feat/xxx`）
-3. **暂存并提交**：`git add .` 暂存所有文件，然后用规范的 commit message 提交（遵循项目已有的 commit 风格）
-4. **推送远程**：`git push -u origin <branch-name>`
-5. **创建 PR**：使用 `gh pr create --base main`，PR 标题和描述应从用户视角概括变更内容
+1. **创建功能分支**：当前分支如果不是功能分支，先根据变更内容创建一个新的功能分支（如 `fix/xxx`、`feat/xxx`）
+2. **检查状态**：运行 `git status` 和 `git diff main..HEAD --stat` 了解当前变更情况
+3. **确认分支**：如果当前已在非 main 的功能分支上，直接使用该分支；否则根据变更内容自动创建一个语义化的新分支（格式如 `fix/xxx`、`feat/xxx`）
+4. **暂存并提交**：`git add .` 暂存所有文件，然后用规范的 commit message 提交（遵循项目已有的 commit 风格）
+5. **推送远程**：`git push -u origin <branch-name>`
+6. **创建 PR**：使用 `gh pr create --base main`，PR 标题和描述应从用户视角概括变更内容，并包含必要的细节（如相关 issue、变更类型等）
 
 注意事项：
 - 每一步执行前先确认上一步成功

--- a/docs/markdown/shineout/changelog-common.md
+++ b/docs/markdown/shineout/changelog-common.md
@@ -1,3 +1,8 @@
+## 3.9.16-beta.4
+2026-06-03
+### 🐞 BugFix
+- 修复所有含弹出层的组件（`Select`、`TreeSelect`、`Cascader`、`DatePicker`、`Dropdown` 等）在页面根容器使用 `position: fixed` 布局时，弹出层不可见的问题 ([#1727](https://github.com/sheinsight/shineout-next/pull/1727))
+
 ## 3.9.16-beta.3
 2026-06-03
 ### 🐞 BugFix

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.16-beta.3",
+  "version": "3.9.16-beta.4",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/common/use-position-style/index.ts
+++ b/packages/hooks/src/common/use-position-style/index.ts
@@ -342,7 +342,15 @@ export const usePositionStyle = (config: PositionStyleConfig) => {
     const { scrollTop, scrollLeft } = getScrollPosition(scrollElRef?.current);
 
     if (needCheck && scrollElRef?.current && scrollElRef.current?.contains(parentElRef.current)) {
-      const visibleRect = scrollElRef.current?.getBoundingClientRect() || {};
+      const rawVisibleRect = scrollElRef.current?.getBoundingClientRect() || {};
+      // 当 scrollElRef 是 html/body 时，若内容全为 fixed 定位，其 getBoundingClientRect 高度会变为 0
+      // 此时应使用 window.innerHeight/innerWidth 作为可视区域判断依据
+      const isDocumentRoot =
+        scrollElRef.current === document.documentElement || scrollElRef.current === document.body;
+      const visibleRect =
+        isDocumentRoot && rawVisibleRect.height === 0
+          ? { top: 0, left: 0, bottom: window.innerHeight, right: window.innerWidth }
+          : rawVisibleRect;
       if (
         rect.bottom < visibleRect.top ||
         rect.top > (visibleRect.bottom + scrollTop) ||


### PR DESCRIPTION
## Summary

修复所有含弹出层的组件（`Select`、`TreeSelect`、`Cascader`、`DatePicker`、`Dropdown` 等）在页面根容器使用 `position: fixed` 布局时，弹出层不可见的问题。

**根本原因：**
当 `#app` 等根容器设为 `position: fixed` 时，所有内容脱离文档流，导致 `html`/`body` 元素高度变为 0。弹出层位置计算逻辑会自动检测最近的滚动容器，当无法找到真正的滚动容器时，降级使用 `document.documentElement`（html 元素）。此时 `getBoundingClientRect().bottom = 0`，导致组件认为触发元素已滚出可视区域，对弹出层应用 `visibility: hidden`。

**修复方式：**
当滚动容器为 `document.documentElement` 或 `document.body` 且其 `getBoundingClientRect().height === 0` 时，使用 `window.innerHeight` / `window.innerWidth` 作为可视区域边界，而非依赖高度为 0 的 bounding rect。

## Test Plan

1. 将页面根容器（`#app`）设置为 `position: fixed`
2. 打开含弹出层的组件（Cascader、Select、DatePicker 等）
3. 确认弹出层正常显示，不再出现 `visibility: hidden`