### PR TITLE
fix(popover): fix arrow misalignment when content is too short

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.16-beta.4",
+  "version": "3.9.16-beta.5",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/popover/popover.ts
+++ b/packages/shineout-style/src/popover/popover.ts
@@ -6,6 +6,7 @@ import { tooltipAnimation, arrowClipPath } from '../tooltip/tooltip';
 export type PopoverClassType = keyof PopoverClasses;
 
 const arrowHeight = 8;
+const arrowWidth = arrowHeight * 2;
 
 const cssvar = '--popover-arrow-gap';
 const hideArrowGap = `var(${cssvar}, 10px)`;
@@ -29,7 +30,7 @@ const popoverStyle: JsStyles<PopoverClassType> = {
       zIndex: 1,
       position: 'absolute',
       overflow: 'visible',
-      width: arrowHeight * 2,
+      width: arrowWidth,
       height: arrowHeight,
       pointerEvents: 'none',
       transformOrigin: 'center center',
@@ -265,6 +266,9 @@ const popoverStyle: JsStyles<PopoverClassType> = {
     display: 'inline-block',
     maxWidth: '320px',
     padding: `${token.popoverPaddingY} ${token.popoverPaddingX}`,
+    '$arrow + &': {
+      minWidth: `calc(${token.popoverPaddingX} * 2 + ${arrowWidth}px)`,
+    }
   },
 
   confirm: {

--- a/packages/shineout/src/popover/__doc__/changelog.cn.md
+++ b/packages/shineout/src/popover/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.9.16-beta.5
+2026-06-04
+### 💅 Style
+- 优化 `Popover` 内容区域最小宽度，防止文本内容过短时箭头与文本区域在视觉上错位的问题 ([#1728](https://github.com/sheinsight/shineout-next/pull/1728))
+
+
 ## 3.9.11-beta.9
 2026-03-13
 ### 🐞 BugFix


### PR DESCRIPTION
## Summary

修复 `Popover` 在内容文字极短时，箭头视觉上超出气泡框边界、与内容区域不成整体的样式问题。

通过为内容区域设置基于箭头宽度计算的最小宽度，确保气泡框始终能完整包裹箭头，避免错位现象。

## Test Plan

1. 使用 `Popover` 组件设置极短内容（如 1~3 个字符）
2. 验证箭头始终位于气泡框内部，视觉上与气泡成为一个整体
3. 验证正常长度内容下显示不受影响