### PR TITLE
fix(upload): expose onSuccess in custom request options for v1 compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.16-beta.4",
+  "version": "3.9.16-beta.5",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-upload/use-upload.ts
+++ b/packages/hooks/src/components/use-upload/use-upload.ts
@@ -118,6 +118,7 @@ const useUpload = <T>(props: UseUploadProps<T>) => {
       headers: props.headers,
       responseType: props.responseType,
       onStart: props.onStart,
+      onSuccess: props.onSuccess,
       onProgress: (e: ProgressEvent & { percent?: number }, msg?: string) => {
         const percent = typeof e.percent === 'number' ? e.percent : (e.loaded / e.total) * 100;
         if (throttle && percent !== 100) return;

--- a/packages/hooks/src/components/use-upload/use-upload.type.ts
+++ b/packages/hooks/src/components/use-upload/use-upload.type.ts
@@ -259,7 +259,7 @@ export interface UploadOptions<T> {
    * @en onSuccess
    * @cn 上传成功事件
    */
-  onSuccess?: (res?: string, file?: File, data?: any, xhr?: XhrResult) => T | Error;
+  onSuccess?: (res: any, file: File, data?: any, xhr?: XhrResult) => T | Error;
   /**
    * @en params
    * @cn 上传参数

--- a/packages/shineout/src/upload/__doc__/changelog.cn.md
+++ b/packages/shineout/src/upload/__doc__/changelog.cn.md
@@ -1,3 +1,11 @@
+## 3.9.16-beta.5
+2026-06-08
+
+### 🐞 BugFix
+
+- 修复 `Upload` 自定义 `request` 上传方法时，回调参数中 `onSuccess` 缺失导致无法手动通知上传成功的问题 ([#1729](https://github.com/sheinsight/shineout-next/pull/1729))
+
+
 ## 3.9.12-beta.3
 2026-03-23
 


### PR DESCRIPTION
## Summary

修复从 shineout v1 升级到 v3 时，自定义 `request` 上传方法的回调参数 `options` 上 `onSuccess` 缺失的问题。

### 问题
v1 中 `request` 回调的 `options` 同时包含 `onSuccess`（透传用户传给 `<Upload onSuccess={...} />` 的 prop）和包装好的 `onLoad`（内部状态管理）。v3 实现时只透传了 `onLoad`，**遗漏**了 `onSuccess`，导致用户从 v1 升上来后 `options.onSuccess()` 调用变成 undefined。

更隐蔽的是，`UploadOptions` 的 TS 类型中依然声明了 `onSuccess`，编译期不会报错，问题只能在浏览器调试时才能被发现。

### 修复
1. `use-upload.ts`：在构造 `options` 时补上 `onSuccess: props.onSuccess`，与 v1 行为对齐
2. `use-upload.type.ts`：校准 `UploadOptions.onSuccess` 签名，从 `(res?: string, file?: File, ...)` 改为 `(res: any, file: File, ...)`，与 `UseUploadProps.onSuccess` 一致（`xhr.response` 可能是任意类型，并非仅 string）

## Test plan

- [x] 自定义 `request`，在回调中解构 `options.onSuccess` 并调用，可正常触发上传成功流程（更新列表、清空 loading）
- [x] TS 类型校验通过
- [x] 现有 Upload 示例无回归