### PR TITLE
fix(cascader): sync children checked state after async loader in multi-select mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.16-beta.5",
+  "version": "3.9.16-beta.6",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/cascader/node.tsx
+++ b/packages/base/src/cascader/node.tsx
@@ -1,6 +1,6 @@
-import { useState, useRef, useContext } from 'react';
+import { useState, useRef, useContext, useEffect } from 'react';
 import classNames from 'classnames';
-import { KeygenResult, util, FilterContext } from '@sheinx/hooks';
+import { KeygenResult, util, FilterContext, useRender } from '@sheinx/hooks';
 import { CascaderClasses } from './cascader.type';
 import { CascaderNodeProps } from './node.type';
 import Checkbox from '../checkbox';
@@ -36,6 +36,22 @@ const CascaderNode = <DataItem, Value extends KeygenResult[]>(
   const checkboxRef = useRef<HTMLElement>();
   const hasHandleSelectRef = useRef(false);
   const isDisabled = datum.isDisabled(id);
+
+  // 仅在使用 loader 的场景下，订阅本节点 valueMap 状态变化。
+  // 解决场景：勾选父节点 → loader 异步带入新子节点 → 子节点先以未勾选状态完成 render，
+  // 之后 useTree.setData → initValue 才把子节点 valueMap 同步为父节点的勾选态；
+  // 若不订阅，Checkbox 会停在未勾选状态，直到下次整体重渲才纠正。
+  // 不带 loader 的同步数据场景不存在该时序窗口，因此用 hasLoader 守卫避免无谓订阅。
+  const hasLoader = !!loader;
+  const forceUpdate = useRender();
+  useEffect(() => {
+    if (!hasLoader) return;
+    datum.bindUpdate(id, forceUpdate);
+    return () => {
+      datum.unBindUpdate(id);
+    };
+  }, [id, hasLoader]);
+
   const children = data[childrenKey] as DataItem[];
   const hasChildren = children && children.length > 0;
   const uncertainChildren = loader && !loading && children === undefined;

--- a/packages/shineout/src/cascader/__doc__/changelog.cn.md
+++ b/packages/shineout/src/cascader/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.9.16-beta.6
+2026-06-09
+
+### 🐞 BugFix
+- 修复 `Cascader` 多选模式（`mode=3`）下，先勾选父节点再通过 `loader` 异步加载子节点时，新加载出的子节点未自动呈现勾选状态的问题 ([#1731](https://github.com/sheinsight/shineout-next/pull/1731))
+
 ## 3.9.12-beta.13
 2026-03-30
 

--- a/packages/shineout/src/cascader/__example__/test-001-loader-mode3-children-checked.tsx
+++ b/packages/shineout/src/cascader/__example__/test-001-loader-mode3-children-checked.tsx
@@ -1,0 +1,66 @@
+/**
+ * cn - mode=3 + loader 勾选父节点后加载子节点的勾选状态同步
+ *    -- 复现：先勾选 node 0，再点击 node 0 触发 loader 加载子节点；子节点应自动呈现勾选态。
+ *    -- 修复前：子节点 Checkbox 显示未勾选，需点别的节点再点回来才会刷新。
+ * en - mode=3 + loader: children checked state after async load
+ *    -- Repro: check node 0, then click node 0 to trigger loader; loaded children should appear checked.
+ *    -- Before fix: children stayed unchecked until switching path forced a re-render.
+ */
+import React, { useState } from 'react';
+import { produce } from 'immer';
+import { Cascader, TYPE } from 'shineout';
+
+type CascaderProps = TYPE.Cascader.Props<DataItem, string[]>;
+
+interface DataItem {
+  value?: string;
+  id?: string;
+  children?: DataItem[];
+}
+
+const initData = ['0', '1', '2', '3', '4', '5', '6', '7', '8'].map((i) => ({ id: i }));
+const createRange = () => Array.from({ length: Math.round(Math.random() * 4) }, (_, i) => i);
+
+export default () => {
+  const [_data, setData] = useState<DataItem[]>(initData);
+  const [value, setValue] = useState<string[]>([]);
+
+  const loader: CascaderProps['loader'] = (key) => {
+    const path = key.toString().split(',');
+    setTimeout(() => {
+      setData(prevState => {
+        const producer = produce((draft) => {
+          let { data } = draft;
+          path.forEach((pid, i) => {
+            data = draft.find((d: { id: string }) => d.id === pid);
+            if (i < path.length - 1) draft = data.children;
+          });
+          data.children = [...createRange().map((i) => ({ id: `${data.id}-${i}` }))];
+        });
+        const nextState = producer(prevState);
+        return nextState;
+      });
+    }, 500);
+  };
+
+  const handleChange: CascaderProps['onChange'] = (v) => setValue(v);
+  const renderItem: CascaderProps['renderItem'] = (node) => `node ${node.id}`;
+  const keyGenerator: CascaderProps['keygen'] = (node, parentKey) =>
+    `${String(parentKey)},${node.id}`.replace(/^,/, '');
+
+  return (
+    <div>
+      <Cascader
+        mode={3}
+        width={300}
+        placeholder='Please select city'
+        data={_data}
+        loader={loader}
+        value={value}
+        onChange={handleChange}
+        keygen={keyGenerator}
+        renderItem={renderItem}
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary

修复 `Cascader` 在「多选 + 异步 loader」组合场景下的勾选状态展示不同步问题。

**复现路径**（`mode=3`）：
1. 用户勾选某个父节点
2. 用户点击该父节点，触发 `loader` 异步加载子节点
3. 子节点加载完成后，前面的 Checkbox **应**自动呈勾选态（符合 mode=3 的「父选 → 子选」规则）
4. 修复前：子节点显示未勾选，必须切换到别的父节点再切回来才会刷新

## Root Cause

Cascader 的 Node 未把自己的 forceUpdate 注册到 `useTree` 的 `forceUpdateMap`。
`loader` 完成 → 顶层 `data` 变化 → `useTree.setData → initValue` 异步把新子节点的 valueMap 校正为勾选；
但子节点已经在更早的 render 阶段以未勾选状态完成首次渲染，且无订阅渠道接收 valueMap 变更通知，所以一直显示错误。

Tree 组件 (`packages/base/src/tree/tree-content.tsx`) 已通过 `bindUpdate` 解决相同问题，本次将同样的订阅机制引入 Cascader 节点，并用 `hasLoader` 守卫将影响范围严格限制在异步加载场景。

## Changes

- `packages/base/src/cascader/node.tsx`: 在存在 `loader` 时通过 `datum.bindUpdate` 订阅 valueMap 更新；卸载时 `unBindUpdate`
- `packages/shineout/src/cascader/__example__/test-001-loader-mode3-children-checked.tsx`: 新增本地测试示例（生产构建会被 example-loader 自动过滤）
- `packages/shineout/src/cascader/__doc__/changelog.cn.md`: 补充 changelog
- `package.json`: 版本号 `3.9.16-beta.5` → `3.9.16-beta.6`

## Test Plan

打开 Cascader 文档页面 → `test-001-loader-mode3-children-checked` 示例：

1. 勾选 `node 0` 的 Checkbox
2. 点击 `node 0` 行触发 loader 加载（500ms 后子节点出现）
3. ✅ 期望：所有子节点 Checkbox 直接显示为已勾选
4. 回归：不使用 loader 的 Cascader、单选模式、其它 mode 行为不变