### PR TITLE
fix(cascader): avoid misjudging loading node as leaf to prevent panel width jitter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.16-beta.6",
+  "version": "3.9.16-beta.7",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/cascader/node.tsx
+++ b/packages/base/src/cascader/node.tsx
@@ -109,7 +109,7 @@ const CascaderNode = <DataItem, Value extends KeygenResult[]>(
 
   const isHoverAble = expandTrigger === 'hover' || expandTrigger === 'hover-only';
 
-  const isRealLeafNode = !hasChildren && !uncertainChildren
+  const isRealLeafNode = !hasChildren && !uncertainChildren && !loading;
 
   const getEvents = () => {
     const events: any = {};

--- a/packages/shineout/src/cascader/__doc__/changelog.cn.md
+++ b/packages/shineout/src/cascader/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.9.16-beta.7
+2026-06-09
+
+### 💅 Style
+- 修复 `Cascader` 节点子项异步加载中时被误判为末级节点，导致该级面板宽度短暂抖动的问题 ([#1732](https://github.com/sheinsight/shineout-next/pull/1732))
+
 ## 3.9.16-beta.6
 2026-06-09
 


### PR DESCRIPTION
## Summary

修复 `Cascader` 节点子项异步加载期间，该节点被错误地判定为「真叶子节点」的问题。

**现象**：在多选 + loader 场景下，用户点击某个节点触发子项加载（界面显示转圈 Spinner）的几百毫秒内：
- 该节点被套用末级节点专属样式（`optionLeaf`），视觉上闪烁切换一下
- 该级面板列宽因样式差异出现短暂抖动，加载完成后又跳回

**根因**：`isRealLeafNode` 仅判断 `!hasChildren && !uncertainChildren`，遗漏了「正在加载中」状态。`uncertainChildren` 自身定义里有 `!loading`，使其在加载中变为 false；此时 `hasChildren` 也是 false（子项尚未返回），三者组合下 `isRealLeafNode` 被错误置 true。

## Changes

- `packages/base/src/cascader/node.tsx`: `isRealLeafNode` 增加 `!loading` 守卫，加载中节点不再被当作末级节点
- `packages/shineout/src/cascader/__doc__/changelog.cn.md`: 补充 changelog
- `package.json`: `3.9.16-beta.6` → `3.9.16-beta.7`

## Test Plan

打开 Cascader 文档站 → `test-001-loader-mode3-children-checked` 示例（或任意带 `loader` 的多选示例）：

1. 点击一个尚未加载子项的节点，观察 Spinner 出现到子项返回这段时间
2. ✅ 期望：该节点保持非末级节点样式，列宽稳定，无视觉抖动
3. 回归：加载完成后行为不变；不带 loader 的同步数据场景行为不变