### PR TITLE
fix(form): validate fields declared in Form.rules even when not mounted

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.16-beta.7",
+  "version": "3.9.16-beta.8",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-form/use-form.ts
+++ b/packages/hooks/src/components/use-form/use-form.ts
@@ -26,11 +26,13 @@ import {
   getAllKeyPaths,
   getParentKeys,
   getCompleteFieldKeys,
+  collectFormRulePaths,
   devUseWarning,
   getFieldId,
   getClosestScrollContainer,
   type FormError,
 } from '../../utils';
+import { validate as validateRuleFn } from '../../utils/validate';
 
 const emptyObj = {};
 
@@ -134,6 +136,34 @@ const useForm = <T extends ObjectType>(props: UseFormProps<T>) => {
             validate(key, deepGet(context.value, key), context.value, config),
           );
         });
+
+        // ============ 新增：从 props.rules 推导未挂载字段并独立校验 ============
+        // 用于虚拟列表 / 大数据场景：业务方在 <Form rules={{...}}> 里声明的字段，
+        // 即便对应的 Form.Item 当前未挂载（虚拟滚动滚出视口），submit 也应校验。
+        // 仅在"全量校验"（fields 为空，或 ignoreBind 走 submit 路径）时启用。
+        const isFullValidate = !fields || config.ignoreBind;
+        if (isFullValidate && isObject(rules)) {
+          const declared = collectFormRulePaths(rules as ObjectType);
+          for (const item of declared) {
+            // 注意：validateMap[name] 是 Set，unbind 后 Set 可能为空但 key 仍在
+            // 必须判断 Set 真有 validate 函数才算"已挂载并已校验"，否则要补独立校验
+            const mountedSet = context.validateMap[item.name];
+            if (mountedSet && mountedSet.size > 0) continue;
+            if (context.ignoreValidateFields.includes(item.name)) continue;
+            const itemValue = deepGet(context.value, item.name);
+            // 关键：validate 工具函数 *校验失败时是 reject(FormError)*，不是 resolve(error)。
+            // 必须用 .catch 把 reject 转成 resolve(err)，否则会变成 unhandled rejection
+            // 串到外层 Promise.all 把整条提交链炸断（".then() never fires" 问题）
+            const p = validateRuleFn(itemValue, context.value, item.rules, {})
+              .then(() => true as const)
+              .catch((err: Error) => {
+                const fe = wrapFormError(err);
+                context.errors[item.name] = fe;
+                return fe;
+              });
+            validates.push([p]);
+          }
+        }
 
         if (config.type === 'withValue') {
           let validatorValue = context.value;

--- a/packages/hooks/src/utils/object.ts
+++ b/packages/hooks/src/utils/object.ts
@@ -336,3 +336,50 @@ export const clearValue = (obj: ObjectType): any => {
   }
   return undefined;
 };
+
+/**
+ * 遍历 `<Form rules={...}>` 的嵌套 / 路径式声明，收集所有叶子路径（即每个字段对应的 rule 数组）。
+ *
+ * 用于让 submit 时把"在 props.rules 中声明、但 Form.Item 当前未挂载"的字段也纳入校验，
+ * 解决虚拟列表 / 大数据场景未渲染行被漏校验的问题。
+ *
+ * 叶子判定：value 是数组（即 FormItemRule 数组）。
+ * 路径生成规则：
+ *   - 字符串 key 直接拼接：`{ user: { name: [...] } }` → `user.name`
+ *   - 数字 key 转成 bracket：`{ rows: { 0: { name: [...] } } }` → `rows[0].name`
+ *   - 顶层用字符串路径声明：`{ 'rows[0].name': [...] }` → 原样保留为 `rows[0].name`
+ *
+ * @example
+ *   collectFormRulePaths({ rows: { 0: { name: [requiredRule] }, 1: { name: [requiredRule] } } })
+ *   // → [
+ *   //   { name: 'rows[0].name', rules: [requiredRule] },
+ *   //   { name: 'rows[1].name', rules: [requiredRule] },
+ *   // ]
+ */
+export const collectFormRulePaths = (
+  rulesObj: ObjectType,
+  parentKey = '',
+): Array<{ name: string; rules: any }> => {
+  if (!isObject(rulesObj)) return [];
+  const out: Array<{ name: string; rules: any }> = [];
+  for (const key of Object.keys(rulesObj)) {
+    const val = rulesObj[key];
+    let currentKey: string;
+    if (!parentKey) {
+      currentKey = key;
+    } else if (/^\d+$/.test(key)) {
+      // 数字 key 视为数组索引
+      currentKey = `${parentKey}[${key}]`;
+    } else {
+      currentKey = `${parentKey}.${key}`;
+    }
+    if (Array.isArray(val)) {
+      // 叶子：FormItemRule 数组
+      out.push({ name: currentKey, rules: val });
+    } else if (isObject(val)) {
+      // 继续往下钻
+      out.push(...collectFormRulePaths(val, currentKey));
+    }
+  }
+  return out;
+};

--- a/packages/shineout/src/form/__doc__/changelog.cn.md
+++ b/packages/shineout/src/form/__doc__/changelog.cn.md
@@ -1,3 +1,8 @@
+## 3.9.16-beta.8
+2026-06-10
+### 🐞 BugFix
+- 修复 `Form` 在虚拟列表或大表格场景下，未挂载的表单项即使在 `Form.rules` 中声明了校验规则，提交时也会跳过校验的问题 ([#1733](https://github.com/sheinsight/shineout-next/pull/1733))
+
 ## 3.9.14-beta.2
 2026-04-21
 ### 🐞 BugFix

--- a/packages/shineout/src/table/__example__/test-011-virtual-form-validate.tsx
+++ b/packages/shineout/src/table/__example__/test-011-virtual-form-validate.tsx
@@ -1,0 +1,143 @@
+/**
+ * cn - 虚拟 Table + Form 级 rules 校验未挂载行
+ *    -- 写法：<Form rules={{ rows: { 0:{name:[...]}, 1:{...}, ..., 499:{...} } }}>
+ *      用嵌套对象 + 数字 key 描述数组每一项的校验规则
+ *    -- submit 时 Form 内部会遍历 props.rules 所有叶子路径（含未挂载字段），
+ *      对未挂载的虚拟行独立调用底层 validate 工具进行校验
+ *    -- 500 行虚拟滚动；row #3 和 #200 故意留空 → Submit 必定捕获两条 required 错误
+ *
+ * en - Virtual Table + Form-level rules validates off-screen rows
+ *    -- Nested object with numeric keys describes per-row rules
+ *    -- On submit, Form walks ALL leaf paths in props.rules and validates off-screen fields
+ *      via the standalone validate() util
+ *    -- 500 rows; rows #3 and #200 are empty — Submit must report both required errors
+ */
+import { useRef, useState } from 'react';
+import { Button, Form, Input, Table, TYPE, Rule, Message, Modal } from 'shineout';
+import { ItemWithRequired } from './24-01-table-with-form';
+
+type TableRef = TYPE.Table.TableRef;
+
+interface TableRowData {
+  id: number;
+  name: string;
+  age: string;
+}
+
+interface FormTableValues {
+  rows: TableRowData[];
+}
+
+type TableColumnItem = TYPE.Table.ColumnItem<TableRowData>;
+
+const rules = Rule();
+
+const ROW_COUNT = 500;
+const EMPTY_INDICES = new Set([3, 200]);
+
+const defaultData: TableRowData[] = Array.from({ length: ROW_COUNT }, (_, i) => ({
+  id: i + 1,
+  name: EMPTY_INDICES.has(i) ? '' : `Tom${i + 1}`,
+  age: EMPTY_INDICES.has(i) ? '' : `${(i + 1) * 1}`,
+}));
+
+// Form 级 rules：嵌套对象 + 数字 key 描述每一行的校验
+// submit 时会展开为 rows[0].name / rows[1].name / ... / rows[499].name，未挂载行也会校验
+const formRules = (() => {
+  const rowRules: Record<string, any> = {};
+  for (let i = 0; i < ROW_COUNT; i++) {
+    rowRules[i] = {
+      name: [rules.required],
+      age: [rules.required],
+    };
+  }
+  return { rows: rowRules };
+})();
+
+export default () => {
+  const [formDatas, setFormDatas] = useState<FormTableValues>({ rows: defaultData });
+  const tableRef = useRef<TableRef>();
+
+  // 走 Table 官方 ref API，避免 DOM 选择器跟文档站其他容器冲突
+  const scrollToRow = (index: number) => {
+    tableRef.current?.scrollToIndex(index);
+  };
+  const scrollToTop = () => {
+    tableRef.current?.scrollToIndex(0);
+  };
+
+  const columns: TableColumnItem[] = [
+    {
+      title: 'ID',
+      width: 80,
+      render: (d) => <div style={{ lineHeight: '32px' }}>{d.id}</div>,
+    },
+    {
+      title: <ItemWithRequired>Name</ItemWithRequired>,
+      width: 240,
+      // 视口内 cell 不写 rules，依赖 Form 级 rules
+      render: (_d, index) => (
+        <Form.Item style={{ marginBottom: 0 }}>
+          <Input name={`rows[${index}].name`} placeholder='必填' />
+        </Form.Item>
+      ),
+    },
+    {
+      title: <ItemWithRequired>Age</ItemWithRequired>,
+      width: 200,
+      render: (_d, index) => (
+        <Form.Item style={{ marginBottom: 0 }}>
+          <Input name={`rows[${index}].age`} placeholder='必填' />
+        </Form.Item>
+      ),
+    },
+    {
+      title: 'Note',
+      render: (d, index) =>
+        EMPTY_INDICES.has(index) ? (
+          <span style={{ color: '#EB4242' }}>
+            ⚠️ Intentionally empty (id={d.id}) — must fail on submit even when off-screen
+          </span>
+        ) : (
+          ''
+        ),
+    },
+  ];
+
+  return (
+    <Form
+      value={formDatas}
+      onChange={setFormDatas}
+      reserveAble
+      rules={formRules}
+      onSubmit={() => {
+        Modal.success({
+          title: 'All rows passed',
+          content: 'Submit succeeded — all 500 rows (including off-screen) passed required.',
+        });
+      }}
+      onError={(error) => {
+        Message.error(`Validation failed: ${error?.message || 'check fields'}`);
+      }}
+    >
+      <div style={{ marginBottom: 12, display: 'flex', gap: 12, alignItems: 'center' }}>
+        <Form.Submit>Submit (校验所有 500 行 - 含未渲染)</Form.Submit>
+        <Button onClick={() => scrollToRow(200)}>Scroll to row #200</Button>
+        <Button onClick={scrollToTop}>Back to top</Button>
+      </div>
+
+      <Table
+        virtual
+        keygen='id'
+        columns={columns}
+        data={formDatas.rows}
+        style={{ height: 480 }}
+        rowsInView={20}
+        bordered
+        tableRef={(ref) => {
+          tableRef.current = ref;
+        }}
+      />
+    </Form>
+  );
+};


### PR DESCRIPTION
## Summary

修复 `Form` 在虚拟列表或大表格场景下，未挂载的表单项（如滚动出可视区域的行）即使在 `Form.rules` 中声明了校验规则，提交时也会跳过校验的问题。用户可以在不触发任何错误提示的情况下提交无效数据。

### 变更内容

- 新增 `collectFormRulePaths` 工具函数，将嵌套的 `Form.rules` 声明展平为叶子路径列表
- `validateFields` 在全量校验（submit）路径下，遍历 `Form.rules` 中声明的所有字段，对未挂载的字段执行独立校验
- 修复 `validateMap` 中 Set 为空但 key 未删除导致的判断遗漏
- 修复 `validate()` 工具函数 reject 未正确捕获导致 Promise.all 提前中断的问题

### 影响范围

- 未传 `rules` 属性的 Form 完全不受影响
- onChange / onBlur / 单字段校验 / clearValidate 等路径不受影响
- 已挂载字段保持原有校验逻辑，不会重复校验

## Test Plan

- 新增测试用例 `test-011-virtual-form-validate.tsx`：500 行虚拟 Table，第 3 行和第 200 行故意留空，提交时须同时捕获两个 required 错误（第 200 行远在可视区域外）