### PR TITLE
feat(theme): export Tokens object for local light theme override

### DIFF
--- a/docs/markdown/shineout/changelog-common.md
+++ b/docs/markdown/shineout/changelog-common.md
@@ -1,3 +1,8 @@
+## 3.9.17-beta.1
+2026-06-16
+### 🆕 Feature
+- 新增 `Tokens` 导出，支持将完整的默认浅色主题 token 传入 `setToken`，一行代码即可将局部区域恢复为浅色主题，无需手动逐条填写 token ([#1735](https://github.com/sheinsight/shineout-next/pull/1735))
+
 ## 3.9.16-beta.4
 2026-06-03
 ### 🐞 BugFix

--- a/docs/theme/layout/desktop/float/index.tsx
+++ b/docs/theme/layout/desktop/float/index.tsx
@@ -36,88 +36,44 @@ const FloatButton = () => {
     }
   };
 
+  const buildToken = (isDark: boolean, isCompact: boolean) => ({
+    ...CommonTokenMap,
+    ...(isDark ? dark : {}),
+    ...(isCompact ? compact : {}),
+  });
+
+  const applyTheme = (isDark: boolean, isCompact: boolean) => {
+    setToken({ selector: 'html', token: buildToken(isDark, isCompact) });
+    if (isDark) {
+      document.documentElement.style.setProperty('color-scheme', 'dark');
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.style.removeProperty('color-scheme');
+      document.documentElement.classList.remove('dark');
+    }
+  };
+
   const setDark = () => {
-    const compactThemeCache = localStorage.getItem('shineout-theme-compact');
-    const darkThemeCache = localStorage.getItem('shineout-theme-dark');
-
-    if (!darkThemeCache) {
-      if (compactThemeCache) {
-        setToken({
-          selector: 'html',
-          token: { ...CommonTokenMap, ...dark, ...compact },
-        });
-        localStorage.setItem('shineout-theme-dark', 'true');
-        setDarkActive('true');
-        document.documentElement.style.setProperty('color-scheme', 'dark');
-        return;
-      }
-
-      setToken({
-        selector: 'html',
-        update: true,
-        token: dark,
-      });
+    const isDark = !localStorage.getItem('shineout-theme-dark');
+    const isCompact = !!localStorage.getItem('shineout-theme-compact');
+    applyTheme(isDark, isCompact);
+    if (isDark) {
       localStorage.setItem('shineout-theme-dark', 'true');
       setDarkActive('true');
-      document.documentElement.style.setProperty('color-scheme', 'dark');
     } else {
-      if (compactThemeCache) {
-        setToken({
-          selector: 'html',
-          token: { ...CommonTokenMap, ...compact },
-        });
-        localStorage.removeItem('shineout-theme-dark');
-        setDarkActive('');
-        document.documentElement.style.removeProperty('color-scheme');
-        return;
-      }
-      setToken({
-        selector: 'html',
-        token: CommonTokenMap as any,
-      });
       localStorage.removeItem('shineout-theme-dark');
       setDarkActive('');
-      // 设置 html 的 style color-scheme 属性
-      document.documentElement.style.removeProperty('color-scheme');
     }
   };
 
   const setCompact = () => {
-    const compactThemeCache = localStorage.getItem('shineout-theme-compact');
-    const darkThemeCache = localStorage.getItem('shineout-theme-dark');
-
-    if (!compactThemeCache) {
-      if (darkThemeCache) {
-        setToken({
-          selector: 'html',
-          token: { ...CommonTokenMap, ...dark, ...compact },
-        });
-        localStorage.setItem('shineout-theme-compact', 'true');
-        setCompactActive('true');
-        return;
-      }
-
-      setToken({
-        selector: 'html',
-        update: true,
-        token: compact,
-      });
+    const isDark = !!localStorage.getItem('shineout-theme-dark');
+    const isCompact = !localStorage.getItem('shineout-theme-compact');
+    applyTheme(isDark, isCompact);
+    if (isCompact) {
       localStorage.setItem('shineout-theme-compact', 'true');
       setCompactActive('true');
     } else {
-      if (darkThemeCache) {
-        setToken({
-          selector: 'html',
-          token: { ...CommonTokenMap, ...dark },
-        });
-        localStorage.removeItem('shineout-theme-compact');
-        setCompactActive('');
-        return;
-      }
-      setToken({
-        selector: 'html',
-        token: CommonTokenMap as any,
-      });
       localStorage.removeItem('shineout-theme-compact');
       setCompactActive('');
     }
@@ -213,23 +169,9 @@ const FloatButton = () => {
   }, [open]);
 
   useEffect(() => {
-    const compactThemeCache = localStorage.getItem('shineout-theme-compact');
-    const darkThemeCache = localStorage.getItem('shineout-theme-dark');
-    let token = { ...CommonTokenMap };
-
-    if (compactThemeCache === 'true') {
-      token = { ...token, ...compact };
-    }
-
-    if (darkThemeCache === 'true') {
-      token = { ...token, ...dark };
-      // 设置 html 的 color-scheme 属性
-      document.documentElement.style.setProperty('color-scheme', 'dark');
-    }
-    setToken({
-      selector: 'html',
-      token,
-    });
+    const isDark = localStorage.getItem('shineout-theme-dark') === 'true';
+    const isCompact = localStorage.getItem('shineout-theme-compact') === 'true';
+    applyTheme(isDark, isCompact);
   }, []);
 
   return (

--- a/docs/theme/layout/desktop/float/theme.ts
+++ b/docs/theme/layout/desktop/float/theme.ts
@@ -20,6 +20,7 @@ const dark = {
   'Neutral-fill-3': '#2D364C',
   'Neutral-fill-2': '#21283D',
   'Neutral-fill-1': '#11192E',
+  backgroundPopup: '#11192E',
   buttonPrimaryDisabledFontColor: 'var(--soui-neutral-text-2)',
   buttonSecondaryFontColor: 'var(--soui-neutral-text-1)',
   buttonWarningDisabledFontColor: 'var(--soui-neutral-text-2)',

--- a/docs/theme/layout/desktop/style.ts
+++ b/docs/theme/layout/desktop/style.ts
@@ -359,6 +359,10 @@ export default createUseStyles(
       '&:hover': {
         boxShadow: 'var(--soui-shadow-3)',
       },
+      'html.dark &' :{
+        fill: 'white',
+        boxShadow: '0 0 4px 0 rgba(255, 255, 255, 0.5)',
+      }
     },
     floatButtonMenu: {
       opacity: 0,
@@ -380,6 +384,10 @@ export default createUseStyles(
       boxShadow: 'var(--soui-shadow-2)',
       backgroundColor: 'var(--soui-neutral-fill-1)',
       cursor: 'pointer',
+      'html.dark &' :{
+        fill: 'white',
+        boxShadow: '0 0 4px 0 rgba(255, 255, 255, 0.5)',
+      }
     },
     floatButtonMenuItemActive: {
       backgroundColor: 'var(--soui-brand-6)',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.16",
+  "version": "3.9.17-beta.1",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout/src/index.ts
+++ b/packages/shineout/src/index.ts
@@ -56,6 +56,7 @@ export { default as Upload } from './upload';
 export { setConfig, config, setLocale, setIcons, icons } from '@sheinx/base';
 export type { ConfigOption } from '@sheinx/base';
 export { setToken, useToken } from '@sheinx/theme';
+export { default as Tokens } from '@sheinx/theme';
 export {
   JssProvider,
   SheetsRegistry,

--- a/packages/theme/src/utils/token-setter.ts
+++ b/packages/theme/src/utils/token-setter.ts
@@ -46,7 +46,7 @@ export interface Options {
    * @en Custom token parameters
    * @default undefined
    */
-  token?: Partial<Tokens> & { [customTokenKey: string]: string };
+  token?: Partial<Tokens> | (Partial<Tokens> & { [customTokenKey: string]: string });
   /**
    * @cn 是否只生效关键 token，默认为 false
    * @en Whether only the key token is effective, default is false


### PR DESCRIPTION
## Summary

在整体暗黑主题的应用中，局部区域需要保持浅色主题时，用户可以通过 `setToken` 将默认样式变量挂载到指定元素上。但之前完整的默认 `Tokens` 对象未从 `shineout` 直接导出，用户需要额外安装内部包 `@sheinx/theme`，或手动逐条填写 token 值，非常不便。

本次变更：
- 从 `shineout` 直接导出 `Tokens` 对象（包含所有全局 token + 组件 token 的默认值），用户无需安装额外依赖
- 放宽 `setToken` 的 `token` 参数类型，允许直接传入完整 `Tokens` 对象而无需 `as any`

用法示例：
```tsx
import { setToken, Tokens } from 'shineout';

setToken({
  selector: '#my-container',
  token: Tokens, // 一行还原为默认浅色主题
});
```

## Test Plan

- [ ] 在暗黑主题应用中，对某个容器使用 `setToken({ selector: '#id', token: Tokens })`，确认容器内所有组件恢复为浅色主题
- [ ] 确认 TypeScript 类型检查通过，无需 `as any`
- [ ] 确认未传 `token` 参数时 `setToken` 行为不变（仍使用内置默认值）