### PR TITLE
fix(deps): downgrade immer from v10 to v9 to fix compatibility with browsers below Chrome 80

### DIFF
--- a/.claude/commands/changelog.md
+++ b/.claude/commands/changelog.md
@@ -34,3 +34,4 @@ pr-number的获取方式： 通过 `gh api "repos/sheinsight/shineout-next/pulls
 - 不要提及内部实现细节（如变量名、函数名、文件路径）
 - 如果涉及多个组件，分别写入各自的 changelog 文件
 - 描述语言简洁，参考已有 changelog 条目的风格
+- 全局性的changelog写在docs/markdown/shineout/changelog-common.md文件里

--- a/docs/markdown/shineout/changelog-common.md
+++ b/docs/markdown/shineout/changelog-common.md
@@ -1,3 +1,8 @@
+## 3.9.17-beta.2
+2026-06-17
+### 🐞 BugFix
+- 降级内部依赖 `immer` 至 `v9`，修复在兼容 Chrome 80 以下浏览器的项目中可能导致白屏的问题 ([#1736](https://github.com/sheinsight/shineout-next/pull/1736))
+
 ## 3.9.17-beta.1
 2026-06-16
 ### 🆕 Feature

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.17-beta.1",
+  "version": "3.9.17-beta.2",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -85,7 +85,7 @@
     "classnames": "2.3.2",
     "core-js": "3.33.3",
     "fflate": "^0.8.2",
-    "immer": "10.0.2",
+    "immer": "^9.0.0",
     "react": "18.3.1",
     "react-dom": "18.3.1"
   },

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -21,7 +21,7 @@
     "dayjs": "^1.11.9",
     "react-fast-compare": "^3.2.2",
     "@shined/reactive": "^0.3.3",
-    "immer": "10.0.2"
+    "immer": "^9.0.0"
   },
   "peerDependencies": {
     "react": ">=16.14.0",

--- a/packages/shineout/package.json
+++ b/packages/shineout/package.json
@@ -29,7 +29,7 @@
     "@sheinx/theme": "workspace:*",
     "classnames": "^2.0.0",
     "deep-eql": "^4.0.0",
-    "immer": "^10.0.0"
+    "immer": "^9.0.0"
   },
   "devDependencies": {
     "@sheinx/mock": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         specifier: ^0.8.2
         version: 0.8.2
       immer:
-        specifier: 10.0.2
-        version: 10.0.2
+        specifier: ^9.0.0
+        version: 9.0.21
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -277,8 +277,8 @@ importers:
         specifier: ^1.11.9
         version: 1.11.9
       immer:
-        specifier: 10.0.2
-        version: 10.0.2
+        specifier: ^9.0.0
+        version: 9.0.21
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -344,8 +344,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       immer:
-        specifier: ^10.0.0
-        version: 10.0.2
+        specifier: ^9.0.0
+        version: 9.0.21
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -5024,6 +5024,9 @@ packages:
 
   immer@10.0.2:
     resolution: {integrity: sha512-Rx3CqeqQ19sxUtYV9CU911Vhy8/721wRFnJv3REVGWUmoAcIwzifTsdmJte/MV+0/XpM35LZdQMBGkRIoLPwQA==}
+
+  immer@9.0.21:
+    resolution: {integrity: sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==}
 
   import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
@@ -10934,7 +10937,7 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.0
 
-  '@stylelint/postcss-css-in-js@0.38.0(postcss-syntax@0.36.2(postcss@8.5.3))(postcss@8.5.3)':
+  '@stylelint/postcss-css-in-js@0.38.0(postcss-syntax@0.36.2(postcss@8.4.24))(postcss@8.5.3)':
     dependencies:
       '@babel/core': 7.23.2
       postcss: 8.5.3
@@ -11513,7 +11516,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.23.2
       '@babel/eslint-parser': 7.22.15(@babel/core@7.23.2)(eslint@8.52.0)
-      '@stylelint/postcss-css-in-js': 0.38.0(postcss-syntax@0.36.2(postcss@8.5.3))(postcss@8.5.3)
+      '@stylelint/postcss-css-in-js': 0.38.0(postcss-syntax@0.36.2(postcss@8.4.24))(postcss@8.5.3)
       '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.52.0)(typescript@5.7.2))(eslint@8.52.0)(typescript@5.7.2)
       '@typescript-eslint/parser': 5.62.0(eslint@8.52.0)(typescript@5.7.2)
       '@umijs/babel-preset-umi': 4.0.87(styled-components@6.0.0(babel-plugin-styled-components@2.1.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -14404,6 +14407,8 @@ snapshots:
   immediate@3.0.6: {}
 
   immer@10.0.2: {}
+
+  immer@9.0.21: {}
 
   import-fresh@3.3.0:
     dependencies:


### PR DESCRIPTION
## Summary

将内部依赖 `immer` 从 `v10` 降级至 `v9`，修复在兼容 Chrome 80 以下浏览器的项目中可能导致白屏的问题。

### 问题背景

`immer@10.x` 的发布产物中使用了 Optional Chaining（`?.`）等现代语法，该语法需要 Chrome 80+ 才能原生支持。由于 shineout 采用 bundless 方式发布，`immer` 不会在组件库构建时被预处理，而是在用户项目打包时才被解析。

当用户项目的目标浏览器低于 Chrome 80 时：
- 若开启了构建兼容性检查（如 `browserCompat: true`），会在构建阶段中断报错
- 若未开启检查，`?.` 语法会直接进入生产产物，在低版本浏览器中触发 JS 语法错误，**导致页面白屏**

### 变更内容

- `immer`: `^10.0.0` → `^9.0.0`（实际安装 `9.0.21`，v9 最终版本）
- 涉及：根目录 `package.json`、`packages/hooks/package.json`、`packages/shineout/package.json`

### 兼容性验证

- v9 与 v10 在本项目使用到的所有 API（`produce`、`current`、`setAutoFreeze`、`Draft<T>`）行为完全一致
- `immer@9.0.21` 产物中无任何 `?.` 语法
- v9 → v10 的所有 breaking change 均未命中本项目的实际用法

## Test plan

- [ ] 验证表单（Form）数据读写、校验等功能正常
- [ ] 在构建工具配置 Chrome 70 目标 + `browserCompat: true` 的项目中引入 shineout，确认构建不再报错