### PR TITLE
docs(tooltip,popover): refactor pointAtCenter example to position grid layout

### DIFF
--- a/docs/theme/components/example/codesandbox/index.tsx
+++ b/docs/theme/components/example/codesandbox/index.tsx
@@ -40,7 +40,7 @@ const Codesandbox = (props: CodesandboxProps) => {
     "react-dom/client": "react-dom@18.3.1",
     "react-router-dom": "6.11.2",
     "react-jss": "10.9.2",
-    "shineout": "3.9.13-beta.18",
+    "shineout": "3.9.17-beta.3",
     "classnames": "2.3.2",
     "immer": "10.0.2"
   }

--- a/packages/shineout/src/popover/__example__/16-point-at-center.tsx
+++ b/packages/shineout/src/popover/__example__/16-point-at-center.tsx
@@ -5,49 +5,45 @@
  *    -- Use `pointAtCenter` to make the arrow point to the center of the trigger element
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 import { Button, Popover, TYPE } from 'shineout';
 
 type PopoverProps = TYPE.Popover.Props;
 type PopoverPosition = PopoverProps['position'];
 
-const positions: Array<PopoverPosition> = [
-  'bottom-left',
-  'bottom-right',
-  'top-left',
-  'top-right',
-  'left-top',
-  'left-bottom',
-  'right-top',
-  'right-bottom',
+const positions: Array<PopoverPosition[]> = [
+  [undefined, 'bottom-left', 'bottom', 'bottom-right', undefined],
+  ['right-top', undefined, undefined, undefined, 'left-top'],
+  ['right', undefined, undefined, undefined, 'left'],
+  ['right-bottom', undefined, undefined, undefined, 'left-bottom'],
+  [undefined, 'top-left', 'top', 'top-right', undefined],
 ];
 
-const App: React.FC = () => {
-  const [pointAtCenter, setPointAtCenter] = useState(true);
-
-  return (
-    <div>
-      <div style={{ marginBottom: 16 }}>
-        <Button
-          onClick={() => setPointAtCenter((v) => !v)}
-          type='primary'
-          mode='outline'
-        >
-          pointAtCenter: {String(pointAtCenter)}
-        </Button>
-      </div>
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12 }}>
-        {positions.map((p) => (
-          <Button key={p} mode='outline' style={{ width: 140 }}>
-            <Popover trigger='hover' position={p} pointAtCenter={pointAtCenter} useTextStyle>
-              {p}
-            </Popover>
-            {p}
-          </Button>
-        ))}
-      </div>
-    </div>
-  );
+const style: React.CSSProperties = {
+  margin: 4,
+  width: 110,
+  display: 'inline-block',
 };
+
+const App: React.FC = () => (
+  <div>
+    {positions.map((row, i) => (
+      <div key={i}>
+        {row.map((p, j) =>
+          p ? (
+            <Button key={j} mode='outline' style={style}>
+              <Popover trigger='hover' position={p} pointAtCenter useTextStyle>
+                {p}
+              </Popover>
+              {p}
+            </Button>
+          ) : (
+            <div key={j} style={{ ...style, border: 0 }} />
+          ),
+        )}
+      </div>
+    ))}
+  </div>
+);
 
 export default App;

--- a/packages/shineout/src/tooltip/__example__/example-10-point-at-center.tsx
+++ b/packages/shineout/src/tooltip/__example__/example-10-point-at-center.tsx
@@ -6,53 +6,49 @@
  *
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 import { Button, Tooltip, TYPE } from 'shineout';
 
 type PopoverProps = TYPE.Popover.Props;
 type PopoverPosition = PopoverProps['position'];
 
-const positions: Array<PopoverPosition> = [
-  'bottom-left',
-  'bottom-right',
-  'top-left',
-  'top-right',
-  'left-top',
-  'left-bottom',
-  'right-top',
-  'right-bottom',
+const positions: Array<PopoverPosition[]> = [
+  [undefined, 'bottom-left', 'bottom', 'bottom-right', undefined],
+  ['right-top', undefined, undefined, undefined, 'left-top'],
+  ['right', undefined, undefined, undefined, 'left'],
+  ['right-bottom', undefined, undefined, undefined, 'left-bottom'],
+  [undefined, 'top-left', 'top', 'top-right', undefined],
 ];
 
-const App: React.FC = () => {
-  const [pointAtCenter, setPointAtCenter] = useState(true);
-
-  return (
-    <div>
-      <div style={{ marginBottom: 16 }}>
-        <Button
-          onClick={() => setPointAtCenter((v) => !v)}
-          type='primary'
-          mode='outline'
-        >
-          pointAtCenter: {String(pointAtCenter)}
-        </Button>
-      </div>
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12 }}>
-        {positions.map((p) => (
-          <Tooltip
-            key={p}
-            position={p}
-            pointAtCenter={pointAtCenter}
-            tip={<div>{p}</div>}
-          >
-            <Button mode='outline' style={{ width: 140 }}>
-              {p}
-            </Button>
-          </Tooltip>
-        ))}
-      </div>
-    </div>
-  );
+const style: React.CSSProperties = {
+  margin: 4,
+  width: 110,
+  display: 'inline-block',
 };
+
+const App: React.FC = () => (
+  <div>
+    {positions.map((row, i) => (
+      <div key={i}>
+        {row.map((p, j) =>
+          p ? (
+            <Tooltip
+              key={j}
+              position={p}
+              pointAtCenter
+              tip={<div>{p}</div>}
+            >
+              <Button mode='outline' style={style}>
+                {p}
+              </Button>
+            </Tooltip>
+          ) : (
+            <div key={j} style={{ ...style, border: 0 }} />
+          ),
+        )}
+      </div>
+    ))}
+  </div>
+);
 
 export default App;


### PR DESCRIPTION
## Summary

将 Tooltip 和 Popover 的 `pointAtCenter` 示例布局，由 flex-wrap 平铺方式重构为与 `example-02-position` 一致的方位矩阵布局。

**变更文件：**
- `packages/shineout/src/tooltip/__example__/example-10-point-at-center.tsx`
- `packages/shineout/src/popover/__example__/16-point-at-center.tsx`

**具体改动：**
- 按实际弹出方位将 12 个位置排列成矩阵网格，空位用无边框 `div` 占位，视觉上与 position 示例风格统一
- 移除切换按钮交互，`pointAtCenter` 默认开启（改为 JSX 布尔属性 shorthand）

## Test Plan

- [x] 本地预览 Tooltip `pointAtCenter` 示例，确认矩阵布局正确渲染
- [x] 本地预览 Popover `pointAtCenter` 示例，确认矩阵布局正确渲染