### PR TITLE
fix(upload): name prop not applied as FormData key when upgrading from v1/v2 to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.17-beta.3",
+  "version": "3.9.17-beta.4",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout/src/upload/__doc__/changelog.cn.md
+++ b/packages/shineout/src/upload/__doc__/changelog.cn.md
@@ -1,3 +1,11 @@
+## 3.9.17-beta.4
+2026-06-30
+
+### 🐞 BugFix
+
+- 修复 `Upload` / `Upload.Image` 的 `name` 属性在 v1/v2 升级 v3 后不再作为上传文件字段名的问题 ([#1741](https://github.com/sheinsight/shineout-next/pull/1741))
+
+
 ## 3.9.16-beta.5
 2026-06-08
 

--- a/packages/shineout/src/upload/image.tsx
+++ b/packages/shineout/src/upload/image.tsx
@@ -28,5 +28,9 @@ BaseUploadImage.displayName = 'ShineoutUploadImage';
 export default <T,>(props: UploadImageProps<T>) => {
   const customProps = useUploadCommon({ rules: props.rules });
 
-  return useFieldCommon({ ...props, ...customProps }, BaseUploadImage<T>);
+  // 同 upload.tsx：useFieldCommon 会把 name 从子组件 props 中移除，
+  // 提前将其作为 htmlName 的 fallback 保存，以兼容 v2 中 name 作为 FormData 键名的行为。
+  const htmlName = props.htmlName ?? (typeof props.name === 'string' ? props.name : undefined);
+
+  return useFieldCommon({ ...props, htmlName, ...customProps }, BaseUploadImage<T>);
 };

--- a/packages/shineout/src/upload/upload.tsx
+++ b/packages/shineout/src/upload/upload.tsx
@@ -29,5 +29,10 @@ BaseUpload.displayName = 'ShineoutUpload';
 export default <T,>(props: UploadProps<T>) => {
   const customProps = useUploadCommon({ rules: props.rules });
 
-  return useFieldCommon({ ...props, ...customProps }, BaseUpload<T>, 'array');
+  // useFieldCommon 会把 name 从转发给子组件的 props 中移除（name 被用作 Form 字段 key）。
+  // 但 Upload 的 name 在 v2 中同时作为 FormData 的键名，为了兼容 v2 行为，
+  // 在 name 被移除之前将其作为 htmlName 的 fallback 保存下来。
+  const htmlName = props.htmlName ?? (typeof props.name === 'string' ? props.name : undefined);
+
+  return useFieldCommon({ ...props, htmlName, ...customProps }, BaseUpload<T>, 'array');
 };


### PR DESCRIPTION
## Summary

修复 `Upload` / `Upload.Image` 组件的 `name` 属性在从 v1/v2 升级到 v3 后不再作为上传文件 FormData 键名的问题。

**根本原因：** 表单集成层会将 `name` 属性拦截用于表单字段注册，导致底层上传逻辑收不到该 prop，文件字段名始终退为默认值 `file`。

**修复方式：** 在 `name` 被拦截之前，将其作为 `htmlName` 的 fallback 提前保存并传入底层，恢复与 v1/v2 一致的优先级逻辑：`htmlName` > `name` > `'file'`。

## Test Plan

- [ ] 设置 `name="custom"`，未设置 `htmlName`，验证上传请求 FormData 中文件字段名为 `custom`
- [ ] 同时设置 `htmlName="h"` 和 `name="n"`，验证字段名以 `htmlName` 为准，值为 `h`
- [ ] 不设置 `name` 和 `htmlName`，验证字段名退为默认值 `file`
- [ ] `Upload.Image` 同上三条验证
- [ ] 在 Form 内使用时，`name` 的表单字段标识功能不受影响