### PR TITLE
fix(table): 修复条件渲染切换视图后横向滚动失效

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.17-beta.4",
+  "version": "3.9.17-beta.5",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/virtual-scroll/scroll-table.tsx
+++ b/packages/base/src/virtual-scroll/scroll-table.tsx
@@ -69,7 +69,6 @@ const Scroll = (props: ScrollProps) => {
     display: 'flex',
     position: 'sticky',
     flexDirection: 'column',
-    overflow: props.isScrollX ? 'initial' : 'hidden',
     top: 0,
   } as React.CSSProperties;
 

--- a/packages/shineout/src/table/__doc__/changelog.cn.md
+++ b/packages/shineout/src/table/__doc__/changelog.cn.md
@@ -1,3 +1,11 @@
+## 3.9.17-beta.5
+2026-07-06
+
+### 🐞 BugFix
+
+- 修复 `Table` 通过条件渲染切换视图后重新挂载时，横向滚动失效的问题（Mac 非常驻滚动条环境下） ([#1742](https://github.com/sheinsight/shineout-next/pull/1742))
+
+
 ## 3.9.15-beta.3
 2026-05-22
 


### PR DESCRIPTION
## Summary

修复 Table 组件通过条件渲染（如视图切换：卡片视图/列表视图）重新挂载后，横向滚动功能失效的问题。

**问题表现：**
- 切换视图再切回 Table 后，表格内容溢出容器但无法横向滚动
- 页面级别横向滚动把整个表格区域拖走
- Mac 系统滚动条设置为「滚动时显示」（非常驻滚动条）时 100% 复现

**根因：**
虚拟滚动容器在横向滚动模式下设置了 `overflow: 'initial'`，导致 macOS overlay scrollbar 环境下重新挂载后滚动上下文丢失。

**修复方式：**
移除该条件性 overflow 样式，让容器保持默认的 overflow 行为。

## Test Plan

- Mac 系统设置滚动条为「滚动时显示」
- 使用条件渲染切换 Table 视图（如卡片视图 ↔ 列表视图）
- 验证切回 Table 后横向滚动正常工作