### PR TITLE
fix(tag): 框类选择组件禁用项隐藏删除图标

### DIFF
--- a/docs/markdown/shineout/changelog-common.md
+++ b/docs/markdown/shineout/changelog-common.md
@@ -1,3 +1,8 @@
+## 3.9.18-beta.1
+2026-07-10
+### 💅 Style
+- 框类选择组件（`Select`、`TreeSelect`、`Cascader` 等）结果项处于禁用状态时，不再显示删除图标 ([#1744](https://github.com/sheinsight/shineout-next/pull/1744))
+
 ## 3.9.17-beta.2
 2026-06-17
 ### 🐞 BugFix

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.17",
+  "version": "3.9.18-beta.1",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/tag/tag.ts
+++ b/packages/shineout-style/src/tag/tag.ts
@@ -65,10 +65,7 @@ const brightTag = (name: tagType, type: TagType) => ({
     border: `1px solid ${Token[`tag${type}DisabledBackgroundColor`]}`,
 
     '& $closeIconWrapper': {
-      fill: Token[`tag${type}IconDisabledFontColor`],
-      '&:hover': {
-        backgroundColor: 'transparent',
-      },
+      display: 'none',
     },
   },
 });


### PR DESCRIPTION
## Summary

框类选择组件（Select、TreeSelect、Cascader 等）中，当已选中的结果项处于禁用状态时，隐藏其删除图标，避免用户误以为可以操作。

## Changes

- 禁用状态的 Tag 关闭图标由灰色显示改为完全隐藏（`display: none`）

## Test Plan

- 在 Select/TreeSelect/Cascader 多选模式下，设置部分选项为 disabled
- 验证禁用项不再显示 × 删除图标
- 验证非禁用项的删除图标仍正常显示和交互