### PR TITLE
fix(table): header group row renders blank cell after dynamic column group toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.17",
+  "version": "3.9.18-beta.1",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/table/thead.tsx
+++ b/packages/base/src/table/thead.tsx
@@ -346,7 +346,7 @@ export default (props: TheadProps) => {
       createTh(trs, col, 0, isLast, index);
     });
     return trs.map((tr, i) => (
-      <tr key={i} ref={(el) => (trRefs.current[i] = el)}>
+      <tr key={`${i}-${tr.map(item => item.props.colSpan).toString()}`} ref={(el) => (trRefs.current[i] = el)}>
         {tr}
       </tr>
     ));

--- a/packages/shineout/src/table/__doc__/changelog.cn.md
+++ b/packages/shineout/src/table/__doc__/changelog.cn.md
@@ -1,3 +1,11 @@
+## 3.9.18-beta.1
+2026-07-13
+
+### 🐞 BugFix
+
+- 修复 `Table` 动态切换列的分组属性后，表头分组行渲染异常出现空白单元格的问题 ([#1745](https://github.com/sheinsight/shineout-next/pull/1745))
+
+
 ## 3.9.17-beta.5
 2026-07-06
 

--- a/packages/shineout/src/table/__test__/table.spec.tsx
+++ b/packages/shineout/src/table/__test__/table.spec.tsx
@@ -452,8 +452,9 @@ describe('Table[Base]', () => {
     expect(theadTh[0].textContent).toBe(columns[0].title);
     expect(theadTh[1].textContent).toBe(columns[1].title);
     fireEvent.click(container.querySelector('button')!);
-    expect(theadTr.querySelectorAll('th').length).toBe(newColumn.length);
-    expect(theadTr.querySelectorAll('th')[0].textContent).toBe(newColumn[0].title);
+    const updatedTheadTr = container.querySelector('thead')!.querySelector('tr')!;
+    expect(updatedTheadTr.querySelectorAll('th').length).toBe(newColumn.length);
+    expect(updatedTheadTr.querySelectorAll('th')[0].textContent).toBe(newColumn[0].title);
   });
   test('should render when set empty', () => {
     const emptyText = 'empty';


### PR DESCRIPTION
## Summary

修复 Table 组件动态切换列的 group 属性后，表头分组行渲染异常出现空白单元格的问题。

## Problem

当某列通过 setState 从分组中移出（group 设为 undefined）再移入（group 恢复）后，表头的分组行（如 group2）右侧会出现一个多余的空白单元格。DOM 结构中 colspan=2 是正确的，但浏览器在 table-layout:fixed 下对复用的 tr DOM 节点未能正确重新计算 rowspan/colspan 布局。

## Solution

在 thead 的 tr 元素 key 中加入 colSpan 信息，当分组结构变化时强制 React 重建受影响的 tr 节点，避免浏览器使用旧的表格布局缓存。

## Test Plan

1. 使用带有 group 属性的多列表格
2. 动态移除某列的 group 属性（挪出）
3. 再恢复该列的 group 属性（挪入）
4. 验证表头分组行无多余空白单元格，与初始状态一致