### PR TITLE
fix(date-picker): disabled 状态下不再触发 onBlur/onFocus 事件

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.18-beta.1",
+  "version": "3.9.18-beta.2",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/date-picker/date-picker.tsx
+++ b/packages/base/src/date-picker/date-picker.tsx
@@ -172,11 +172,13 @@ const DatePicker = <Value extends DatePickerValueType>(props0: DatePickerProps<V
   });
 
   const handleFocus = usePersistFn((e: React.FocusEvent<HTMLInputElement>) => {
+    if (disabledStatus === 'all') return;
     setFocused(true);
     props.onFocus?.(e);
   });
 
   const handleBlur = usePersistFn((e: React.FocusEvent<HTMLInputElement>, index?: number) => {
+    if (disabledStatus === 'all') return;
     setFocused(false);
     props.onBlur?.(e, index);
 

--- a/packages/shineout/src/date-picker/__doc__/changelog.cn.md
+++ b/packages/shineout/src/date-picker/__doc__/changelog.cn.md
@@ -1,3 +1,8 @@
+## 3.9.18-beta.2
+2026-07-14
+### 🐞 BugFix
+- 修复 `DatePicker` 设置 `disabled` 后，仍然会触发 `onBlur` 和 `onFocus` 事件的问题 ([#1746](https://github.com/sheinsight/shineout-next/pull/1746))
+
 ## 3.9.8-beta.13
 2026-01-22
 ### 🐞 BugFix


### PR DESCRIPTION
## Summary

修复 `DatePicker` 设置 `disabled` 后，内部 input 因使用 `readOnly` 而非 `disabled`（为保证 form 提交值可收集），仍可获得焦点并触发 `onBlur`/`onFocus` 回调的问题。

## Changes

在 `handleFocus` 和 `handleBlur` 入口处增加 `disabledStatus === 'all'` 守卫，disabled 时直接 return。

## Test Plan

- 设置 `disabled` 的 DatePicker 点击/Tab 不再触发 onBlur/onFocus 回调
- 非 disabled 的 DatePicker focus/blur 行为不受影响
- disabled 的 DatePicker 在 Form 中值仍可正常收集