### PR TITLE
fix: 修复 Collocator Tooltip key 警告

### DIFF
--- a/docs/theme/components/collocator/index.tsx
+++ b/docs/theme/components/collocator/index.tsx
@@ -50,9 +50,8 @@ const Collocator = (props: CollocatorProps) => {
     <div className={styles.functions}>
       <Codesandbox code={examples.code} className={classNames(styles.icon, styles.codesandBox)} tip='更多组合用法, 可前往Playground...' />
       {functions.map((item, index) => (
-        <Tooltip tip={item.tip} trigger='hover' position='top'>
+        <Tooltip key={index} tip={item.tip} trigger='hover' position='top'>
           <div
-            key={index}
             className={classNames(styles.icon, [item.type === attachedType && styles.active])}
             onClick={item.onClick}
           >{item.name}</div>


### PR DESCRIPTION
<!-- 请在对应的「[ ]」中填写「x」以勾选 -->

### 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 站点 / 文档更新
- [ ] 示例更新
- [ ] 组件样式更新
- [ ] TypeScript 类型定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化
- [ ] 重构
- [x] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流
- [ ] 其他

### 背景

| 信息 | 说明 |
| --- | --- |
| 浏览器 | Chrome / Safari / Firefox |
| 版本 | 所有受支持版本 |
| 操作系统 | MacOS / Windows / Linux |

`Collocator` 使用 `map` 渲染功能入口时，列表的 `key` 当前位于 `Tooltip` 内部的 `div` 上。React 要求 `key` 设置在 `map` 直接返回的最外层元素上，否则会产生缺少 `key` 的警告，并且无法使用该值进行列表协调。

### 变更日志

- 修复 `Collocator` 功能列表的 `key` 位置，消除 React 缺少 `key` 的警告。

### Playground ID

无

### 其他信息

无