### PR TITLE
chore: release 3.9.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.18-beta.2",
+  "version": "3.9.18",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/version.ts
+++ b/packages/shineout-style/src/version.ts
@@ -1,1 +1,1 @@
-export default '3.9.17';
+export default '3.9.18';

--- a/packages/shineout/src/index.ts
+++ b/packages/shineout/src/index.ts
@@ -68,4 +68,4 @@ export * from './deprecated';
 
 export * as TYPE from './type';
 
-export default { version: '3.9.17' };
+export default { version: '3.9.18' };


### PR DESCRIPTION
## Summary

发布 shineout-next v3.9.18 正式版本。

### Changes
- `package.json`: 3.9.18-beta.2 → 3.9.18
- `packages/shineout-style/src/version.ts`: 3.9.17 → 3.9.18
- `packages/shineout/src/index.ts`: 3.9.17 → 3.9.18

## Test Plan
版本号变更，无功能改动。