### PR TITLE
chore: bump version to 3.10.0-beta.1 and add Watermark changelog

### DIFF
--- a/docs/markdown/shineout/changelog-common.md
+++ b/docs/markdown/shineout/changelog-common.md
@@ -1,3 +1,8 @@
+## 3.10.0-beta.1
+2026-07-17
+### 🆕 Feature
+- 新增 `Watermark` 水印组件，支持文本/图片水印、多行文本、自定义样式，并自动覆盖 `Modal`/`Drawer` 等弹出层 ([#1749](https://github.com/sheinsight/shineout-next/pull/1749))
+
 ## 3.9.18-beta.1
 2026-07-10
 ### 💅 Style

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.9.18",
+  "version": "3.10.0-beta.1",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/version.ts
+++ b/packages/shineout-style/src/version.ts
@@ -1,1 +1,1 @@
-export default '3.9.18';
+export default '3.10.0-beta.1';

--- a/packages/shineout/src/index.ts
+++ b/packages/shineout/src/index.ts
@@ -69,4 +69,4 @@ export * from './deprecated';
 
 export * as TYPE from './type';
 
-export default { version: '3.9.18' };
+export default { version: '3.10.0-beta.1' };

--- a/packages/shineout/src/watermark/__doc__/index.md
+++ b/packages/shineout/src/watermark/__doc__/index.md
@@ -1,6 +1,7 @@
 ---
 name: Watermark
 group: Feedback
+version: 3.10.0
 ---
 
 # Title


### PR DESCRIPTION
## Changes

- 版本号升级至 `3.10.0-beta.1`
- 新增 Watermark 水印组件的 changelog 条目

关联 PR: #1749