### PR TITLE
fix(upload): 避免重复调用 beforeUpload

### DIFF
--- a/packages/hooks/src/components/use-upload/use-upload.ts
+++ b/packages/hooks/src/components/use-upload/use-upload.ts
@@ -278,10 +278,8 @@ const useUpload = <T>(props: UseUploadProps<T>) => {
       }
       if (props.beforeUpload) {
         const beforeUploadResult = props.beforeUpload(blob);
-        // @ts-ignoreq
         if (beforeUploadResult && beforeUploadResult.then) {
-          props
-            .beforeUpload(blob)
+          beforeUploadResult
             .then((args) => {
               if (args.status !== 'error') {
                 newFiles[id].xhr = uploadFile(id, blob, fileRecord.src);

--- a/packages/shineout/src/upload/__test__/upload.spec.tsx
+++ b/packages/shineout/src/upload/__test__/upload.spec.tsx
@@ -354,14 +354,14 @@ describe('Upload[Multiple]', () => {
     });
     expect(beforeUploadFn.mock.calls.length).toBe(1);
   });
-  test('should render when set beforeUpload is promise(resolve)', async () => {
+  test('should call promise beforeUpload once for each file', async () => {
     const beforeUploadProFn = jest.fn(() => Promise.resolve({ status: 200 }));
     const { container } = render(<UploadTest name='file' beforeUpload={beforeUploadProFn} />);
     uploadFile(container, { name: fileTextName });
     await waitFor(async () => {
       await delay(200);
     });
-    expect(beforeUploadProFn.mock.calls.length).toBe(2);
+    expect(beforeUploadProFn).toHaveBeenCalledTimes(1);
   });
   test('should render when set customResult', async () => {
     const CustomResult = ({ value }: any) => <div className='demo'>{value}</div>;

--- a/packages/shineout/src/upload/__test__/upload.spec.tsx
+++ b/packages/shineout/src/upload/__test__/upload.spec.tsx
@@ -354,14 +354,24 @@ describe('Upload[Multiple]', () => {
     });
     expect(beforeUploadFn.mock.calls.length).toBe(1);
   });
-  test('should call promise beforeUpload once for each file', async () => {
-    const beforeUploadProFn = jest.fn(() => Promise.resolve({ status: 200 }));
-    const { container } = render(<UploadTest name='file' beforeUpload={beforeUploadProFn} />);
-    uploadFile(container, { name: fileTextName });
+  test('should call promise beforeUpload and request once for each file', async () => {
+    const beforeUploadProFn = jest.fn((_file: File) => Promise.resolve({ status: 200 }));
+    const request = jest.fn((_options: any) => undefined);
+    const files = [
+      new File(['content'], 'file1.txt'),
+      new File(['content'], 'file2.txt'),
+    ];
+    const { container } = render(
+      <UploadTest name='file' multiple beforeUpload={beforeUploadProFn} request={request} />,
+    );
+    uploadFile(container, { files });
     await waitFor(async () => {
       await delay(200);
     });
-    expect(beforeUploadProFn).toHaveBeenCalledTimes(1);
+    expect(beforeUploadProFn).toHaveBeenCalledTimes(2);
+    expect(beforeUploadProFn.mock.calls.map(([file]) => file)).toStrictEqual(files);
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(request.mock.calls.map(([options]) => options.file)).toStrictEqual(files);
   });
   test('should render when set customResult', async () => {
     const CustomResult = ({ value }: any) => <div className='demo'>{value}</div>;


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information | Descriptions |
| --- | --- |
| Browser | Chrome / Safari |
| Version | 3.10.0-beta.1 |
| OS | macOS / Windows / Linux |

当 `beforeUpload` 返回 Promise 时，Upload 内部会先调用一次回调判断返回值，随后再次调用回调并注册 Promise 处理逻辑。这会导致同一个文件触发两次用户回调，同时第一次返回的 Promise 被丢弃。

本次修改复用第一次调用得到的 Promise，保持原有上传成功、拒绝及错误状态处理流程不变。

### Changelog

- 修复 `Upload` 对单个文件重复调用 Promise 型 `beforeUpload` 的问题。

### Playground id

N/A

### Other information

N/A