### PR TITLE
fix(tooltip): 修复无效子元素导致的 Hooks 顺序错误

### DIFF
--- a/packages/base/src/tooltip/tooltip.tsx
+++ b/packages/base/src/tooltip/tooltip.tsx
@@ -29,12 +29,6 @@ const Tooltip = (props: TooltipProps) => {
     pointAtCenter = false,
   } = props;
 
-  // Early validation checks BEFORE any hooks
-  if (!isValidElement(children)) {
-    devUseWarning.error('Tooltip children expect a single ReactElement.');
-    return null;
-  }
-
   const tooltipClasses = jssStyle?.tooltip?.();
   const config = useConfig();
 
@@ -124,6 +118,11 @@ const Tooltip = (props: TooltipProps) => {
     }
     return events;
   }, [persistent, events, trigger]);
+
+  if (!isValidElement(children)) {
+    devUseWarning.error('Tooltip children expect a single ReactElement.');
+    return null;
+  }
 
   const inner = disabledChild && tip ? (
     <span className={tooltipClasses?.target} style={{ cursor: 'not-allowed' }}>

--- a/packages/base/src/tooltip/tooltip.tsx
+++ b/packages/base/src/tooltip/tooltip.tsx
@@ -10,7 +10,11 @@ const { devUseWarning } = util;
 
 const defaultDelay = 0;
 
-const Tooltip = (props: TooltipProps) => {
+type ValidTooltipProps = Omit<TooltipProps, 'children'> & {
+  children: React.ReactElement;
+};
+
+const TooltipInner = (props: ValidTooltipProps) => {
   const {
     trigger = 'hover',
     priorityDirection,
@@ -34,9 +38,7 @@ const Tooltip = (props: TooltipProps) => {
 
   const persistent = persistentProp ?? config.tooltip?.persistent;
 
-  const childrenProps = isValidElement(children)
-    ? (children?.props as { [name: string]: any })
-    : {};
+  const childrenProps = children.props as { [name: string]: any };
 
   const delay = props.delay || props.mouseEnterDelay || defaultDelay;
   const mouseLeaveDelay = props.mouseLeaveDelay || defaultDelay;
@@ -119,11 +121,6 @@ const Tooltip = (props: TooltipProps) => {
     return events;
   }, [persistent, events, trigger]);
 
-  if (!isValidElement(children)) {
-    devUseWarning.error('Tooltip children expect a single ReactElement.');
-    return null;
-  }
-
   const inner = disabledChild && tip ? (
     <span className={tooltipClasses?.target} style={{ cursor: 'not-allowed' }}>
       {cloneElement(children as React.ReactElement, {
@@ -189,6 +186,17 @@ const Tooltip = (props: TooltipProps) => {
       )}
     </>
   );
+};
+
+const Tooltip = (props: TooltipProps) => {
+  const { children, ...innerProps } = props;
+
+  if (!isValidElement(children)) {
+    devUseWarning.error('Tooltip children expect a single ReactElement.');
+    return null;
+  }
+
+  return <TooltipInner {...innerProps}>{children}</TooltipInner>;
 };
 
 export default Tooltip;

--- a/packages/shineout/src/tooltip/__test__/tooltip.spec.tsx
+++ b/packages/shineout/src/tooltip/__test__/tooltip.spec.tsx
@@ -367,7 +367,7 @@ describe('Tooltip[Base]', () => {
     const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
 
     try {
-      const { rerender, unmount } = render(
+      const { rerender } = render(
         <Tooltip tip='hello' persistent>
           <span>demo</span>
         </Tooltip>,
@@ -377,15 +377,42 @@ describe('Tooltip[Base]', () => {
       )?.[1];
       expect(resizeListener).toEqual(expect.any(Function));
 
+      removeEventListenerSpy.mockClear();
       rerender(
         // @ts-ignore
         <Tooltip tip='hello' persistent></Tooltip>,
       );
-      removeEventListenerSpy.mockClear();
-      unmount();
       expect(removeEventListenerSpy).toHaveBeenCalledWith('resize', resizeListener);
     } finally {
       removeEventListenerSpy.mockRestore();
+      addEventListenerSpy.mockRestore();
+      spyError.mockRestore();
+    }
+  });
+  test('should bind persistent events after children becomes valid', async () => {
+    const spyError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+
+    try {
+      const { rerender } = render(
+        // @ts-ignore
+        <Tooltip tip='hello' persistent></Tooltip>,
+      );
+      addEventListenerSpy.mockClear();
+
+      rerender(
+        <Tooltip tip='hello' persistent>
+          <span>demo</span>
+        </Tooltip>,
+      );
+
+      expect(addEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function));
+      fireEvent.mouseEnter(screen.getByText('demo'));
+      await waitFor(async () => {
+        await delay(200);
+      });
+      classContentTest(document.querySelector(tooltipClassName)!, tooltipWrapperOpenClassName);
+    } finally {
       addEventListenerSpy.mockRestore();
       spyError.mockRestore();
     }

--- a/packages/shineout/src/tooltip/__test__/tooltip.spec.tsx
+++ b/packages/shineout/src/tooltip/__test__/tooltip.spec.tsx
@@ -361,6 +361,35 @@ describe('Tooltip[Base]', () => {
     classLengthTest(document, tooltipClassName, 0);
     spyError.mockRestore();
   });
+  test('should clean up persistent events after children becomes invalid', () => {
+    const spyError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+    const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+
+    try {
+      const { rerender, unmount } = render(
+        <Tooltip tip='hello' persistent>
+          <span>demo</span>
+        </Tooltip>,
+      );
+      const resizeListener = addEventListenerSpy.mock.calls.find(
+        ([eventName]) => eventName === 'resize',
+      )?.[1];
+      expect(resizeListener).toEqual(expect.any(Function));
+
+      rerender(
+        // @ts-ignore
+        <Tooltip tip='hello' persistent></Tooltip>,
+      );
+      removeEventListenerSpy.mockClear();
+      unmount();
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('resize', resizeListener);
+    } finally {
+      removeEventListenerSpy.mockRestore();
+      addEventListenerSpy.mockRestore();
+      spyError.mockRestore();
+    }
+  });
   test('should render when set persistent', async () => {
     render(<TooltipDemo persistent />);
     fireEvent.mouseEnter(screen.getByText('demo'));


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information | Descriptions |
| --- | --- |
| Browser | Chrome / Safari |
| Version | 3.10.0-beta.1 |
| OS | macOS / Windows / Linux |

Tooltip 在 `children` 无效时会在调用组件内 Hooks 之前提前返回，导致后续 Hooks 成为条件调用，并使 `persistent` 模式下已绑定的窗口事件在组件卸载时无法清理。

本次将无效子元素校验移动到全部 Hooks 之后，保留原有开发期告警与返回 `null` 的行为；同时新增有效子元素变为无效后卸载的回归测试，验证注册的 `resize` 回调使用同一函数引用被移除。

### Changelog

- 修复 `Tooltip` 无效子元素路径违反 Hooks 调用顺序并遗漏事件清理的问题。
- 新增 `persistent` 模式下动态无效子元素的事件清理回归测试。

### Playground id

N/A

### Other information

N/A
