### PR TITLE
fix(select,tree-select): 修复 renderOptionList 空数据时双重渲染及焦点丢失

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.10.0-beta.1",
+  "version": "3.10.0-beta.2",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/select/select.tsx
+++ b/packages/base/src/select/select.tsx
@@ -743,7 +743,7 @@ function Select<DataItem, Value>(props0: SelectPropsBase<DataItem, Value>) {
 
     const options = 'treeData' in props ? renderTreeList() : renderList();
     if (renderOptionList) {
-      return renderOptionList(isEmpty ? renderEmpty() : options, { loading: loading });
+      return renderOptionList(isEmpty ? null : options, { loading: loading, empty: isEmpty });
     }
 
     if (isEmpty) return renderEmpty();

--- a/packages/base/src/select/select.type.ts
+++ b/packages/base/src/select/select.type.ts
@@ -260,7 +260,7 @@ export interface SelectPropsBase<DataItem, Value>
    */
   renderOptionList?: (
     list: React.ReactNode,
-    info: { loading?: boolean | React.ReactNode },
+    info: { loading?: boolean | React.ReactNode; empty?: boolean },
   ) => React.ReactNode;
 
   /**

--- a/packages/base/src/tree-select/tree-select.tsx
+++ b/packages/base/src/tree-select/tree-select.tsx
@@ -718,7 +718,7 @@ const TreeSelect = <DataItem, Value extends TreeSelectValueType>(
     );
 
     if (renderOptionList) {
-      return renderOptionList(isEmpty ? renderEmpty() : tree);
+      return renderOptionList(isEmpty ? null : tree, { empty: isEmpty });
     }
 
     if (isEmpty) return renderEmpty();

--- a/packages/base/src/tree-select/tree-select.type.ts
+++ b/packages/base/src/tree-select/tree-select.type.ts
@@ -514,5 +514,5 @@ export interface TreeSelectProps<DataItem, Value>
    * @when For complete control over dropdown content (e.g., custom wrapper, animations, additional UI elements around the option list)
    * @version 3.9.4
    */
-  renderOptionList?: (list: React.ReactNode) => React.ReactNode;
+  renderOptionList?: (list: React.ReactNode, info: { empty?: boolean }) => React.ReactNode;
 }

--- a/packages/shineout/src/select/__doc__/changelog.cn.md
+++ b/packages/shineout/src/select/__doc__/changelog.cn.md
@@ -1,3 +1,8 @@
+## 3.10.0-beta.2
+2026-07-21
+### 🐞 BugFix
+- 修复 `Select` 开启 `renderOptionList` 后，当数据为空时 `emptyText` 内容被传入 `renderOptionList` 导致自定义筛选输入框双重渲染及焦点丢失的问题 ([#1755](https://github.com/sheinsight/shineout-next/pull/1755))
+
 ## 3.9.14-beta.11
 2026-05-19
 ### 🐞 BugFix

--- a/packages/shineout/src/select/__doc__/changelog.cn.md
+++ b/packages/shineout/src/select/__doc__/changelog.cn.md
@@ -1,7 +1,7 @@
 ## 3.10.0-beta.2
 2026-07-21
 ### 🐞 BugFix
-- 修复 `Select` 开启 `renderOptionList` 后，当数据为空时 `emptyText` 内容被传入 `renderOptionList` 导致自定义筛选输入框双重渲染及焦点丢失的问题 ([#1755](https://github.com/sheinsight/shineout-next/pull/1755))
+- 修复 `Select` 开启 `renderOptionList` 后，当数据为空时 `emptyText` 内容被传入 `renderOptionList` 导致自定义内容双重渲染的问题 ([#1755](https://github.com/sheinsight/shineout-next/pull/1755))
 
 ## 3.9.14-beta.11
 2026-05-19

--- a/packages/shineout/src/select/__example__/17-custom-result-2.tsx
+++ b/packages/shineout/src/select/__example__/17-custom-result-2.tsx
@@ -167,11 +167,11 @@ export default () => {
     }
   }, [displayData.length]);
 
-  const renderOptionList = (list: React.ReactNode) => {
+  const renderOptionList = (list: React.ReactNode, info: { empty?: boolean }) => {
     return (
-      <div style={{ height: 173, overflow: 'au' }}>
+      <div style={{ height: 173, overflow: 'auto' }}>
         <FilterInput value={filterText} onChange={setFilterText} ref={inputRef} />
-        {list}
+        {info.empty ? <Empty style={{ margin: '24px auto 12px' }} /> : list}
       </div>
     );
   };
@@ -186,17 +186,7 @@ export default () => {
         width={300}
         renderItem={renderItem}
         className={classes.select}
-        emptyText={
-          <div>
-            <FilterInput
-              value={filterText}
-              onChange={setFilterText}
-              style={{ margin: '-6px 0 0 -12px', width: 'calc(100% + 24px)' }}
-              ref={inputRef}
-            />
-            <Empty style={{ margin: '24px auto 12px' }} />
-          </div>
-        }
+        emptyText={false}
         data={displayData}
         placeholder='Please Select'
         clearable

--- a/packages/shineout/src/tree-select/__doc__/changelog.cn.md
+++ b/packages/shineout/src/tree-select/__doc__/changelog.cn.md
@@ -1,3 +1,8 @@
+## 3.10.0-beta.2
+2026-07-21
+### 🐞 BugFix
+- 修复 `TreeSelect` 开启 `renderOptionList` 后，当数据为空时 `emptyText` 内容被传入 `renderOptionList` 导致自定义内容双重渲染的问题 ([#1755](https://github.com/sheinsight/shineout-next/pull/1755))
+
 ## 3.9.12-beta.13
 2026-03-30
 

--- a/packages/shineout/src/tree-select/__example__/12-render-option-list.tsx
+++ b/packages/shineout/src/tree-select/__example__/12-render-option-list.tsx
@@ -1,11 +1,12 @@
 /**
  * cn - 自定义列表布局
  *    -- 通过设置`renderOptionList`可以自定义列表内容，并将列表实例抛出
- *    -- 注意：与`emptyText`属性搭配使用时，`emptyText`渲染优先级高于`renderOptionList`
- *    -- 可将`emptyText`设置为 false 忽略空内容渲染，如需渲染空内容，请在`renderOptionList`中自行处理
+ *    -- 当数据为空时，`list` 参数为 `null`，可通过第二个参数 `info.empty` 判断是否为空状态
+ *    -- 可将`emptyText`设置为 false 禁用内置空态渲染，在`renderOptionList`中自行处理空内容
  * en - Custom render option list
  *    -- Set `renderOptionList` to customize the list content
- *    -- When used with the `emptyText` property, the rendering priority of `emptyText` is higher than that of `renderOptionList`. You can set `emptyText` to false to ignore the empty content rendering. If you need to render the empty content, please handle it in `renderOptionList`
+ *    -- When data is empty, `list` is `null`. You can use `info.empty` from the second parameter to determine the empty state
+ *    -- Set `emptyText` to false to disable the built-in empty rendering, and handle empty content in `renderOptionList`
  */
 import { useState } from 'react';
 import { TreeSelect, Checkbox } from 'shineout';


### PR DESCRIPTION
## Summary

修复 Select/TreeSelect 开启 `renderOptionList` 后，当搜索无匹配数据时，`emptyText` 内容被作为 `list` 参数传入 `renderOptionList`，导致自定义内容（如搜索输入框）双重渲染，以及删除关键字后输入框失焦的问题。

## Changes

- `renderOptionList` 空数据时 `list` 参数传 `null` 而非 `renderEmpty()` 的结果
- `info` 参数新增 `empty?: boolean` 字段，用户可据此判断空态并自行渲染
- 更新 Select/TreeSelect 的类型定义和相关示例

## Test Plan

- Select 单元测试 72 个全部通过
- TreeSelect 单元测试 26 个全部通过
- 无类型错误