### PR TITLE
fix(popover): 修复 border 属性未传递给箭头边框颜色的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.10.0-beta.2",
+  "version": "3.10.0-beta.3",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/popover/popover.tsx
+++ b/packages/base/src/popover/popover.tsx
@@ -173,6 +173,7 @@ const Popover = (props: PopoverProps) => {
     display: open ? undefined : 'none',
     borderColor: props.border,
     backgroundColor: props.background,
+    '--popover-border-color': props.border,
     '--popover-background-color': props.background,
   };
 

--- a/packages/shineout-style/src/popover/popover.ts
+++ b/packages/shineout-style/src/popover/popover.ts
@@ -11,7 +11,7 @@ const arrowWidth = arrowHeight * 2;
 const cssvar = '--popover-arrow-gap';
 const hideArrowGap = `var(${cssvar}, 10px)`;
 const extraArrowGap = 'var(--popover-arrow-gap-extra, 0px)';
-
+const arrowBorderColor = `var(--popover-border-color, ${token.popoverBorderColor})`
 const poyfillPos = `calc((${hideArrowGap} + ${extraArrowGap}) * -1)`;
 const poyfillHeight = `calc((${hideArrowGap} + ${extraArrowGap}))`;
 
@@ -34,7 +34,7 @@ const popoverStyle: JsStyles<PopoverClassType> = {
       height: arrowHeight,
       pointerEvents: 'none',
       transformOrigin: 'center center',
-      filter: `drop-shadow(0 1px 0 ${token.popoverBorderColor}) drop-shadow(0 -1px 0 ${token.popoverBorderColor}) drop-shadow(1px 0 0 ${token.popoverBorderColor}) drop-shadow(-1px 0 0 ${token.popoverBorderColor})`,
+      filter: `drop-shadow(0 1px 0 ${arrowBorderColor}) drop-shadow(0 -1px 0 ${arrowBorderColor}) drop-shadow(1px 0 0 ${arrowBorderColor}) drop-shadow(-1px 0 0 ${arrowBorderColor})`,
       '&::before': {
         display: 'block',
         content: '""',

--- a/packages/shineout/src/popover/__doc__/changelog.cn.md
+++ b/packages/shineout/src/popover/__doc__/changelog.cn.md
@@ -1,3 +1,8 @@
+## 3.10.0-beta.3
+2026-07-22
+### 🐞 BugFix
+- 修复 `Popover` 设置 `border` 属性后，箭头边框颜色未跟随变化的问题 ([#1756](https://github.com/sheinsight/shineout-next/pull/1756))
+
 ## 3.9.17-beta.3
 2026-06-23
 ### 🆕 Feature


### PR DESCRIPTION
## Summary

修复 Popover 组件设置 `border` 属性后，箭头边框颜色未同步变化的问题。

**问题现象：** 设置 `border` 属性后，弹出框主体边框颜色正确变化，但箭头部分仍显示默认边框颜色，导致视觉不一致。

**修复方案：** 通过 CSS 变量 `--popover-border-color` 将自定义边框颜色传递给箭头的 drop-shadow，确保箭头与主体边框颜色保持一致。

## Test Plan

1. 使用 Popover 组件并设置 `border` 属性为自定义颜色
2. 验证弹出框主体和箭头的边框颜色一致
3. 验证未设置 `border` 属性时，默认样式不受影响