### PR TITLE
chore(upload): 补充 beforeUpload 重复调用修复的 changelog

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.10.0-beta.3",
+  "version": "3.10.0-beta.4",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/version.ts
+++ b/packages/shineout-style/src/version.ts
@@ -1,1 +1,1 @@
-export default '3.10.0-beta.1';
+export default '3.10.0-beta.4';

--- a/packages/shineout/src/index.ts
+++ b/packages/shineout/src/index.ts
@@ -69,4 +69,4 @@ export * from './deprecated';
 
 export * as TYPE from './type';
 
-export default { version: '3.10.0-beta.1' };
+export default { version: '3.10.0-beta.4' };

--- a/packages/shineout/src/upload/__doc__/changelog.cn.md
+++ b/packages/shineout/src/upload/__doc__/changelog.cn.md
@@ -1,3 +1,8 @@
+## 3.10.0-beta.4
+2026-07-22
+### 🐞 BugFix
+- 修复 `Upload` 当 `beforeUpload` 返回 Promise 时，同一个文件会重复触发两次回调的问题 ([#1753](https://github.com/sheinsight/shineout-next/pull/1753))
+
 ## 3.9.17-beta.4
 2026-06-30
 


### PR DESCRIPTION
### Types of changes

- [x] Others

### Summary

为 PR #1753 的修复补充 changelog 条目，并升级版本号至 `3.10.0-beta.4`。

### Changes

- 新增 Upload changelog：修复 `beforeUpload` 返回 Promise 时同一文件重复触发两次回调的问题
- 版本号升级至 `3.10.0-beta.4`

### Related

- #1753