### PR TITLE
chore(tooltip): 补充 Tooltip hooks 顺序修复的 changelog

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.10.0-beta.4",
+  "version": "3.10.0-beta.5",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/version.ts
+++ b/packages/shineout-style/src/version.ts
@@ -1,1 +1,1 @@
-export default '3.10.0-beta.4';
+export default '3.10.0-beta.5';

--- a/packages/shineout/src/index.ts
+++ b/packages/shineout/src/index.ts
@@ -69,4 +69,4 @@ export * from './deprecated';
 
 export * as TYPE from './type';
 
-export default { version: '3.10.0-beta.4' };
+export default { version: '3.10.0-beta.5' };

--- a/packages/shineout/src/tooltip/__doc__/changelog.cn.md
+++ b/packages/shineout/src/tooltip/__doc__/changelog.cn.md
@@ -1,3 +1,8 @@
+## 3.10.0-beta.5
+2026-07-22
+### 🐞 BugFix
+- 修复 `Tooltip` 当 `children` 动态变为无效元素时，可能导致 React Hooks 调用顺序错误及事件监听未清理的问题 ([#1754](https://github.com/sheinsight/shineout-next/pull/1754))
+
 ## 3.9.17-beta.3
 2026-06-23
 ### 🆕 Feature


### PR DESCRIPTION
### Types of changes

- [x] Others

### Summary

为 PR #1754 的修复补充 changelog 条目，并升级版本号至 `3.10.0-beta.5`。

### Changes

- 新增 Tooltip changelog：修复 `children` 动态变为无效元素时，可能导致 React Hooks 调用顺序错误及事件监听未清理的问题
- 版本号升级至 `3.10.0-beta.5`

### Related

- #1754