### PR TITLE
docs(watermark): 修复暗色模式示例样式

### DIFF
--- a/docs/theme/components/collocator/preset.tsx
+++ b/docs/theme/components/collocator/preset.tsx
@@ -58,7 +58,8 @@ const WatermarkPreset = (watermarkProps: any) => {
             width: '100%',
             height: '100%',
             padding: 24,
-            background: '#fafafa'
+            background: 'var(--soui-neutral-fill-2)',
+            color: 'var(--soui-neutral-text-5)'
           }}
         >
           <div style={{ display: 'flex', gap: 12, marginBottom: 24 }}>
@@ -3243,7 +3244,7 @@ const StarRate = Rate(star, star)
       element: (props: any) => <WatermarkPreset {...props} />,
       code: `<div ref={setContainer} style={{ width: '100%', height: 320, overflow: 'hidden', transform: 'translateZ(0)' }}>
   <Watermark#placeholder>
-    <div style={{ width: '100%', height: '100%', padding: 24, background: '#fafafa' }}>
+    <div style={{ width: '100%', height: '100%', padding: 24, background: 'var(--soui-neutral-fill-2)', color: 'var(--soui-neutral-text-5)' }}>
       <Button mode='outline' onClick={() => setModalVisible(true)}>Open Modal</Button>
       <Button mode='outline' onClick={() => setDrawerVisible(true)}>Open Drawer</Button>
       Watermark content
@@ -3276,7 +3277,9 @@ const StarRate = Rate(star, star)
         {
           name: 'font',
           type: 'other',
-          initValue: { color: 'rgba(0, 0, 0, 0.15)', fontSize: 16 }
+          defaultValue: { color: 'rgba(153, 157, 168, 0.55)', fontSize: 16 },
+          initValue: { color: 'rgba(153, 157, 168, 0.55)', fontSize: 16 },
+          notHideDefaultValue: true
         },
         {
           name: 'onRemove',

--- a/packages/shineout/src/watermark/__example__/01-base.tsx
+++ b/packages/shineout/src/watermark/__example__/01-base.tsx
@@ -9,13 +9,13 @@ import { Watermark } from 'shineout';
 
 export default () => {
   return (
-    <Watermark content='Shineout'>
+    <Watermark content='Shineout' font={{ color: 'rgba(153, 157, 168, 0.55)' }}>
       <div
         style={{
           height: 240,
           padding: 24,
-          background: '#fafafa',
-          color: '#141414',
+          background: 'var(--soui-neutral-fill-2)',
+          color: 'var(--soui-neutral-text-5)',
         }}
       >
         Basic watermark

--- a/packages/shineout/src/watermark/__example__/02-multiline.tsx
+++ b/packages/shineout/src/watermark/__example__/02-multiline.tsx
@@ -10,15 +10,23 @@ import { Watermark } from 'shineout';
 export default () => {
   return (
     <Watermark
+      font={{ color: 'rgba(153, 157, 168, 0.55)' }}
       content={[
-        { text: 'Shineout', font: { color: 'rgba(0, 0, 0, 0.18)', fontSize: 18 } },
+        { text: 'Shineout', font: { fontSize: 18 } },
         {
           text: 'Watermark',
-          font: { color: 'rgba(206, 32, 41, 0.22)', fontSize: 12, fontWeight: 600 },
+          font: { color: 'rgba(206, 32, 41, 0.55)', fontSize: 12, fontWeight: 600 },
         },
       ]}
     >
-      <div style={{ height: 240, padding: 24, background: '#fafafa' }}>
+      <div
+        style={{
+          height: 240,
+          padding: 24,
+          background: 'var(--soui-neutral-fill-2)',
+          color: 'var(--soui-neutral-text-5)',
+        }}
+      >
         Multi-line watermark
       </div>
     </Watermark>

--- a/packages/shineout/src/watermark/__example__/03-image.tsx
+++ b/packages/shineout/src/watermark/__example__/03-image.tsx
@@ -12,8 +12,23 @@ const image =
 
 export default () => {
   return (
-    <Watermark image={image} content='Shineout' width={72} height={48}>
-      <div style={{ height: 240, padding: 24, background: '#fafafa' }}>Image watermark</div>
+    <Watermark
+      image={image}
+      content='Shineout'
+      width={72}
+      height={48}
+      font={{ color: 'rgba(153, 157, 168, 0.55)' }}
+    >
+      <div
+        style={{
+          height: 240,
+          padding: 24,
+          background: 'var(--soui-neutral-fill-2)',
+          color: 'var(--soui-neutral-text-5)',
+        }}
+      >
+        Image watermark
+      </div>
     </Watermark>
   );
 };

--- a/packages/shineout/src/watermark/__example__/04-custom.tsx
+++ b/packages/shineout/src/watermark/__example__/04-custom.tsx
@@ -17,9 +17,16 @@ export default () => {
       offset={[16, 20]}
       rotate={-16}
       zIndex={20}
-      font={{ color: 'rgba(20, 86, 122, 0.2)', fontSize: 14, fontWeight: 600 }}
+      font={{ color: 'rgba(153, 157, 168, 0.55)', fontSize: 14, fontWeight: 600 }}
     >
-      <div style={{ height: 240, padding: 24, background: '#fafafa' }}>
+      <div
+        style={{
+          height: 240,
+          padding: 24,
+          background: 'var(--soui-neutral-fill-2)',
+          color: 'var(--soui-neutral-text-5)',
+        }}
+      >
         Custom watermark
       </div>
     </Watermark>

--- a/packages/shineout/src/watermark/__example__/05-popup.tsx
+++ b/packages/shineout/src/watermark/__example__/05-popup.tsx
@@ -17,8 +17,19 @@ export default () => {
       ref={setContainer}
       style={{ position: 'relative', height: 320, overflow: 'hidden', transform: 'translateZ(0)' }}
     >
-      <Watermark content='Shineout' style={{ height: '100%' }}>
-        <div style={{ height: '100%', padding: 24, background: '#fafafa' }}>
+      <Watermark
+        content='Shineout'
+        font={{ color: 'rgba(153, 157, 168, 0.55)' }}
+        style={{ height: '100%' }}
+      >
+        <div
+          style={{
+            height: '100%',
+            padding: 24,
+            background: 'var(--soui-neutral-fill-2)',
+            color: 'var(--soui-neutral-text-5)',
+          }}
+        >
           <div style={{ display: 'flex', gap: 12 }}>
             <Button mode='outline' onClick={() => setModalVisible(true)}>
               Open Modal

--- a/packages/shineout/src/watermark/__test__/watermark-example.spec.tsx
+++ b/packages/shineout/src/watermark/__test__/watermark-example.spec.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import ShallowRenderer from 'react-test-renderer/shallow';
+import { Watermark } from 'shineout';
+import BaseExample from '../__example__/01-base';
+import MultilineExample from '../__example__/02-multiline';
+import ImageExample from '../__example__/03-image';
+import CustomExample from '../__example__/04-custom';
+import PopupExample from '../__example__/05-popup';
+import { collocatorPreset } from '../../../../../docs/theme/components/collocator/preset';
+
+const examples = [
+  ['Basic watermark', BaseExample],
+  ['Multi-line watermark', MultilineExample],
+  ['Image watermark', ImageExample],
+  ['Custom watermark', CustomExample],
+  ['Popup inheritance', PopupExample],
+] as const;
+const watermarkColor = 'rgba(153, 157, 168, 0.55)';
+
+interface ExampleElementProps {
+  children?: React.ReactNode;
+  style?: React.CSSProperties;
+}
+
+const findContentElement = (
+  node: React.ReactNode,
+): React.ReactElement<ExampleElementProps> | null => {
+  if (!React.isValidElement<ExampleElementProps>(node)) return null;
+  if (node.props.style?.background) return node;
+
+  for (const child of React.Children.toArray(node.props.children)) {
+    const contentElement = findContentElement(child);
+    if (contentElement) return contentElement;
+  }
+
+  return null;
+};
+
+const findWatermarkElement = (
+  node: React.ReactNode,
+): React.ReactElement<{ font?: { color?: string } }> | null => {
+  if (!React.isValidElement(node)) return null;
+  if (node.type === Watermark) {
+    return node as React.ReactElement<{ font?: { color?: string } }>;
+  }
+
+  for (const child of React.Children.toArray((node.props as ExampleElementProps).children)) {
+    const watermarkElement = findWatermarkElement(child);
+    if (watermarkElement) return watermarkElement;
+  }
+
+  return null;
+};
+
+describe.each(examples)('%s example', (content, Example) => {
+  test('uses theme-aware content colors', () => {
+    const renderer = new ShallowRenderer();
+    renderer.render(<Example />);
+
+    const contentElement = findContentElement(renderer.getRenderOutput());
+
+    expect(contentElement).not.toBeNull();
+    expect(contentElement?.props.style?.background).toBe('var(--soui-neutral-fill-2)');
+    expect(contentElement?.props.style?.color).toBe('var(--soui-neutral-text-5)');
+  });
+
+  test('uses a watermark color visible on light and dark backgrounds', () => {
+    const renderer = new ShallowRenderer();
+    renderer.render(<Example />);
+
+    expect(findWatermarkElement(renderer.getRenderOutput())?.props.font?.color).toBe(
+      watermarkColor,
+    );
+  });
+});
+
+describe('Watermark playground', () => {
+  test('uses theme-aware content colors in the preview and generated code', () => {
+    const playground = collocatorPreset.Watermark.Watermark;
+    const renderer = new ShallowRenderer();
+    renderer.render(playground.element({ content: 'Shineout' }));
+
+    const contentElement = findContentElement(renderer.getRenderOutput());
+
+    expect(contentElement).not.toBeNull();
+    expect(contentElement?.props.style?.background).toBe('var(--soui-neutral-fill-2)');
+    expect(contentElement?.props.style?.color).toBe('var(--soui-neutral-text-5)');
+    expect(playground.code).toContain("background: 'var(--soui-neutral-fill-2)'");
+    expect(playground.code).toContain("color: 'var(--soui-neutral-text-5)'");
+
+    const fontProperty = playground.properties.find(
+      (property: { name: string }) => property.name === 'font',
+    );
+    expect(fontProperty.defaultValue).toEqual({ color: watermarkColor, fontSize: 16 });
+    expect(fontProperty.notHideDefaultValue).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- Put an `x` in "[ ]" to check a box) -->

### Types of changes

- [ ] New feature
- [x] Bug fix
- [x] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Others

### Background

| Information | Descriptions |
| --- | --- |
| Browser | Chrome |
| Version | N/A |
| OS | Windows |

Watermark 文档示例和沙盒使用了固定的浅色背景与低透明深色水印，切换暗色模式后背景样式不一致，水印内容也难以辨识。

本次将示例及沙盒内容区改为主题中性色变量，并使用在明暗背景下均清晰的中性水印色，同时补充回归测试覆盖示例与沙盒生成代码。

### Changelog

- 修复 Watermark 文档示例及沙盒在暗色模式下背景和水印颜色显示不清晰的问题。

### Playground id

N/A

### Other information

N/A