### PR TITLE
fix(steps): 修复箭头类型在多步骤场景下分隔符错位问题

### DIFF
--- a/docs/theme/components/style.ts
+++ b/docs/theme/components/style.ts
@@ -90,6 +90,7 @@ export default createUseStyles(
     },
     stickyHeader: {
       position: 'sticky',
+      zIndex: 10,
       top: 0,
       marginTop: -65,
       // marginBottom: 32,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.10.0-beta.5",
+  "version": "3.10.0-beta.6",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/steps/step.arrow.tsx
+++ b/packages/base/src/steps/step.arrow.tsx
@@ -1,13 +1,17 @@
-import classNames from 'classnames';
 import { util } from '@sheinx/hooks';
 import { useConfig } from '../config';
 import { StepsClasses } from './steps.type';
 import { StepStyleProps } from './steps.type';
 
+const Arrow = (
+  <svg viewBox='0 0 40 100' xmlns='http://www.w3.org/2000/svg' preserveAspectRatio='none'>
+    <path d='M 0 0 L 40 50 L 0 100' fill='currentColor' />
+  </svg>
+);
+
 const ArrowStep = (props: StepStyleProps) => {
   const { jssStyle, title, description, onChange, index, status } = props;
   const styles = jssStyle?.steps?.() || ({} as StepsClasses);
-  const rootClass = classNames(styles.arrow);
   const config = useConfig();
 
   const renderTitle = () => {
@@ -31,9 +35,19 @@ const ArrowStep = (props: StepStyleProps) => {
     );
   };
 
+  const renderArrow = () => {
+    return (
+      <div className={styles.arrowIcon}>
+        {Arrow}
+        {Arrow}
+      </div>
+    );
+  };
+
   return (
-    <div className={rootClass} onClick={onChange} dir={config.direction}>
+    <div className={styles.arrow} onClick={onChange} dir={config.direction}>
       {renderContent()}
+      {renderArrow()}
     </div>
   );
 };

--- a/packages/base/src/steps/step.tsx
+++ b/packages/base/src/steps/step.tsx
@@ -63,7 +63,7 @@ const Step = (props: StepPropsWidthContext) => {
     [styles.finish]: current > index,
     [styles.horizontalLabel]: labelPlacement === 'horizontal',
     [styles.verticalLabel]: labelPlacement === 'vertical',
-    [styles.widthDescription]: !!description,
+    [styles.withDescription]: !!description,
   });
 
   const handleChange = (e: React.MouseEvent<HTMLElement>) => {

--- a/packages/base/src/steps/steps.type.ts
+++ b/packages/base/src/steps/steps.type.ts
@@ -27,7 +27,8 @@ export type StepsClasses = {
   iconWrapper: string;
   dot: string;
   arrow: string;
-  widthDescription: string;
+  arrowIcon: string;
+  withDescription: string;
   default: string;
   click: string;
 };

--- a/packages/shineout-style/src/steps/steps.ts
+++ b/packages/shineout-style/src/steps/steps.ts
@@ -49,7 +49,7 @@ const stepsStyle: JsStyles<StepsClassType> = {
         left: -12,
       },
       '& $step:not(:last-child)': {
-        '&$widthDescription': {
+        '&$withDescription': {
           '&:after': {
             borderLeftWidth: 22,
             borderTopWidth: 28,
@@ -90,7 +90,7 @@ const stepsStyle: JsStyles<StepsClassType> = {
         },
       },
       '& $step:last-child': {
-        '&$widthDescription': {
+        '&$withDescription': {
           '&:before': {
             borderLeftWidth: 22,
             borderTopWidth: 28,
@@ -186,7 +186,7 @@ const stepsStyle: JsStyles<StepsClassType> = {
   large: {
     '&$arrow': {
       '& $step:not(:last-child)': {
-        '&$widthDescription': {
+        '&$withDescription': {
           '&:after': {
             top: 0,
             width: 30,
@@ -230,7 +230,7 @@ const stepsStyle: JsStyles<StepsClassType> = {
         },
       },
       '& $step:last-child': {
-        '&$widthDescription': {
+        '&$withDescription': {
           '&:before': {
             borderLeftWidth: 30,
             borderTopWidth: 36,
@@ -594,52 +594,63 @@ const stepsStyle: JsStyles<StepsClassType> = {
       '& $title': {},
     },
   },
+  arrowIcon: {
+    position: 'absolute',
+    top: 0,
+    right: 0.25,
+    bottom: 0,
+    transform: 'translateX(100%)',
+    zIndex: 1,
+    '@media (min-resolution: 2dppx)': {
+      right: 0,
+    },
+    '$withDescription &': {
+      transform: 'translateX(calc(100% - 0.5px))',
+      '@media (min-resolution: 2dppx)': {
+        transform: 'translateX(100%)',
+      },
+    },
+    '& > svg':{
+      display: 'block',
+      height: '100%',
+      color: Token.stepsFinishBackgroundColor,
+      '$process &': {
+        color: Token.stepsProcessBackgroundColor,
+      },
+      '$wait &': {
+        color: Token.stepsWaitBackgroundColor,
+      },
+      '&:last-child': {
+        position: 'relative',
+      },
+      '&:first-child': {
+        position: 'absolute',
+        top: 0,
+        left: 4,
+        color: 'white',
+        '$arrow[dir=rtl] &': {
+          right: 4,
+          left: 'auto'
+        }
+      }
+    },
+    '$step:last-child &': {
+      display: 'none',
+    },
+    '$arrow[dir=rtl] &': {
+      left: '0.25px',
+      right: 'auto',
+      transform: 'translateX(-100%)',
+      '& > svg': {
+        transform: "rotate(180deg)",
+      }
+    },
+  },
   arrow: {
     position: 'relative',
-    zIndex: 0,
-    '&$steps': {
-      overflow: 'hidden',
-    },
     '& $step': {
       marginRight: 4,
       paddingLeft: Token.stepsArrowPaddingX,
-      // before
-      '&:before': {
-        content: '""',
-        position: 'absolute',
-        width: 0,
-        height: 0,
-        top: 0,
-        borderLeftWidth: 16,
-        borderTopWidth: 20,
-        borderBottomWidth: 20,
-        borderLeftColor: '#ffffff',
-      },
-      '&[dir=ltr]:before': {
-        left: 0,
-      },
-      '&[dir=rtl]:before': {
-        right: 0,
-      },
-      // after
-      '&:after': {
-        content: '""',
-        position: 'absolute',
-        width: 0,
-        height: 0,
-
-        top: 0,
-        zIndex: 1,
-        borderLeftWidth: 16,
-        borderTopWidth: 20,
-        borderBottomWidth: 20,
-      },
-      '&[dir=ltr]:after': {
-        right: -16,
-      },
-      '&[dir=rtl]:after': {
-        left: -16,
-      },
     },
     '&$horizontal': {
       '& $horizontalLabel $title:after': {
@@ -648,31 +659,9 @@ const stepsStyle: JsStyles<StepsClassType> = {
     },
     '& $step:first-child': {
       padding: 0,
-      '&:before': {
-        display: 'none',
-      },
-      '&$widthDescription': {
-        '&:after': {
-          borderLeftWidth: 26,
-          borderTopWidth: 32,
-          borderBottomWidth: 32,
-        },
-        '&[dir=ltr]:after': { right: -26 },
-        '&[dir=rtl]:after': { left: -26 },
-      },
     },
     '& $step:last-child': {
       paddingRight: 0,
-      '&:after': {
-        display: 'none',
-      },
-      '&$widthDescription': {
-        '&:before': {
-          borderLeftWidth: 26,
-          borderTopWidth: 32,
-          borderBottomWidth: 32,
-        },
-      },
     },
 
     '& $description': {
@@ -689,16 +678,6 @@ const stepsStyle: JsStyles<StepsClassType> = {
     },
     '& $finish': {
       backgroundColor: Token.stepsFinishBackgroundColor,
-      '&:after': {
-        borderLeft: `16px solid ${Token.stepsFinishBackgroundColor}`,
-        borderTop: `20px solid transparent`,
-        borderBottom: `20px solid transparent`,
-      },
-      '&:before': {
-        // borderLeft: `16px solid #ffffff`,
-        // borderTop: `20px solid transparent`,
-        // borderBottom: `20px solid transparent`,
-      },
     },
     '& $process': {
       color: Token.stepsProcessFontColor,
@@ -706,39 +685,13 @@ const stepsStyle: JsStyles<StepsClassType> = {
       '& $description': {
         color: Token.stepsProcessFontColor,
       },
-      '&:after': {
-        borderLeft: `16px solid ${Token.stepsProcessBackgroundColor}`,
-        borderTop: `20px solid transparent`,
-        borderBottom: `20px solid transparent`,
-      },
-      '&[dir=ltr]:after': {
-        right: -16,
-      },
-      '&[dir=rtl]:after': {
-        left: -16,
-      },
-      '&:before': {
-        borderLeft: `16px solid #ffffff`,
-        borderTop: `20px solid transparent`,
-        borderBottom: `20px solid transparent`,
-      },
     },
     '& $wait': {
       color: Token.stepsWaitFontColor,
       // backgroundColor: Token.stepsWaitBackgroundColor,
       backgroundColor: Token.stepsWaitBackgroundColor,
-      '&:after': {
-        borderLeft: `16px solid ${Token.stepsWaitBackgroundColor}`,
-        borderTop: `20px solid transparent`,
-        borderBottom: `20px solid transparent`,
-      },
-      '&:before': {
-        borderLeft: `16px solid #ffffff`,
-        borderTop: `20px solid transparent`,
-        borderBottom: `20px solid transparent`,
-      },
     },
-    '& $widthDescription': {
+    '& $withDescription': {
       '& $content,$description': {
         textAlign: 'left',
       },
@@ -746,23 +699,9 @@ const stepsStyle: JsStyles<StepsClassType> = {
       '& $title': {
         marginBottom: Token.stepsDescriptionTitleMarginX,
       },
-      '&$process,$finish,$wait': {
-        '&:after': {
-          borderLeftWidth: 26,
-          borderTopWidth: 32,
-          borderBottomWidth: 32,
-        },
-        '&[dir=ltr]:after': { right: -26 },
-        '&[dir=rtl]:after': { left: -26 },
-        '&:before': {
-          borderLeftWidth: 26,
-          borderTopWidth: 32,
-          borderBottomWidth: 32,
-        },
-      },
     },
   },
-  widthDescription: {},
+  withDescription: {},
   default: {
     lineHeight: 0,
     '&$vertical': {

--- a/packages/shineout/src/steps/__doc__/changelog.cn.md
+++ b/packages/shineout/src/steps/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.10.0-beta.6
+2026-07-24
+### 💅 Style
+- 修复 `Steps` 箭头类型在多步骤场景下箭头分隔符错位的问题 ([#1760](https://github.com/sheinsight/shineout-next/pull/1760))
+
+
 ## 3.9.5-beta.9
 2025-12-29
 ### 🐞 BugFix

--- a/packages/shineout/src/steps/__test__/__snapshots__/steps.spec.tsx.snap
+++ b/packages/shineout/src/steps/__test__/__snapshots__/steps.spec.tsx.snap
@@ -132,7 +132,7 @@ exports[`Steps[Base] should render correctly about description 1`] = `
     class="soui-steps soui-steps-steps soui-steps-default soui-steps-horizontal"
   >
     <div
-      class="soui-steps-step soui-steps-finish soui-steps-finish soui-steps-vertical-label soui-steps-width-description"
+      class="soui-steps-step soui-steps-finish soui-steps-finish soui-steps-vertical-label soui-steps-with-description"
       dir="ltr"
     >
       <div
@@ -182,7 +182,7 @@ exports[`Steps[Base] should render correctly about description 1`] = `
       </div>
     </div>
     <div
-      class="soui-steps-step soui-steps-process soui-steps-vertical-label soui-steps-width-description"
+      class="soui-steps-step soui-steps-process soui-steps-vertical-label soui-steps-with-description"
       dir="ltr"
     >
       <div
@@ -221,7 +221,7 @@ exports[`Steps[Base] should render correctly about description 1`] = `
       </div>
     </div>
     <div
-      class="soui-steps-step soui-steps-wait soui-steps-vertical-label soui-steps-width-description"
+      class="soui-steps-step soui-steps-wait soui-steps-vertical-label soui-steps-with-description"
       dir="ltr"
     >
       <div
@@ -391,7 +391,7 @@ exports[`Steps[Base] should render correctly about direction 1`] = `
       class="soui-steps soui-steps-steps soui-steps-default soui-steps-vertical"
     >
       <div
-        class="soui-steps-step soui-steps-finish soui-steps-finish soui-steps-horizontal-label soui-steps-width-description"
+        class="soui-steps-step soui-steps-finish soui-steps-finish soui-steps-horizontal-label soui-steps-with-description"
         dir="ltr"
       >
         <div
@@ -441,7 +441,7 @@ exports[`Steps[Base] should render correctly about direction 1`] = `
         </div>
       </div>
       <div
-        class="soui-steps-step soui-steps-process soui-steps-horizontal-label soui-steps-width-description"
+        class="soui-steps-step soui-steps-process soui-steps-horizontal-label soui-steps-with-description"
         dir="ltr"
       >
         <div
@@ -480,7 +480,7 @@ exports[`Steps[Base] should render correctly about direction 1`] = `
         </div>
       </div>
       <div
-        class="soui-steps-step soui-steps-wait soui-steps-horizontal-label soui-steps-width-description"
+        class="soui-steps-step soui-steps-wait soui-steps-horizontal-label soui-steps-with-description"
         dir="ltr"
       >
         <div
@@ -630,7 +630,7 @@ exports[`Steps[Base] should render correctly about direction 1`] = `
       class="soui-steps soui-steps-steps soui-steps-dot soui-steps-vertical"
     >
       <div
-        class="soui-steps-step soui-steps-finish soui-steps-finish soui-steps-horizontal-label soui-steps-width-description"
+        class="soui-steps-step soui-steps-finish soui-steps-finish soui-steps-horizontal-label soui-steps-with-description"
         dir="ltr"
       >
         <div
@@ -668,7 +668,7 @@ exports[`Steps[Base] should render correctly about direction 1`] = `
         </div>
       </div>
       <div
-        class="soui-steps-step soui-steps-process soui-steps-horizontal-label soui-steps-width-description"
+        class="soui-steps-step soui-steps-process soui-steps-horizontal-label soui-steps-with-description"
         dir="ltr"
       >
         <div
@@ -706,7 +706,7 @@ exports[`Steps[Base] should render correctly about direction 1`] = `
         </div>
       </div>
       <div
-        class="soui-steps-step soui-steps-wait soui-steps-horizontal-label soui-steps-width-description"
+        class="soui-steps-step soui-steps-wait soui-steps-horizontal-label soui-steps-with-description"
         dir="ltr"
       >
         <div
@@ -951,7 +951,7 @@ exports[`Steps[Base] should render correctly about labelPlacement 1`] = `
     class="soui-steps soui-steps-steps soui-steps-default soui-steps-horizontal"
   >
     <div
-      class="soui-steps-step soui-steps-finish soui-steps-finish soui-steps-horizontal-label soui-steps-width-description"
+      class="soui-steps-step soui-steps-finish soui-steps-finish soui-steps-horizontal-label soui-steps-with-description"
       dir="ltr"
     >
       <div
@@ -995,7 +995,7 @@ exports[`Steps[Base] should render correctly about labelPlacement 1`] = `
       </div>
     </div>
     <div
-      class="soui-steps-step soui-steps-process soui-steps-horizontal-label soui-steps-width-description"
+      class="soui-steps-step soui-steps-process soui-steps-horizontal-label soui-steps-with-description"
       dir="ltr"
     >
       <div
@@ -1028,7 +1028,7 @@ exports[`Steps[Base] should render correctly about labelPlacement 1`] = `
       </div>
     </div>
     <div
-      class="soui-steps-step soui-steps-wait soui-steps-horizontal-label soui-steps-width-description"
+      class="soui-steps-step soui-steps-wait soui-steps-horizontal-label soui-steps-with-description"
       dir="ltr"
     >
       <div
@@ -1674,7 +1674,7 @@ exports[`Steps[Base] should render correctly about type 1`] = `
       style="margin-bottom: 32px;"
     >
       <div
-        class="soui-steps-step soui-steps-finish soui-steps-finish soui-steps-vertical-label soui-steps-width-description"
+        class="soui-steps-step soui-steps-finish soui-steps-finish soui-steps-vertical-label soui-steps-with-description"
         dir="ltr"
       >
         <div
@@ -1712,7 +1712,7 @@ exports[`Steps[Base] should render correctly about type 1`] = `
         </div>
       </div>
       <div
-        class="soui-steps-step soui-steps-process soui-steps-vertical-label soui-steps-width-description"
+        class="soui-steps-step soui-steps-process soui-steps-vertical-label soui-steps-with-description"
         dir="ltr"
       >
         <div
@@ -1750,7 +1750,7 @@ exports[`Steps[Base] should render correctly about type 1`] = `
         </div>
       </div>
       <div
-        class="soui-steps-step soui-steps-wait soui-steps-vertical-label soui-steps-width-description"
+        class="soui-steps-step soui-steps-wait soui-steps-vertical-label soui-steps-with-description"
         dir="ltr"
       >
         <div
@@ -1814,6 +1814,30 @@ exports[`Steps[Base] should render correctly about type 1`] = `
               Succeeded
             </div>
           </div>
+          <div
+            class="soui-steps-arrow-icon"
+          >
+            <svg
+              preserveAspectRatio="none"
+              viewBox="0 0 40 100"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M 0 0 L 40 50 L 0 100"
+                fill="currentColor"
+              />
+            </svg>
+            <svg
+              preserveAspectRatio="none"
+              viewBox="0 0 40 100"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M 0 0 L 40 50 L 0 100"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
         </div>
       </div>
       <div
@@ -1833,6 +1857,30 @@ exports[`Steps[Base] should render correctly about type 1`] = `
             >
               Complete information
             </div>
+          </div>
+          <div
+            class="soui-steps-arrow-icon"
+          >
+            <svg
+              preserveAspectRatio="none"
+              viewBox="0 0 40 100"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M 0 0 L 40 50 L 0 100"
+                fill="currentColor"
+              />
+            </svg>
+            <svg
+              preserveAspectRatio="none"
+              viewBox="0 0 40 100"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M 0 0 L 40 50 L 0 100"
+                fill="currentColor"
+              />
+            </svg>
           </div>
         </div>
       </div>
@@ -1854,6 +1902,30 @@ exports[`Steps[Base] should render correctly about type 1`] = `
               Pending
             </div>
           </div>
+          <div
+            class="soui-steps-arrow-icon"
+          >
+            <svg
+              preserveAspectRatio="none"
+              viewBox="0 0 40 100"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M 0 0 L 40 50 L 0 100"
+                fill="currentColor"
+              />
+            </svg>
+            <svg
+              preserveAspectRatio="none"
+              viewBox="0 0 40 100"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M 0 0 L 40 50 L 0 100"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
         </div>
       </div>
     </div>
@@ -1861,7 +1933,7 @@ exports[`Steps[Base] should render correctly about type 1`] = `
       class="soui-steps soui-steps-steps soui-steps-arrow soui-steps-horizontal"
     >
       <div
-        class="soui-steps-step soui-steps-finish soui-steps-finish soui-steps-vertical-label soui-steps-width-description"
+        class="soui-steps-step soui-steps-finish soui-steps-finish soui-steps-vertical-label soui-steps-with-description"
         dir="ltr"
       >
         <div
@@ -1883,10 +1955,34 @@ exports[`Steps[Base] should render correctly about type 1`] = `
               This is a description
             </div>
           </div>
+          <div
+            class="soui-steps-arrow-icon"
+          >
+            <svg
+              preserveAspectRatio="none"
+              viewBox="0 0 40 100"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M 0 0 L 40 50 L 0 100"
+                fill="currentColor"
+              />
+            </svg>
+            <svg
+              preserveAspectRatio="none"
+              viewBox="0 0 40 100"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M 0 0 L 40 50 L 0 100"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
         </div>
       </div>
       <div
-        class="soui-steps-step soui-steps-process soui-steps-vertical-label soui-steps-width-description"
+        class="soui-steps-step soui-steps-process soui-steps-vertical-label soui-steps-with-description"
         dir="ltr"
       >
         <div
@@ -1908,10 +2004,34 @@ exports[`Steps[Base] should render correctly about type 1`] = `
               Please fill in your home address and phone number
             </div>
           </div>
+          <div
+            class="soui-steps-arrow-icon"
+          >
+            <svg
+              preserveAspectRatio="none"
+              viewBox="0 0 40 100"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M 0 0 L 40 50 L 0 100"
+                fill="currentColor"
+              />
+            </svg>
+            <svg
+              preserveAspectRatio="none"
+              viewBox="0 0 40 100"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M 0 0 L 40 50 L 0 100"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
         </div>
       </div>
       <div
-        class="soui-steps-step soui-steps-wait soui-steps-vertical-label soui-steps-width-description"
+        class="soui-steps-step soui-steps-wait soui-steps-vertical-label soui-steps-with-description"
         dir="ltr"
       >
         <div
@@ -1932,6 +2052,30 @@ exports[`Steps[Base] should render correctly about type 1`] = `
             >
               This is a description
             </div>
+          </div>
+          <div
+            class="soui-steps-arrow-icon"
+          >
+            <svg
+              preserveAspectRatio="none"
+              viewBox="0 0 40 100"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M 0 0 L 40 50 L 0 100"
+                fill="currentColor"
+              />
+            </svg>
+            <svg
+              preserveAspectRatio="none"
+              viewBox="0 0 40 100"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M 0 0 L 40 50 L 0 100"
+                fill="currentColor"
+              />
+            </svg>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

修复 Steps 组件使用箭头（arrow）类型时，步骤数量 >3 且高亮非首个步骤时箭头分隔符错位变形的样式问题。

**方案：** 使用 SVG 绘制箭头替代原有 CSS border trick，箭头自适应高度，简化各尺寸/描述文字变体的适配逻辑。

## Changes

- 用 SVG path 替代 CSS border hack 实现箭头分隔
- 修正 typo: widthDescription → withDescription
- 移除不必要的 classNames 依赖
- 完善 RTL 方向适配

## Test Plan

- 验证 arrow 类型在 3/4/5+ 步骤下各高亮位置的显示
- 验证 small / default / large 尺寸表现
- 验证带 description 和不带 description 的场景
- 验证 RTL 布局下箭头方向正确