### PR TITLE
fix(date-picker): Enter key confirms value when needConfirm + inputable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.10.0-beta.6",
+  "version": "3.10.0-beta.7",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/date-picker/date-picker.tsx
+++ b/packages/base/src/date-picker/date-picker.tsx
@@ -265,18 +265,15 @@ const DatePicker = <Value extends DatePickerValueType>(props0: DatePickerProps<V
         onKeyDown={(e) => {
           if (e.key === 'Enter') {
             if (open) {
-              // needConfirm + inputable 时，回车视为确认操作
+              // needConfirm + inputable 时，先用宽松模式解析输入框的值，回车视为确认操作
               if (props.needConfirm && props.inputable) {
-                // 先用宽松模式解析当前输入框的值（模拟 blur 行为）
                 inputRef.current.inputRefs.forEach((el, index) => {
                   if (el && el.value) {
                     func.handleInputBlur(el.value, index);
                   }
                 });
-                handleClose(true);
-              } else {
-                handleClose();
               }
+              handleClose(props.needConfirm && props.inputable);
             } else {
               openPop();
             }

--- a/packages/base/src/date-picker/date-picker.tsx
+++ b/packages/base/src/date-picker/date-picker.tsx
@@ -265,7 +265,18 @@ const DatePicker = <Value extends DatePickerValueType>(props0: DatePickerProps<V
         onKeyDown={(e) => {
           if (e.key === 'Enter') {
             if (open) {
-              handleClose();
+              // needConfirm + inputable 时，回车视为确认操作
+              if (props.needConfirm && props.inputable) {
+                // 先用宽松模式解析当前输入框的值（模拟 blur 行为）
+                inputRef.current.inputRefs.forEach((el, index) => {
+                  if (el && el.value) {
+                    func.handleInputBlur(el.value, index);
+                  }
+                });
+                handleClose(true);
+              } else {
+                handleClose();
+              }
             } else {
               openPop();
             }

--- a/packages/shineout/src/date-picker/__doc__/changelog.cn.md
+++ b/packages/shineout/src/date-picker/__doc__/changelog.cn.md
@@ -1,3 +1,8 @@
+## 3.10.0-beta.7
+2026-07-27
+### 🐞 BugFix
+- 修复 `DatePicker` 同时开启 `needConfirm` 和 `inputable` 时，手动输入日期后按回车键值被清空而非提交的问题 ([#1761](https://github.com/sheinsight/shineout-next/pull/1761))
+
 ## 3.9.18-beta.2
 2026-07-14
 ### 🐞 BugFix

--- a/packages/shineout/src/date-picker/__example__/09-select-confirm.tsx
+++ b/packages/shineout/src/date-picker/__example__/09-select-confirm.tsx
@@ -39,6 +39,7 @@ const App: React.FC = () => {
         }}
         clearable
         needConfirm={isConfirm}
+        inputable
       />
     </div>
   );

--- a/packages/shineout/src/date-picker/__test__/datePicker.spec.tsx
+++ b/packages/shineout/src/date-picker/__test__/datePicker.spec.tsx
@@ -1811,3 +1811,40 @@ describe('DatePicker[Error/Warn]', () => {
   });
 });
 // defaultRangeMonth/timeZone/placeTitle
+describe('DatePicker[NeedConfirm + Inputable]', () => {
+  test('should apply input value when press Enter with needConfirm and inputable', async () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <DatePicker inputable needConfirm onChange={onChange} />,
+    );
+    const datePickerWrapper = container.querySelector(wrapper)!;
+    const datePickerResultWrapper = datePickerWrapper.querySelector(resultWrapper)!;
+
+    // 打开面板
+    fireEvent.click(datePickerResultWrapper);
+    await waitFor(async () => {
+      await delay(300);
+    });
+
+    const resultInput = datePickerResultWrapper.querySelector('input')!;
+    const tempTime = '2025-06-15';
+
+    // 输入日期
+    fireEvent.change(resultInput, { target: { value: tempTime } });
+    await waitFor(async () => {
+      await delay(100);
+    });
+
+    // 按 Enter 确认
+    fireEvent.keyDown(datePickerResultWrapper, { key: 'Enter' });
+    await waitFor(async () => {
+      await delay(300);
+    });
+
+    // 应该触发 onChange 且值不为空
+    expect(onChange).toHaveBeenCalled();
+    const calledValue = onChange.mock.calls[0][0];
+    expect(calledValue).toBeTruthy();
+    expect(calledValue).toContain('2025-06-15');
+  });
+});

--- a/packages/shineout/src/form/__example__/test-0012-datepicker-confirm.tsx
+++ b/packages/shineout/src/form/__example__/test-0012-datepicker-confirm.tsx
@@ -1,0 +1,54 @@
+/**
+ * cn - Form + DatePicker(needConfirm + inputable)
+ *    -- 验证在 Form name 受控用法下，DatePicker 同时开启 needConfirm 和 inputable 时，输入日期后回车可以正常提交值
+ * en - Form + DatePicker(needConfirm + inputable)
+ *    -- Verify DatePicker with needConfirm and inputable works correctly in Form controlled mode
+ */
+import React, { useState } from 'react';
+import { Form, DatePicker, Button } from 'shineout';
+
+interface FormValue {
+  date?: string;
+  dateRange?: string[];
+}
+
+const App: React.FC = () => {
+  const [formValue, setFormValue] = useState<FormValue>({});
+
+  return (
+    <div>
+      <h4>Form 受控 + DatePicker needConfirm + inputable</h4>
+      <Form
+        value={formValue}
+        onChange={(v) => {
+          console.log('Form onChange:', v);
+          setFormValue(v);
+        }}
+        onSubmit={(data) => {
+          console.log('Form onSubmit:', data);
+        }}
+      >
+        <Form.Item label="单选日期">
+          <DatePicker name="date" needConfirm inputable clearable />
+        </Form.Item>
+
+        <Form.Item label="范围日期">
+          <DatePicker name="dateRange" range needConfirm inputable clearable />
+        </Form.Item>
+
+        <Form.Item label="">
+          <Form.Submit>Submit</Form.Submit>
+          <Form.Reset>Reset</Form.Reset>
+          <Button onClick={() => setFormValue({})}>Clear</Button>
+        </Form.Item>
+      </Form>
+
+      <div style={{ marginTop: 16, padding: 12, background: '#f5f5f5' }}>
+        <strong>当前 Form 值：</strong>
+        <pre>{JSON.stringify(formValue, null, 2)}</pre>
+      </div>
+    </div>
+  );
+};
+
+export default App;


### PR DESCRIPTION
## Summary

修复 `DatePicker` 同时开启 `needConfirm` 和 `inputable` 时，手动输入日期后按回车键值被清空而非提交的问题。

现在回车键在该场景下等同于点击「确定」按钮，会正确提交输入的日期值。

## Changes

- 修复回车键在 needConfirm + inputable 模式下的行为，视为确认操作
- 回车前先用宽松模式解析输入框当前值，确保不完整格式也能被正确识别
- 新增单元测试覆盖该场景
- 新增 Form + DatePicker 集成示例验证受控用法不受影响
- 更新确认选择示例添加 inputable 属性

## Test Plan

- [x] 单元测试通过（76 cases all passed）
- [x] 类型检查无新增错误
- 手动验证：打开 09-select-confirm 示例 → 输入日期 → 按 Enter → 日期正确提交