### PR TITLE
chore(border-beam): add changelog and bump version to 3.10.0-beta.8

### DIFF
--- a/docs/markdown/shineout/changelog-common.md
+++ b/docs/markdown/shineout/changelog-common.md
@@ -1,3 +1,8 @@
+## 3.10.0-beta.8
+2026-07-29
+### 🆕 Feature
+- 新增 `BorderBeam` 边框流光组件 ([#1762](https://github.com/sheinsight/shineout-next/pull/1762))
+
 ## 3.10.0-beta.1
 2026-07-17
 ### 🆕 Feature

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.10.0-beta.7",
+  "version": "3.10.0-beta.8",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout/src/border-beam/__doc__/index.md
+++ b/packages/shineout/src/border-beam/__doc__/index.md
@@ -1,6 +1,6 @@
 ---
 name: BorderBeam
-group: Other
+group: Feedback
 version: 3.10.0
 ---
 


### PR DESCRIPTION
## Summary

- 新增 BorderBeam 组件的 changelog 条目（3.10.0-beta.8）
- 版本号从 `3.10.0-beta.7` 升至 `3.10.0-beta.8`
- BorderBeam 文档分组从 "Other" 调整为 "Feedback"

## Related PR
- #1762 (feat: add BorderBeam)

## Test Plan
- 文档/配置变更，无需额外测试