### PR TITLE
fix(table): fix radio click not working in filter column single-select mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.10.0-beta.8",
+  "version": "3.10.0-beta.9",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/table/thead-filter.tsx
+++ b/packages/base/src/table/thead-filter.tsx
@@ -80,7 +80,7 @@ export const FilterSelect = (props: TheadCommonProps) => {
             : (d: TableFilterData) => d.label;
           return (
             <div className={tableClasses.filterRadio}>
-              <Radio checked={active} jssStyle={props.jssStyle} />
+              <Radio checked={active} jssStyle={props.jssStyle} style={{ pointerEvents: 'none' }} />
               {renderProp(d)}
             </div>
           );

--- a/packages/shineout/src/table/__doc__/changelog.cn.md
+++ b/packages/shineout/src/table/__doc__/changelog.cn.md
@@ -1,3 +1,11 @@
+## 3.10.0-beta.9
+2026-07-29
+
+### 🐞 BugFix
+
+- 修复 `Table` 筛选列单选模式下，点击 Radio 选项无法选中的问题 ([#1764](https://github.com/sheinsight/shineout-next/pull/1764))
+
+
 ## 3.9.18-beta.1
 2026-07-13
 


### PR DESCRIPTION
## Summary

修复 Table 筛选列单选模式下，点击 Radio 选项无法触发选中的问题。

**原因**：Radio 组件内部的 `stopPropagation()` 阻止了点击事件冒泡到 Tree 节点的文本区域，导致 `setActive` 永远不会被调用。

**修复**：给 Radio 添加 `style={{ pointerEvents: 'none' }}`，因为它在此场景中仅用于展示选中状态，不需要接收鼠标事件。点击事件会穿透 Radio 直接到达父级 div，正常触发选中逻辑。

## Test Plan

1. 打开 Table 筛选列示例（如 Salary 列的单选筛选）
2. 点击弹出面板中的 Radio 选项
3. 验证选项能正常选中并高亮
4. 验证多选模式（如 Age 列的 Checkbox）仍然正常工作