### PR TITLE
fix(border-beam): use CSS variable to avoid micro-frontend mask merge

### DIFF
--- a/docs/theme/components/example/codesandbox/index.tsx
+++ b/docs/theme/components/example/codesandbox/index.tsx
@@ -40,7 +40,7 @@ const Codesandbox = (props: CodesandboxProps) => {
     "react-dom/client": "react-dom@18.3.1",
     "react-router-dom": "6.11.2",
     "react-jss": "10.9.2",
-    "shineout": "3.9.17-beta.3",
+    "shineout": "3.10.0-beta.10",
     "classnames": "2.3.2",
     "immer": "10.0.2"
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.10.0-beta.9",
+  "version": "3.10.0-beta.10",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/border-beam/border-beam.ts
+++ b/packages/shineout-style/src/border-beam/border-beam.ts
@@ -24,9 +24,10 @@ const borderBeamStyle: JsStyles<keyof BorderBeamClasses> = {
     pointerEvents: 'none',
     padding: 'var(--soui-border-beam-line-width, 1px)',
     [MASK_SUPPORT]: {
-      WebkitMask: 'linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)',
+      '--soui-border-beam-mask': 'linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)',
+      WebkitMask: 'var(--soui-border-beam-mask)',
+      mask: 'var(--soui-border-beam-mask)',
       WebkitMaskComposite: 'xor',
-      mask: 'linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)',
       maskComposite: 'exclude',
       [PATH_SUPPORT]: {
         display: 'block',


### PR DESCRIPTION
## 问题

微前端（如 Alita）的 CSS 处理器在做样式隔离时，会错误地将 `mask-composite` / `-webkit-mask-composite` 合并进 `mask` 简写属性，导致镂空边框效果失效。

转换前（正确）：
```css
mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
mask-composite: exclude;
-webkit-mask-composite: xor;
```

转换后（错误）：
```css
mask: linear-gradient(...) content-box xor, linear-gradient(...);
```

## 修复方案

将 mask 的值通过 CSS 自定义变量 (`var()`) 包裹，微前端 CSS 处理器遇到 `var()` 时无法解析内部值，从而跳过合并逻辑，保持 `mask` 和 `mask-composite` 属性的独立性。

## 变更内容

- `packages/shineout-style/src/border-beam/border-beam.ts`: 用 `--soui-border-beam-mask` CSS 变量包裹 mask 值