### PR TITLE
fix(table): 修复窗口 resize 时右固定列阴影状态未更新的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.10.0-beta.12",
+  "version": "3.10.0-beta.13",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-table/use-table-layout.tsx
+++ b/packages/hooks/src/components/use-table/use-table-layout.tsx
@@ -279,6 +279,7 @@ const useTableLayout = (props: UseTableLayoutProps) => {
   const handleResize = usePersistFn((_, dir: { x: boolean; y: boolean; sX: boolean }) => {
     checkScroll();
     syncScrollWidth();
+    checkFloat();
     if (dir.x) {
       //table 宽度发生变化的时候, 需要同步 colgroup 宽度 给拖拽列或者固定列使用
       resetColGroup();

--- a/packages/shineout/src/table/__doc__/changelog.cn.md
+++ b/packages/shineout/src/table/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.10.0-beta.13
+2026-08-06
+
+### 🐞 BugFix
+
+- 修复 `Table` 在浏览器窗口 resize 时，右固定列的阴影效果状态未正确更新，导致固定列边框和阴影异常消失的问题 ([#1767](https://github.com/sheinsight/shineout-next/pull/1767))
+
 ## 3.10.0-beta.12
 2026-08-04
 


### PR DESCRIPTION
## Summary

修复 Table 组件在浏览器窗口 resize 时，右固定列的阴影效果和分隔边框偶发性消失的问题。

## Root Cause

容器尺寸变化时（ResizeObserver 回调），只更新了滚动状态但未重新计算固定列的 float 状态，导致 `floatRight` 状态过时。

## Fix

在 resize 回调中增加 `checkFloat()` 调用，确保每次容器尺寸变化后固定列阴影状态被正确更新。

## Test Plan

- 在非 100% 缩放比例下，来回调整浏览器窗口宽度
- 验证右固定列阴影在表格可横向滚动时始终显示
- 验证左固定列行为不受影响

## Playground ID
d4d03aee-5c01-4a77-ae35-e574f936145a