### PR TITLE
fix(table): 修复右固定列在容器宽度临界点时边框和阴影消失的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.10.0-beta.13",
+  "version": "3.10.0-beta.14",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-table/use-table-layout.tsx
+++ b/packages/hooks/src/components/use-table/use-table-layout.tsx
@@ -92,7 +92,9 @@ const useTableLayout = (props: UseTableLayoutProps) => {
     context.clientWidth = scrollEl.clientWidth;
     if (scrollEl.clientHeight === 0) return;
     const overHeight = scrollEl.scrollHeight > scrollEl.clientHeight;
-    const overWidth = scrollEl.scrollWidth > context.clientWidth;
+    // 使用 > 1 容差，与 checkFloat 中 floatRight 的判断保持一致
+    // 避免缩放比例下亚像素误差导致 isScrollX=true 但 floatRight=false 的不一致状态
+    const overWidth = scrollEl.scrollWidth - context.clientWidth > 1;
     const newScrollBarWidth = overHeight ? scrollEl.offsetWidth - scrollEl.clientWidth : 0;
     if (newScrollBarWidth !== scrollBarWidth) setScrollBarWidth(newScrollBarWidth);
 
@@ -279,7 +281,6 @@ const useTableLayout = (props: UseTableLayoutProps) => {
   const handleResize = usePersistFn((_, dir: { x: boolean; y: boolean; sX: boolean }) => {
     checkScroll();
     syncScrollWidth();
-    checkFloat();
     if (dir.x) {
       //table 宽度发生变化的时候, 需要同步 colgroup 宽度 给拖拽列或者固定列使用
       resetColGroup();

--- a/packages/shineout/src/table/__doc__/changelog.cn.md
+++ b/packages/shineout/src/table/__doc__/changelog.cn.md
@@ -1,9 +1,9 @@
-## 3.10.0-beta.13
+## 3.10.0-beta.14
 2026-08-06
 
 ### 🐞 BugFix
 
-- 修复 `Table` 在浏览器窗口 resize 时，右固定列的阴影效果状态未正确更新，导致固定列边框和阴影异常消失的问题 ([#1767](https://github.com/sheinsight/shineout-next/pull/1767))
+- 修复 `Table` 右固定列在容器宽度变化临界点时边框和阴影异常消失的问题 ([#1768](https://github.com/sheinsight/shineout-next/pull/1768))
 
 ## 3.10.0-beta.12
 2026-08-04


### PR DESCRIPTION
## Summary

修复 Table 右固定列在容器宽度变化到临界点时，边框和阴影异常消失的问题。

## Root Cause

`isScrollX` 使用 `scrollWidth > clientWidth`（差值 >= 1px 即为 true），而 `floatRight` 使用 `scrollWidth - clientWidth - scrollLeft > 1`（差值 > 1 才为 true）。在非 100% 缩放下，亚像素误差导致两者在临界点不一致：`isScrollX = true` 使右固定列保持 `position: sticky` 遮挡了相邻列的 border，但 `floatRight = false` 使阴影消失。

## Fix

将 `isScrollX` 的判断容差从 `> 0` 改为 `> 1`，与 `floatRight` 保持一致，消除临界点的状态不一致。

## Test Plan

- 在非 100% 缩放比例下（如 90%/110%），缓慢拖拽容器宽度到固定列效果消失的临界点
- 验证右固定列的边框和阴影同步消失/出现，不会出现 sticky 残留但无阴影的中间态