### PR TITLE
fix(tabs): fix scroll position reset in button shape mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.10.0-beta.14",
+  "version": "3.10.0-beta.15",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/tabs/tab.tsx
+++ b/packages/base/src/tabs/tab.tsx
@@ -94,12 +94,14 @@ const Tab = (props: TabProps, ref: any) => {
   };
 
   if (shape === 'button') {
+    const { ref: buttonRef, ...restContainerProps } = containerProps;
     return (
       <Button
         jssStyle={{ button: buttonStyle }}
         disabled={disabled}
         type={isActive ? 'primary' : 'secondary'}
-        {...containerProps}
+        {...restContainerProps}
+        {...({ onRef: buttonRef } as any)}
       >
         {tab}
       </Button>

--- a/packages/base/src/tabs/tabs-header.tsx
+++ b/packages/base/src/tabs/tabs-header.tsx
@@ -231,7 +231,15 @@ const TabsHeader = (props: TabsHeaderProps) => {
           {shape === 'button' && (
             <Button.Group jssStyle={{ button: buttonStyle, buttonGroup: buttonGroupStyle }}>
               {tabs.map((tab, index) => {
-                return <Tab key={index} {...tab}></Tab>;
+                return (
+                  <Tab
+                    key={index}
+                    {...tab}
+                    ref={(node: any) => {
+                      tabRef.current[tab.id] = node;
+                    }}
+                  ></Tab>
+                );
               })}
             </Button.Group>
           )}

--- a/packages/shineout/src/tabs/__doc__/changelog.cn.md
+++ b/packages/shineout/src/tabs/__doc__/changelog.cn.md
@@ -1,3 +1,8 @@
+## 3.10.0-beta.15
+2026-08-07
+### 🐞 BugFix
+- 修复 `Tabs` button 模式下点击标签滚动条回弹到起始位置的问题 ([#1769](https://github.com/sheinsight/shineout-next/pull/1769))
+
 ## 3.9.13-beta.5
 2026-04-03
 ### 💅 Style


### PR DESCRIPTION
## Summary

修复 Tabs 组件在 `shape="button"` 模式下，标签数量较多出现滚动时，点击标签会导致滚动条回弹到起始位置的问题。

## Root Cause

button 模式下 Tab 未正确传递 ref，导致滚动计算时无法获取当前激活标签的 DOM 位置，错误地将滚动偏移重置为 0。

## Fix

- 在 `tabs-header.tsx` 中为 button 模式的 Tab 添加 ref callback
- 在 `tab.tsx` 中将 React ref 通过 `onRef` prop 正确传递给 Button 组件

## Test Plan

1. 打开 Tabs 滚动示例（shape=button，100 个标签）
2. 向右滚动到 Tab 20 附近
3. 点击 Tab 20，确认滚动条不会回弹到起始位置
4. 验证其他 shape（line/card/dash）滚动行为无回归