### PR TITLE
fix(select): clearable button not visible when showArrow={false}

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.10.0-beta.16",
+  "version": "3.10.0-beta.17",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/select/select.tsx
+++ b/packages/base/src/select/select.tsx
@@ -534,7 +534,6 @@ function Select<DataItem, Value>(props0: SelectPropsBase<DataItem, Value>) {
   });
 
   const renderClearable = () => {
-    if (!multiple !== undefined && !showArrow) return null;
     const defaultIcon = multiple ? Icons.select.More : Icons.select.DropdownArrow;
     const arrow = (
       <span
@@ -553,7 +552,7 @@ function Select<DataItem, Value>(props0: SelectPropsBase<DataItem, Value>) {
     return (
       <>
         {close}
-        {!open && arrow}
+        {(multiple || showArrow) && !open && arrow}
       </>
     );
   };

--- a/packages/shineout/src/select/__doc__/changelog.cn.md
+++ b/packages/shineout/src/select/__doc__/changelog.cn.md
@@ -1,3 +1,8 @@
+## 3.10.0-beta.17
+2026-08-12
+### 🐞 BugFix
+- 修复 `Select` 设置 `showArrow={false}` 后，`clearable` 清除按钮也无法显示的问题 ([#1771](https://github.com/sheinsight/shineout-next/pull/1771))
+
 ## 3.10.0-beta.2
 2026-07-21
 ### 🐞 BugFix


### PR DESCRIPTION
## Summary

修复 Select 组件设置 `showArrow={false}` 后，`clearable` 清除按钮无法显示的问题。

## 原因

`renderClearable` 函数中存在错误的前置判断条件，导致 `showArrow={false}` 时整个清除按钮渲染被跳过。

## 修复内容

- 移除 `renderClearable` 中错误的 early return 逻辑
- 箭头图标的渲染改由 `showArrow` 和 `multiple` 共同控制，确保清除按钮不受影响

## Test Plan

- Select 单选模式：`showArrow={false}` + `clearable`，选中值后 hover 可见清除按钮
- Select 多选模式：`showArrow={false}` + `clearable`，选中值后 hover 可见清除按钮
- Select 默认（`showArrow={true}`）：行为不变