### PR TITLE
fix(docs): prevent menu item text wrapping

### DIFF
--- a/docs/theme/layout/desktop/menu/index.tsx
+++ b/docs/theme/layout/desktop/menu/index.tsx
@@ -170,7 +170,7 @@ const MenuComponent = () => {
                       >
                         {component.title[state.locales]}
 
-                        {component.version && <Tag color='success'>{component.version}</Tag>}
+                        {component.version && <Tag color='success' className="version">{component.version}</Tag>}
                       </MenuItem>
                     )
                   );

--- a/docs/theme/layout/desktop/style.ts
+++ b/docs/theme/layout/desktop/style.ts
@@ -128,6 +128,13 @@ export default createUseStyles(
           borderRadius: 4,
           marginTop: 4,
           marginBottom: 4,
+          position: 'relative',
+          '& > .version': {
+            position: 'absolute',
+            right: 8,
+            top: '50%',
+            transform: 'translateY(-50%)',
+          },
           '&.active': {
             color: 'var(--soui-brand-6)',
             fontWeight: 500,


### PR DESCRIPTION
## 修复内容

菜单项文字过多时会引起换行，导致不美观。

## 修改方案

- 将 version Tag 添加 `className="version"` 并改为绝对定位（`position: absolute`），避免与菜单文字争抢空间
- 菜单 `li` 元素添加 `position: relative` 作为定位参考