### PR TITLE
fix(badge): support color prop in dot + text mode & add unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.10.0-beta.18",
+  "version": "3.10.0-beta.19",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/base/src/badge/badge.tsx
+++ b/packages/base/src/badge/badge.tsx
@@ -88,6 +88,7 @@ const Badge = (props: BadgeProps) => {
     return (
       <>
         <span
+          style={{ background: color }}
           className={classNames(
             badgeStyle.textDot,
             status && {

--- a/packages/shineout/src/badge/__doc__/changelog.cn.md
+++ b/packages/shineout/src/badge/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.10.0-beta.19
+2026-08-14
+
+### 🐞 BugFix
+
+- 修复 `Badge` 同时使用 `dot` 和 `text` 属性时 `color` 不生效的问题 ([#1774](https://github.com/sheinsight/shineout-next/pull/1774))
+
 ## 3.9.13-beta.3
 2026-04-02
 

--- a/packages/shineout/src/badge/__example__/04-dot.tsx
+++ b/packages/shineout/src/badge/__example__/04-dot.tsx
@@ -14,6 +14,8 @@ export default () => {
       <Badge dot>
         <Avatar></Avatar>
       </Badge>
+
+      <Badge dot color="black" text="自定义文案"></Badge>
     </div>
   );
 };

--- a/packages/shineout/src/badge/__test__/__snapshots__/badge.spec.tsx.snap
+++ b/packages/shineout/src/badge/__test__/__snapshots__/badge.spec.tsx.snap
@@ -1,0 +1,408 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Badge[Base] should render correctly  1`] = `
+<div
+  style="display: flex; align-items: center; gap: 32px;"
+>
+  <span
+    class="soui-badge soui-badge-badge"
+  >
+    <div
+      style="height: 32px; width: 32px; border-radius: 4px; background: rgb(232, 235, 240); display: flex; align-items: center; justify-content: center;"
+    >
+      <svg
+        fill="rgba(179, 183, 193, 1)"
+        height="16px"
+        viewBox="0 0 24 24"
+        width="16px"
+      >
+        <path
+          d="M12 13C15.3137 13 18 10.3137 18 7C18 3.68629 15.3137 1 12 1C8.68629 1 6 3.68629 6 7C6 10.3137 8.68629 13 12 13Z"
+        />
+        <path
+          d="M8.16949 15C4.76218 15 2 17.7622 2 21.1695C2 21.6282 2.37183 22 2.83051 22H21.1695C21.6282 22 22 21.6282 22 21.1695C22 17.7622 19.2378 15 15.8305 15H8.16949Z"
+        />
+      </svg>
+    </div>
+    <sup
+      class="soui-badge-count soui-badge-number soui-badge-single-word"
+    >
+      1
+    </sup>
+  </span>
+  <span
+    class="soui-badge soui-badge-badge"
+  >
+    <button
+      class="soui-switch soui-switch-wrapper"
+      role="switch"
+      type="button"
+    >
+      <input
+        style="display: none;"
+        tabindex="0"
+        type="checkbox"
+      />
+      <div
+        class="soui-switch-indicator"
+        dir="ltr"
+      />
+      <div
+        class="soui-switch-content"
+      >
+        <div
+          class="soui-switch-text-padding"
+        />
+      </div>
+    </button>
+  </span>
+</div>
+`;
+
+exports[`Badge[Base] should render correctly about dot 1`] = `
+<div
+  style="display: flex; align-items: center; gap: 32px;"
+>
+  <span
+    class="soui-badge soui-badge-badge"
+  >
+    <div
+      style="height: 32px; width: 32px; border-radius: 4px; background: rgb(232, 235, 240); display: flex; align-items: center; justify-content: center;"
+    >
+      <svg
+        fill="rgba(179, 183, 193, 1)"
+        height="16px"
+        viewBox="0 0 24 24"
+        width="16px"
+      >
+        <path
+          d="M12 13C15.3137 13 18 10.3137 18 7C18 3.68629 15.3137 1 12 1C8.68629 1 6 3.68629 6 7C6 10.3137 8.68629 13 12 13Z"
+        />
+        <path
+          d="M8.16949 15C4.76218 15 2 17.7622 2 21.1695C2 21.6282 2.37183 22 2.83051 22H21.1695C21.6282 22 22 21.6282 22 21.1695C22 17.7622 19.2378 15 15.8305 15H8.16949Z"
+        />
+      </svg>
+    </div>
+    <sup
+      class="soui-badge-dot"
+    />
+  </span>
+  <span
+    class="soui-badge soui-badge-badge soui-badge-text-badge"
+  >
+    <span
+      class="soui-badge-text-dot"
+      style="background: black;"
+    />
+    <span
+      class="soui-badge-text"
+    >
+      自定义文案
+    </span>
+  </span>
+</div>
+`;
+
+exports[`Badge[Base] should render correctly about no children 1`] = `
+<div
+  style="display: flex; align-items: center; gap: 42px;"
+>
+  <span
+    class="soui-badge soui-badge-badge soui-badge-standalone"
+  >
+    <sup
+      class="soui-badge-count soui-badge-number soui-badge-single-word"
+    >
+      1
+    </sup>
+  </span>
+  <span
+    class="soui-badge soui-badge-badge soui-badge-standalone"
+  >
+    <sup
+      class="soui-badge-count soui-badge-number soui-badge-multiple-words"
+      style="background: rgb(250, 173, 20);"
+    >
+      99+
+    </sup>
+  </span>
+</div>
+`;
+
+exports[`Badge[Base] should render correctly about overflow count 1`] = `
+<div
+  style="display: flex; align-items: center; gap: 32px;"
+>
+  <span
+    class="soui-badge soui-badge-badge"
+  >
+    <div
+      style="height: 32px; width: 32px; border-radius: 4px; background: rgb(232, 235, 240); display: flex; align-items: center; justify-content: center;"
+    >
+      <svg
+        fill="rgba(179, 183, 193, 1)"
+        height="16px"
+        viewBox="0 0 24 24"
+        width="16px"
+      >
+        <path
+          d="M12 13C15.3137 13 18 10.3137 18 7C18 3.68629 15.3137 1 12 1C8.68629 1 6 3.68629 6 7C6 10.3137 8.68629 13 12 13Z"
+        />
+        <path
+          d="M8.16949 15C4.76218 15 2 17.7622 2 21.1695C2 21.6282 2.37183 22 2.83051 22H21.1695C21.6282 22 22 21.6282 22 21.1695C22 17.7622 19.2378 15 15.8305 15H8.16949Z"
+        />
+      </svg>
+    </div>
+    <sup
+      class="soui-badge-count soui-badge-number soui-badge-multiple-words"
+    >
+      99
+    </sup>
+  </span>
+  <span
+    class="soui-badge soui-badge-badge"
+  >
+    <div
+      style="height: 32px; width: 32px; border-radius: 4px; background: rgb(232, 235, 240); display: flex; align-items: center; justify-content: center;"
+    >
+      <svg
+        fill="rgba(179, 183, 193, 1)"
+        height="16px"
+        viewBox="0 0 24 24"
+        width="16px"
+      >
+        <path
+          d="M12 13C15.3137 13 18 10.3137 18 7C18 3.68629 15.3137 1 12 1C8.68629 1 6 3.68629 6 7C6 10.3137 8.68629 13 12 13Z"
+        />
+        <path
+          d="M8.16949 15C4.76218 15 2 17.7622 2 21.1695C2 21.6282 2.37183 22 2.83051 22H21.1695C21.6282 22 22 21.6282 22 21.1695C22 17.7622 19.2378 15 15.8305 15H8.16949Z"
+        />
+      </svg>
+    </div>
+    <sup
+      class="soui-badge-count soui-badge-number soui-badge-multiple-words"
+    >
+      9+
+    </sup>
+  </span>
+  <span
+    class="soui-badge soui-badge-badge"
+  >
+    <div
+      style="height: 32px; width: 32px; border-radius: 4px; background: rgb(232, 235, 240); display: flex; align-items: center; justify-content: center;"
+    >
+      <svg
+        fill="rgba(179, 183, 193, 1)"
+        height="16px"
+        viewBox="0 0 24 24"
+        width="16px"
+      >
+        <path
+          d="M12 13C15.3137 13 18 10.3137 18 7C18 3.68629 15.3137 1 12 1C8.68629 1 6 3.68629 6 7C6 10.3137 8.68629 13 12 13Z"
+        />
+        <path
+          d="M8.16949 15C4.76218 15 2 17.7622 2 21.1695C2 21.6282 2.37183 22 2.83051 22H21.1695C21.6282 22 22 21.6282 22 21.1695C22 17.7622 19.2378 15 15.8305 15H8.16949Z"
+        />
+      </svg>
+    </div>
+    <sup
+      class="soui-badge-count soui-badge-number soui-badge-multiple-words"
+    >
+      99+
+    </sup>
+  </span>
+  <span
+    class="soui-badge soui-badge-badge"
+  >
+    <div
+      style="height: 32px; width: 32px; border-radius: 4px; background: rgb(232, 235, 240); display: flex; align-items: center; justify-content: center;"
+    >
+      <svg
+        fill="rgba(179, 183, 193, 1)"
+        height="16px"
+        viewBox="0 0 24 24"
+        width="16px"
+      >
+        <path
+          d="M12 13C15.3137 13 18 10.3137 18 7C18 3.68629 15.3137 1 12 1C8.68629 1 6 3.68629 6 7C6 10.3137 8.68629 13 12 13Z"
+        />
+        <path
+          d="M8.16949 15C4.76218 15 2 17.7622 2 21.1695C2 21.6282 2.37183 22 2.83051 22H21.1695C21.6282 22 22 21.6282 22 21.1695C22 17.7622 19.2378 15 15.8305 15H8.16949Z"
+        />
+      </svg>
+    </div>
+    <sup
+      class="soui-badge-count soui-badge-number soui-badge-multiple-words"
+    >
+      999+
+    </sup>
+  </span>
+</div>
+`;
+
+exports[`Badge[Base] should render correctly about small size 1`] = `
+<div
+  style="display: flex; align-items: center; gap: 24px;"
+>
+  <span
+    class="soui-badge soui-badge-badge"
+  >
+    <div
+      style="height: 32px; width: 32px; border-radius: 4px; background: rgb(232, 235, 240); display: flex; align-items: center; justify-content: center;"
+    >
+      <svg
+        fill="rgba(179, 183, 193, 1)"
+        height="16px"
+        viewBox="0 0 24 24"
+        width="16px"
+      >
+        <path
+          d="M12 13C15.3137 13 18 10.3137 18 7C18 3.68629 15.3137 1 12 1C8.68629 1 6 3.68629 6 7C6 10.3137 8.68629 13 12 13Z"
+        />
+        <path
+          d="M8.16949 15C4.76218 15 2 17.7622 2 21.1695C2 21.6282 2.37183 22 2.83051 22H21.1695C21.6282 22 22 21.6282 22 21.1695C22 17.7622 19.2378 15 15.8305 15H8.16949Z"
+        />
+      </svg>
+    </div>
+    <sup
+      class="soui-badge-small soui-badge-count soui-badge-number soui-badge-multiple-words"
+    >
+      99
+    </sup>
+  </span>
+  <span
+    class="soui-badge soui-badge-badge"
+  >
+    <div
+      style="height: 32px; width: 32px; border-radius: 4px; background: rgb(232, 235, 240); display: flex; align-items: center; justify-content: center;"
+    >
+      <svg
+        fill="rgba(179, 183, 193, 1)"
+        height="16px"
+        viewBox="0 0 24 24"
+        width="16px"
+      >
+        <path
+          d="M12 13C15.3137 13 18 10.3137 18 7C18 3.68629 15.3137 1 12 1C8.68629 1 6 3.68629 6 7C6 10.3137 8.68629 13 12 13Z"
+        />
+        <path
+          d="M8.16949 15C4.76218 15 2 17.7622 2 21.1695C2 21.6282 2.37183 22 2.83051 22H21.1695C21.6282 22 22 21.6282 22 21.1695C22 17.7622 19.2378 15 15.8305 15H8.16949Z"
+        />
+      </svg>
+    </div>
+    <sup
+      class="soui-badge-count soui-badge-number soui-badge-multiple-words"
+    >
+      99
+    </sup>
+  </span>
+</div>
+`;
+
+exports[`Badge[Base] should render correctly about status 1`] = `
+<div>
+  <div
+    style="display: flex; align-items: center; gap: 24px; margin-bottom: 32px;"
+  >
+    <span
+      class="soui-badge soui-badge-badge soui-badge-text-badge"
+    >
+      <span
+        class="soui-badge-text-dot soui-badge-default"
+      />
+    </span>
+    <span
+      class="soui-badge soui-badge-badge soui-badge-text-badge"
+    >
+      <span
+        class="soui-badge-text-dot soui-badge-processing"
+      />
+    </span>
+    <span
+      class="soui-badge soui-badge-badge soui-badge-text-badge"
+    >
+      <span
+        class="soui-badge-text-dot soui-badge-error"
+      />
+    </span>
+    <span
+      class="soui-badge soui-badge-badge soui-badge-text-badge"
+    >
+      <span
+        class="soui-badge-text-dot soui-badge-warning"
+      />
+    </span>
+    <span
+      class="soui-badge soui-badge-badge soui-badge-text-badge"
+    >
+      <span
+        class="soui-badge-text-dot soui-badge-success"
+      />
+    </span>
+  </div>
+  <div
+    style="display: flex; align-items: center; gap: 24px;"
+  >
+    <span
+      class="soui-badge soui-badge-badge soui-badge-text-badge"
+    >
+      <span
+        class="soui-badge-text-dot soui-badge-default"
+      />
+      <span
+        class="soui-badge-text"
+      >
+        Default
+      </span>
+    </span>
+    <span
+      class="soui-badge soui-badge-badge soui-badge-text-badge"
+    >
+      <span
+        class="soui-badge-text-dot soui-badge-processing"
+      />
+      <span
+        class="soui-badge-text"
+      >
+        Processing
+      </span>
+    </span>
+    <span
+      class="soui-badge soui-badge-badge soui-badge-text-badge"
+    >
+      <span
+        class="soui-badge-text-dot soui-badge-error"
+      />
+      <span
+        class="soui-badge-text"
+      >
+        Error
+      </span>
+    </span>
+    <span
+      class="soui-badge soui-badge-badge soui-badge-text-badge"
+    >
+      <span
+        class="soui-badge-text-dot soui-badge-warning"
+      />
+      <span
+        class="soui-badge-text"
+      >
+        Warning
+      </span>
+    </span>
+    <span
+      class="soui-badge soui-badge-badge soui-badge-text-badge"
+    >
+      <span
+        class="soui-badge-text-dot soui-badge-success"
+      />
+      <span
+        class="soui-badge-text"
+      >
+        Success
+      </span>
+    </span>
+  </div>
+</div>
+`;

--- a/packages/shineout/src/badge/__test__/badge.spec.tsx
+++ b/packages/shineout/src/badge/__test__/badge.spec.tsx
@@ -1,0 +1,198 @@
+import { cleanup, render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Badge from '..';
+import mountTest from '../../tests/mountTest';
+import {
+  childrenTest,
+  classContentTest,
+  createClassName,
+  displayTest,
+  snapshotTest,
+  textContentTest,
+} from '../../tests/utils';
+import BadgeBase from '../__example__/01-base';
+import BadgeNoChildren from '../__example__/02-nochildren';
+import BadgeOverflowCount from '../__example__/03-overflowcount';
+import BadgeSmallSize from '../__example__/03-small-size';
+import BadgeDot from '../__example__/04-dot';
+import BadgeStatus from '../__example__/05-status';
+
+const SO_PREFIX = 'badge';
+const originClasses = ['badge', 'textBadge', 'standalone'];
+const originItemClasses = [
+  'count',
+  'custom',
+  'number',
+  'small',
+  'dot',
+  'textDot',
+  'text',
+  'singleWord',
+  'multipleWords',
+  'warning',
+  'success',
+  'error',
+  'default',
+  'processing',
+];
+
+const { badge, textBadge, standalone, count, number, small, dot, textDot, text, singleWord, multipleWords } =
+  createClassName(SO_PREFIX, originClasses, originItemClasses);
+
+afterEach(cleanup);
+mountTest(<Badge count={1} />);
+
+describe('Badge[Base]', () => {
+  displayTest(Badge, 'ShineoutBadge');
+  childrenTest(Badge, badge);
+
+  test('should render when set className', () => {
+    const { container } = render(<Badge count={1} className="demo" />);
+    const wrapper = container.querySelector(badge)!;
+    expect(wrapper.classList.contains('demo')).toBe(true);
+  });
+  snapshotTest(<BadgeBase />);
+  snapshotTest(<BadgeNoChildren />, 'about no children');
+  snapshotTest(<BadgeOverflowCount />, 'about overflow count');
+  snapshotTest(<BadgeSmallSize />, 'about small size');
+  snapshotTest(<BadgeDot />, 'about dot');
+  snapshotTest(<BadgeStatus />, 'about status');
+
+  test('should render default with count', () => {
+    const { container } = render(<Badge count={5}><span>child</span></Badge>);
+    const wrapper = container.querySelector(badge)!;
+    expect(wrapper).toBeInTheDocument();
+    const sup = wrapper.querySelector('sup')!;
+    expect(sup).toBeInTheDocument();
+    classContentTest(sup, number);
+    classContentTest(sup, singleWord);
+    textContentTest(sup, '5');
+  });
+
+  test('should render multi-digit count', () => {
+    const { container } = render(<Badge count={100}><span>child</span></Badge>);
+    const sup = container.querySelector('sup')!;
+    classContentTest(sup, number);
+    classContentTest(sup, multipleWords);
+    textContentTest(sup, '100');
+  });
+
+  test('should not render when count is 0 and showZero is false', () => {
+    const { container } = render(<Badge count={0}><span>child</span></Badge>);
+    const sup = container.querySelector('sup');
+    expect(sup).toBeNull();
+  });
+
+  test('should render when count is 0 and showZero is true', () => {
+    const { container } = render(<Badge count={0} showZero><span>child</span></Badge>);
+    const sup = container.querySelector('sup')!;
+    expect(sup).toBeInTheDocument();
+    textContentTest(sup, '0');
+  });
+});
+
+describe('Badge[OverflowCount]', () => {
+  test('should render overflowCount+', () => {
+    const { container } = render(<Badge count={100} overflowCount={99}><span>child</span></Badge>);
+    const sup = container.querySelector('sup')!;
+    textContentTest(sup, '99+');
+    classContentTest(sup, multipleWords);
+  });
+
+  test('should render normal count when less than overflowCount', () => {
+    const { container } = render(<Badge count={50} overflowCount={99}><span>child</span></Badge>);
+    const sup = container.querySelector('sup')!;
+    textContentTest(sup, '50');
+  });
+});
+
+describe('Badge[Size]', () => {
+  test('should render small size', () => {
+    const { container } = render(<Badge count={5} size="small"><span>child</span></Badge>);
+    const sup = container.querySelector('sup')!;
+    classContentTest(sup, small);
+  });
+
+  test('should not have small class when size is default', () => {
+    const { container } = render(<Badge count={5}><span>child</span></Badge>);
+    const sup = container.querySelector('sup')!;
+    classContentTest(sup, small, false);
+  });
+});
+
+describe('Badge[Dot]', () => {
+  test('should render dot mode', () => {
+    const { container } = render(<Badge dot><span>child</span></Badge>);
+    const sup = container.querySelector('sup')!;
+    classContentTest(sup, dot);
+    expect(sup.textContent).toBe('');
+  });
+
+  test('should render dot with color', () => {
+    const { container } = render(<Badge dot color="green"><span>child</span></Badge>);
+    const sup = container.querySelector('sup')!;
+    expect(sup.style.background).toBe('green');
+  });
+
+  test('should render dot with text (textBadge mode)', () => {
+    const { container } = render(<Badge dot text="Online" />);
+    const wrapper = container.querySelector(badge)!;
+    classContentTest(wrapper, textBadge.replace('.', ''));
+    const dotEl = wrapper.querySelector(`span`)!;
+    expect(dotEl).toBeInTheDocument();
+    expect(wrapper.textContent).toContain('Online');
+  });
+
+  test('should apply color in dot + text mode', () => {
+    const { container } = render(<Badge dot color="green" text="Online" />);
+    const wrapper = container.querySelector(badge)!;
+    const dotEl = wrapper.querySelectorAll('span')[0]!;
+    expect(dotEl.style.background).toBe('green');
+  });
+});
+
+describe('Badge[Status]', () => {
+  const statuses = ['default', 'processing', 'error', 'warning', 'success'] as const;
+
+  statuses.forEach((status) => {
+    test(`should render status ${status}`, () => {
+      const { container } = render(<Badge dot status={status} />);
+      const wrapper = container.querySelector(badge)!;
+      const dotEl = wrapper.querySelectorAll('span')[0]!;
+      classContentTest(dotEl, `${SO_PREFIX}-${status}`);
+    });
+  });
+
+  test('should render status with text', () => {
+    const { container } = render(<Badge dot status="success" text="Success" />);
+    const wrapper = container.querySelector(badge)!;
+    expect(wrapper.textContent).toContain('Success');
+  });
+});
+
+describe('Badge[Standalone]', () => {
+  test('should render standalone mode without children', () => {
+    const { container } = render(<Badge count={5} />);
+    const wrapper = container.querySelector(badge)!;
+    classContentTest(wrapper, standalone.replace('.', ''));
+  });
+
+  test('should render standalone with color', () => {
+    const { container } = render(<Badge count={5} color="#faad14" />);
+    const sup = container.querySelector('sup')!;
+    expect(sup.style.background).toBe('rgb(250, 173, 20)');
+  });
+
+  test('should render custom ReactElement count', () => {
+    const { container } = render(<Badge count={<span className="custom-icon">★</span>}><span>child</span></Badge>);
+    const wrapper = container.querySelector(badge)!;
+    expect(wrapper.querySelector('.custom-icon')).toBeInTheDocument();
+    expect(wrapper.querySelector('.custom-icon')!.textContent).toBe('★');
+  });
+
+  test('should render string count', () => {
+    const { container } = render(<Badge count="hot"><span>child</span></Badge>);
+    const sup = container.querySelector('sup')!;
+    expect(sup).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Badge 组件在同时使用 `dot` 和 `text` 属性时，`color` 属性不生效。本 PR 修复该问题并补充完整的单元测试。

## Changes

- **Bug Fix**: `renderText()` 中的 textDot 元素未应用 `color` 属性，添加 `style={{ background: color }}` 使其行为与 `renderSup()` 一致
- **Tests**: 新增 Badge 组件 `__test__` 目录，包含 33 个测试用例，覆盖 count、overflowCount、size、dot、status、standalone 等场景
- **Docs**: 补充 dot 模式示例，展示 color + text 组合用法
- **Changelog**: 更新 Badge changelog，版本号 bump 至 3.10.0-beta.19

## Test Plan

- `npx jest packages/shineout/src/badge/__test__/badge.spec.tsx` — 33 tests passed
- 关键用例：`should apply color in dot + text mode` 验证修复生效