### PR TITLE
feat(radio): add independent fontSize token for button mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.10.0",
+  "version": "3.10.1-beta.1",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/radio/radio.ts
+++ b/packages/shineout-style/src/radio/radio.ts
@@ -17,6 +17,7 @@ const radioStyle: JsStyles<keyof RadioClasses> = {
       marginRight: 0,
     },
     'button&':{
+      fontSize: token.radioButtonFontSize,
       padding: `${token.radioButtonPaddingY} ${token.radioButtonPaddingX}`,
     },
     'button[data-soui-outline]&:not($wrapperChecked):not($wrapperDisabled):not(:hover)':{

--- a/packages/shineout/src/radio/__doc__/changelog.cn.md
+++ b/packages/shineout/src/radio/__doc__/changelog.cn.md
@@ -1,3 +1,9 @@
+## 3.10.1-beta.1
+2026-09-02
+### 💅 Style
+- `Radio` 按钮模式新增独立的字体大小控制，不再依赖 `Button` 组件的字体大小 ([#1782](https://github.com/sheinsight/shineout-next/pull/1782))
+
+
 ## 3.9.9-beta.15
 2026-02-11
 ### 🆕 Feature

--- a/packages/theme/src/radio/radio.ts
+++ b/packages/theme/src/radio/radio.ts
@@ -27,6 +27,7 @@ const radioTokens: RadioTokens = {
   radioButtonPaddingY: 'Spacing-4',
   radioButtonPaddingX: 'Spacing-12',
   radioButtonBorderColor: 'Neutral-border-2',
+  radioButtonFontSize: 'Font-14',
   radioSmallIconWidth: 'Font-12',
   radioSmallIconBorderWidth: 'Border-1',
   radioSmallIconInnerSize: 'Size-3',

--- a/packages/theme/src/radio/token.ts
+++ b/packages/theme/src/radio/token.ts
@@ -55,7 +55,8 @@ const radioTokenExtraValue = {
   padding: { y: 'Spacing-4' },
   button: {
     padding: { y: 'Spacing-4', x: 'Spacing-12' },
-    border: { color: 'Neutral-border-2' }
+    border: { color: 'Neutral-border-2' },
+    font: { size: 'Font-14' },
   },
   small: {
     icon: { width: 'Font-12', gap: '', border: { width: 'Border-1' }, inner: { size: 'Size-3' } },

--- a/packages/theme/src/radio/type.ts
+++ b/packages/theme/src/radio/type.ts
@@ -142,6 +142,12 @@ export interface RadioTokens {
   radioButtonBorderColor: string;
   /**
    * @type {string}
+   * @token Font-14
+   * @description 单选框按钮模式字体字号
+   */
+  radioButtonFontSize: string;
+  /**
+   * @type {string}
    * @token Font-12
    * @description 单选框小尺寸图标宽度
    */


### PR DESCRIPTION
## Summary

Radio 按钮模式新增独立的字体大小 token（`radioButtonFontSize`），不再依赖 Button 组件的字体大小，支持通过主题编辑器单独配置。

## Changes

- 新增 `radioButtonFontSize` token，默认值为 `Font-14`
- Radio 按钮模式样式中应用该 token
- 更新 changelog

## Test Plan

- 验证 Radio 按钮模式字体大小显示正常
- 验证修改 Button 组件字体大小不再影响 Radio 按钮模式
- 验证主题编辑器中可配置该 token