### PR TITLE
fix(table): 修复 bordered 模式下特定宽度出现多余横向滚动条

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.10.1-beta.3",
+  "version": "3.10.1-beta.4",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hooks/src/components/use-table/use-table-layout.tsx
+++ b/packages/hooks/src/components/use-table/use-table-layout.tsx
@@ -229,6 +229,19 @@ const useTableLayout = (props: UseTableLayoutProps) => {
       newCols = [...newCols, ...tempcols];
     }
 
+    // offsetWidth 返回整数（四舍五入），多列累加可能导致总和比表格实际渲染宽度大 1~N px，
+    // 这些多出的像素会让 table-layout:fixed 的表格撑宽，产生不必要的横向滚动条。
+    // 用 <table> 自身的 offsetWidth 作为基准，将取整溢出部分从最后一列减去。
+    if (target.current && newCols.length > 0) {
+      const tableRenderedWidth = target.current.offsetWidth;
+      const measuredSum = newCols.reduce((a, b) => a + b, 0);
+      const excess = measuredSum - tableRenderedWidth;
+      // 仅修正取整误差范围内的溢出（最多每列 1px）
+      if (tableRenderedWidth > 0 && excess > 0 && excess <= items.length) {
+        newCols[newCols.length - 1] -= excess;
+      }
+    }
+
     if (fromDrag && props.columnResizable) {
       const widthArr = [...newCols];
       if (typeof props.width === 'number') {

--- a/packages/shineout/src/table/__doc__/changelog.cn.md
+++ b/packages/shineout/src/table/__doc__/changelog.cn.md
@@ -1,3 +1,10 @@
+## 3.10.1-beta.4
+2026-09-07
+
+### 🐞 BugFix
+
+- 修复 `Table` 开启 `bordered` 后，在特定浏览器窗口宽度下出现不必要的横向滚动条的问题 ([#1785](https://github.com/sheinsight/shineout-next/pull/1785))
+
 ## 3.10.0-beta.14
 2026-08-06
 


### PR DESCRIPTION
## Summary

修复 `Table` 组件开启 `bordered` 后，在特定浏览器窗口宽度下出现不必要的横向滚动条的问题。

### 问题原因

`getColgroup` 通过 `offsetWidth` 读取每列宽度（返回整数），多列累加后总和可能比表格实际渲染宽度多 1\~N px。这些多出的像素会让 `table-layout: fixed` 的表格被撑宽，当 `scrollWidth - clientWidth > 1` 时触发横向滚动条。`bordered` 模式的 wrapper 左右各 1px 边框改变了像素对齐，使取整误差更容易超过阈值。

### 修复方式

在 `getColgroup` 收集完 cell 宽度后，与 `<table>` 元素自身的 `offsetWidth` 对比，将取整溢出部分（不超过列数范围）从最后一列减去。

## Test Plan

1. 打开 Table 固定列示例，开启 `bordered` 属性
2. 缓慢调整浏览器窗口宽度，验证不再出现多余的横向滚动条
3. 验证真正需要横向滚动的场景（列宽总和 > 容器宽度）滚动条仍正常显示
4. 验证拖拽列宽、虚拟滚动等场景不受影响