### PR TITLE
chore: release 3.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sheinx",
   "private": true,
-  "version": "3.10.1-beta.6",
+  "version": "3.10.1",
   "description": "A react library developed with sheinx",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shineout-style/src/version.ts
+++ b/packages/shineout-style/src/version.ts
@@ -1,1 +1,1 @@
-export default '3.10.0';
+export default '3.10.1';

--- a/packages/shineout/src/index.ts
+++ b/packages/shineout/src/index.ts
@@ -70,4 +70,4 @@ export * from './deprecated';
 
 export * as TYPE from './type';
 
-export default { version: '3.10.0' };
+export default { version: '3.10.1' };


### PR DESCRIPTION
## Release 3.10.1

- 版本号从 3.10.1-beta.6 升级为 3.10.1 正式版
- 同步更新 shineout-style 和 shineout 的版本标识

🤖 Generated with [Claude Code](https://claude.com/claude-code)